### PR TITLE
cube: Remove last DebugReport

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -3011,11 +3011,6 @@ static void demo_init_vk(struct demo *demo) {
                 demo->extension_names[demo->enabled_extension_count++] = VK_MVK_MACOS_SURFACE_EXTENSION_NAME;
             }
 #endif
-            if (!strcmp(VK_EXT_DEBUG_REPORT_EXTENSION_NAME, instance_extensions[i].extensionName)) {
-                if (demo->validate) {
-                    demo->extension_names[demo->enabled_extension_count++] = VK_EXT_DEBUG_REPORT_EXTENSION_NAME;
-                }
-            }
             if (!strcmp(VK_EXT_DEBUG_UTILS_EXTENSION_NAME, instance_extensions[i].extensionName)) {
                 if (demo->validate) {
                     demo->extension_names[demo->enabled_extension_count++] = VK_EXT_DEBUG_UTILS_EXTENSION_NAME;


### PR DESCRIPTION
We still had the debug report detection code in cube.  This removes
the last bits of it.

Change-Id: I09559cd56ee4779453221c810d8328cb4c864aef