### PR TITLE
cube: Explicitly set QueueFamilyIndex(s) to QUEUE_FAMILY_IGNORED

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -657,6 +657,8 @@ static void demo_set_image_layout(struct demo *demo, VkImage image, VkImageAspec
                                                  .pNext = NULL,
                                                  .srcAccessMask = srcAccessMask,
                                                  .dstAccessMask = 0,
+                                                 .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+                                                 .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
                                                  .oldLayout = old_image_layout,
                                                  .newLayout = new_image_layout,
                                                  .image = image,

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -2273,8 +2273,8 @@ void Demo::set_image_layout(vk::Image image, vk::ImageAspectFlags aspectMask, vk
                              .setDstAccessMask(DstAccessMask(newLayout))
                              .setOldLayout(oldLayout)
                              .setNewLayout(newLayout)
-                             .setSrcQueueFamilyIndex(0)
-                             .setDstQueueFamilyIndex(0)
+                             .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+                             .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
                              .setImage(image)
                              .setSubresourceRange(vk::ImageSubresourceRange(aspectMask, 0, 1, 0, 1));
 


### PR DESCRIPTION
Fix for #22 
The QueueFamilyIndex fields only come into play when you want
to use an image in two or more queues from different queue
families, which cube does not do.

We've been getting lucky in that the spec says that if src and dst
indices are the same, in the previous scenario both zero, that they
are both treated as IGNORED.  Better to set them explicitly

Change-Id: I610aa8899539eeb25ca06254b88e6a6d0a2ffc97