### PR TITLE
build: Fix mock ICD install issues

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -120,11 +120,11 @@ It should be straightforward to adapt this repository to other Linux distributio
     However, if a specific version of this file is required, please see the [Custom glslang Version](#custom-glslang-version) section below.
 
 Vulkan Loader Library
-  - Building the cube and vulkaninfo applications require linking to the Vulkan Loader Library (libvulkan-1.so).
+  - Building the cube and vulkaninfo applications require linking to the Vulkan Loader Library (libvulkan.so.1).
       - The following option should be used on the cmake command line to specify a vulkan loader library:
-             LOADER_REPO_ROOT=c:\absolute_path_to\Vulkan-Loader
-         makeing sure to specify an absoute path, like so:
-             cmake -DLOADER_REPO_ROOT=c:\absolute_path_to\Vulkan-Loader ....
+             LOADER_REPO_ROOT=/absolute_path_to/Vulkan-Loader
+         making sure to specify an absoute path, like so:
+             cmake -DLOADER_REPO_ROOT=/absolute_path_to/Vulkan-Loader ....
     Currently, the build directory *must* be named either 'build' or 'build32'.
 
 ### Linux Build
@@ -167,13 +167,19 @@ Assuming that you have built the code as described above and the current directo
 
 This command installs files to:
 
-- `/usr/local/include/vulkan`:  Vulkan include files
-- `/usr/local/lib`:  Vulkan Tools shared objects
+- `/usr/local/lib`:  Vulkan Tools shared objects  (e.g., Mock ICD shared library)
 - `/usr/local/bin`:  vulkaninfo application
-- `/usr/local/bin`:  cube application
-- `/usr/local/bin`:  cubepp application
+- `/usr/local/share/vulkan/icd.d`:  Mock ICD JSON file
 
 You may need to run `ldconfig` in order to refresh the system loader search cache on some Linux systems.
+
+Note:  The Mock ICD is not installed by default since it is a "null" driver that does not render anything
+and is used for testing purposes.
+Installing it to system directories may cause some applications to discover and use
+this driver instead of other full drivers installed on the system.
+If you really want to install this null driver, use:
+
+    -DINSTALL_ICD=ON
 
 You can further customize the installation location by setting additional CMake variables to override their defaults.
 For example, if you would like to install to `/tmp/build` instead of `/usr/local`, on your CMake command line specify:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,3 @@
-# The name of our project is "VULKAN". CMakeLists files in this project can
-# refer to the root source directory of the project as ${VULKAN_SOURCE_DIR} and
-# to the root binary directory of the project as ${VULKAN_BINARY_DIR}.
 cmake_minimum_required(VERSION 2.8.11)
 
 # This must come before the project command.
@@ -90,10 +87,13 @@ else()
 
 endif()
 
-
 option(BUILD_CUBE "Build cube" ON)
 option(BUILD_VULKANINFO "Build vulkaninfo" ON)
 option(BUILD_ICD "Build icd" ON)
+# Installing the Mock ICD to system directories is probably not desired since
+# this ICD is not a very complete implementation.
+# Require the user to ask that it be installed if they really want it.
+option(INSTALL_ICD "Install icd" OFF)
 
 if(UNIX)
     include(GNUInstallDirs)

--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -146,7 +146,7 @@ else()
     #target_link_Libraries(VkICD_${target} VkICD_utils)
     add_dependencies(VkICD_${target} icd_generate_helper_files generate_icd_files)
     set_target_properties(VkICD_${target} PROPERTIES LINK_FLAGS "-Wl,-export-dynamic,-Bsymbolic,--exclude-libs,ALL")
-    if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND INSTALL_ICD)
         install(TARGETS VkICD_${target} DESTINATION ${CMAKE_INSTALL_LIBDIR})
         # Add targets for JSON file install on Linux.
         # Need to remove the "./" from the library path before installing to system directories.
@@ -158,7 +158,7 @@ else()
                 VERBATIM
                 DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/linux/${config_file}.json
                 )
-            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/staging-json/${config_file}.json DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/vulkan/explicit_layer.d)
+            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/staging-json/${config_file}.json DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/vulkan/icd.d)
         endforeach(config_file)
     endif()
     endmacro()


### PR DESCRIPTION
- Use correct (icd.d) directory
- Make ICD installation OFF by default
- Fix up docs

Fixes #17