### PR TITLE
Clean up validation errors from separate present queue

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -815,7 +815,7 @@ static void demo_draw_build_cmd(struct demo *demo, VkCommandBuffer cmd_buf) {
         VkImageMemoryBarrier image_ownership_barrier = {.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
                                                         .pNext = NULL,
                                                         .srcAccessMask = 0,
-                                                        .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                                        .dstAccessMask = 0,
                                                         .oldLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
                                                         .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
                                                         .srcQueueFamilyIndex = demo->graphics_queue_family_index,
@@ -823,8 +823,8 @@ static void demo_draw_build_cmd(struct demo *demo, VkCommandBuffer cmd_buf) {
                                                         .image = demo->swapchain_image_resources[demo->current_buffer].image,
                                                         .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}};
 
-        vkCmdPipelineBarrier(cmd_buf, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0,
-                             NULL, 0, NULL, 1, &image_ownership_barrier);
+        vkCmdPipelineBarrier(cmd_buf, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, NULL, 0,
+                             NULL, 1, &image_ownership_barrier);
     }
     if (demo->validate) {
         demo->CmdEndDebugUtilsLabelEXT(cmd_buf);
@@ -848,7 +848,7 @@ void demo_build_image_ownership_cmd(struct demo *demo, int i) {
     VkImageMemoryBarrier image_ownership_barrier = {.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
                                                     .pNext = NULL,
                                                     .srcAccessMask = 0,
-                                                    .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                                    .dstAccessMask = 0,
                                                     .oldLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
                                                     .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
                                                     .srcQueueFamilyIndex = demo->graphics_queue_family_index,
@@ -856,8 +856,8 @@ void demo_build_image_ownership_cmd(struct demo *demo, int i) {
                                                     .image = demo->swapchain_image_resources[i].image,
                                                     .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}};
 
-    vkCmdPipelineBarrier(demo->swapchain_image_resources[i].graphics_to_present_cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, NULL, 0, NULL, 1, &image_ownership_barrier);
+    vkCmdPipelineBarrier(demo->swapchain_image_resources[i].graphics_to_present_cmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, NULL, 0, NULL, 1, &image_ownership_barrier);
     err = vkEndCommandBuffer(demo->swapchain_image_resources[i].graphics_to_present_cmd);
     assert(!err);
 }

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -571,7 +571,7 @@ void Demo::build_image_ownership_cmd(uint32_t const &i) {
     auto const image_ownership_barrier =
         vk::ImageMemoryBarrier()
             .setSrcAccessMask(vk::AccessFlags())
-            .setDstAccessMask(vk::AccessFlagBits::eColorAttachmentWrite)
+            .setDstAccessMask(vk::AccessFlags())
             .setOldLayout(vk::ImageLayout::ePresentSrcKHR)
             .setNewLayout(vk::ImageLayout::ePresentSrcKHR)
             .setSrcQueueFamilyIndex(graphics_queue_family_index)
@@ -580,8 +580,8 @@ void Demo::build_image_ownership_cmd(uint32_t const &i) {
             .setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1));
 
     swapchain_image_resources[i].graphics_to_present_cmd.pipelineBarrier(
-        vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eColorAttachmentOutput,
-        vk::DependencyFlagBits(), 0, nullptr, 0, nullptr, 1, &image_ownership_barrier);
+        vk::PipelineStageFlagBits::eBottomOfPipe, vk::PipelineStageFlagBits::eBottomOfPipe, vk::DependencyFlagBits(), 0, nullptr, 0,
+        nullptr, 1, &image_ownership_barrier);
 
     result = swapchain_image_resources[i].graphics_to_present_cmd.end();
     VERIFY(result == vk::Result::eSuccess);
@@ -845,7 +845,7 @@ void Demo::draw_build_cmd(vk::CommandBuffer commandBuffer) {
         auto const image_ownership_barrier =
             vk::ImageMemoryBarrier()
                 .setSrcAccessMask(vk::AccessFlags())
-                .setDstAccessMask(vk::AccessFlagBits::eColorAttachmentWrite)
+                .setDstAccessMask(vk::AccessFlags())
                 .setOldLayout(vk::ImageLayout::ePresentSrcKHR)
                 .setNewLayout(vk::ImageLayout::ePresentSrcKHR)
                 .setSrcQueueFamilyIndex(graphics_queue_family_index)
@@ -853,7 +853,7 @@ void Demo::draw_build_cmd(vk::CommandBuffer commandBuffer) {
                 .setImage(swapchain_image_resources[current_buffer].image)
                 .setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1));
 
-        commandBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eBottomOfPipe,
+        commandBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eBottomOfPipe, vk::PipelineStageFlagBits::eBottomOfPipe,
                                       vk::DependencyFlagBits(), 0, nullptr, 0, nullptr, 1, &image_ownership_barrier);
     }
 


### PR DESCRIPTION
From the spec:

Whilst it is not invalid to provide destination or source access
masks for memory barriers used for release or acquire operations,
respectively, they have no practical effect. Access after a release
operation has undefined results, and so visibility for those accesses
has no practical effect. Similarly, write access before an acquire
operation will produce undefined results for future access,
so availability of those writes has no practical use. In an earlier
version of the specification, these were required to match on both
sides - but this was subsequently relaxed.
These masks should be set to 0.

Change-Id: I495dc86ad62c0651fbc6acbfb0dfbb8245a324be