### PR TITLE
repo: Reorg to remove Vulkan-Headers submodule

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,6 @@ before_build:
   - glslangValidator.exe --version
   - echo.
   - echo Starting build for %APPVEYOR_REPO_NAME% in %APPVEYOR_BUILD_FOLDER%
-  - git submodule update --init --recursive
   # Determine the appropriate CMake generator for the current version of Visual Studio
   - echo Determining VS version
   - python .\scripts\determine_vs_version.py > vsversion.tmp
@@ -53,9 +52,8 @@ before_build:
   # Build Vulkan-Headers
   - echo Building Vulkan-Headers for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%
-  # Need different name here until Vulkan-Tools stops having Vulkan-Headers as a submodule.
-  - git clone https://github.com/KhronosGroup/Vulkan-Headers.git Vulkan-Headers-TMP
-  - cd Vulkan-Headers-TMP
+  - git clone https://github.com/KhronosGroup/Vulkan-Headers.git
+  - cd Vulkan-Headers
   - mkdir %BUILD_DIR%
   - cd %BUILD_DIR%
   - cmake -G %GENERATOR% -DCMAKE_INSTALL_PREFIX=install ..
@@ -67,14 +65,14 @@ before_build:
   - cd Vulkan-Loader
   - mkdir %BUILD_DIR%
   - cd %BUILD_DIR%
-  - cmake -G %GENERATOR% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers-TMP/%BUILD_DIR%/install ..
-  - cmake --build . --config %CONFIGURATION% -- /maxcpucount
+  - cmake -G %GENERATOR% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/%BUILD_DIR%/install -DCMAKE_INSTALL_PREFIX=install ..
+  - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
   # Generate build files using CMake for the build step.
   - echo Generating Vulkan-Tools CMake files for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build
   - cd build
-  - cmake -G %GENERATOR% -DLOADER_REPO_ROOT=%APPVEYOR_BUILD_FOLDER%\Vulkan-Loader ..
+  - cmake -G %GENERATOR% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/%BUILD_DIR%/install -DVULKAN_LOADER_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Loader/%BUILD_DIR%/install ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
 
 platform:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Vulkan-Headers"]
-	path = Vulkan-Headers
-	url = https://github.com/KhronosGroup/Vulkan-Headers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,15 @@ matrix:
     - env: CHECK_COMMIT_FORMAT=ON
   include:
     # Android build.
-    - os: linux
-      compiler: gcc
-      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-23 ANDROID_ABI=armeabi-v7a
+# Temporary Disable
+#    - os: linux
+#      compiler: gcc
+#      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-23 ANDROID_ABI=armeabi-v7a
     # Android 64-bit build.
-    - os: linux
-      compiler: gcc
-      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-23 ANDROID_ABI=arm64-v8a
+# Temporary Disable
+#    - os: linux
+#      compiler: gcc
+#      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-23 ANDROID_ABI=arm64-v8a
     # Linux GCC debug build.
     - os: linux
       compiler: gcc
@@ -81,9 +83,8 @@ script:
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Build Vulkan-Headers
       cd ${TRAVIS_BUILD_DIR}
-      # Need different name here until Vulkan-Tools stops having Vulkan-Headers as a submodule.
-      git clone https://github.com/KhronosGroup/Vulkan-Headers.git Vulkan-Headers-TMP
-      cd Vulkan-Headers-TMP
+      git clone https://github.com/KhronosGroup/Vulkan-Headers.git
+      cd Vulkan-Headers
       mkdir build
       cd build
       cmake -DCMAKE_INSTALL_PREFIX=install ..
@@ -98,7 +99,7 @@ script:
       cd Vulkan-Loader
       mkdir build
       cd build
-      cmake -DCMAKE_BUILD_TYPE=Debug -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Headers-TMP/build/install -DCMAKE_INSTALL_PREFIX=install ..
+      cmake -DCMAKE_BUILD_TYPE=Debug -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Headers/build/install -DCMAKE_INSTALL_PREFIX=install ..
       make -j $core_count install
       cd ${TRAVIS_BUILD_DIR}
     fi
@@ -108,7 +109,7 @@ script:
       cd ${TRAVIS_BUILD_DIR}
       mkdir build
       cd build
-      cmake -DLOADER_REPO_ROOT=${TRAVIS_BUILD_DIR}/Vulkan-Loader -DCMAKE_BUILD_TYPE=Debug ..
+      cmake -DCMAKE_BUILD_TYPE=Debug -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Headers/build/install -DVULKAN_LOADER_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Loader/build/install ..
       make -j $core_count
       cd ${TRAVIS_BUILD_DIR}
     fi

--- a/BUILD.md
+++ b/BUILD.md
@@ -30,7 +30,7 @@ graphics hardware vendor and install it properly.
 
 To create your local git repository:
 
-    git clone https://github.com/KhronosGroup/Vulkan-Tools
+    git clone https://github.com/KhronosGroup/Vulkan-Tools.git
 
 ## Building On Windows
 
@@ -52,17 +52,22 @@ Windows 7+ with the following software packages:
   - Tell the installer to treat line endings "as is" (i.e. both DOS and Unix-style line endings).
   - Install both the 32-bit and 64-bit versions, as the 64-bit installer does not install the
     32-bit libraries and tools.
-- Vulkan Loader Library
-  - Building the cube and vulkaninfo applications require linking to the Vulkan Loader Library (vulkan-1.dll).
-    Locating the library for this repo can be done in two different ways:
-      -  The Vulkan SDK can be installed. In this case, cmake should be able to locate the loader repo through the VulkanSDK
+- Vulkan Headers and Loader Library
+  - Building the cube and vulkaninfo applications require access to the Vulkan headers and linking to the Vulkan Loader Library (vulkan-1.dll).
+    Locating these components can be done in two different ways:
+      -  The Vulkan SDK can be installed. In this case, cmake should be able to locate the headers and loader through the VulkanSDK
          environment variable.
-      -  The library can be built from the [Vulkan-Loader](https://github.com/KhronosGroup/Vulkan-Loader.git) repository.
-         In this case, the following option should be used on the cmake command line:
-             LOADER_REPO_ROOT=c:\absolute_path_to\Vulkan-Loader
-         and use absolute (not relative) paths, like so:
-             cmake -DLOADER_REPO_ROOT=c:\absolute_path_to\Vulkan-Loader ....
-    Currently, the build directory *must* be named either 'build' or 'build32'.
+      -  The headers can be built from the [Vulkan-Headers](https://github.com/KhronosGroup/Vulkan-Headers.git) repository and the
+         loader library can be built from the [Vulkan-Loader](https://github.com/KhronosGroup/Vulkan-Loader.git) repository.
+         Follow the instructions in those repositories to build the `install` targets.
+         When building this repo,  the following options should be used on the cmake command line:
+
+            VULKAN_HEADERS_INSTALL_DIR=\absolute_path_to\Vulkan-Headers install dir
+            VULKAN_LOADER_INSTALL_DIR=\absolute_path_to\Vulkan-Loader install dir
+         
+         Be sure to use absolute (not relative) paths, like so:
+         
+             cmake -DVULKAN_LOADER_INSTALL_DIR=c:\src\Vulkan-Loader\build\install
 - [glslang](https://github.com/KhronosGroup/glslang)
   - By default, the build scripts will attempt to download the necessary components from the glslang repo.
     However, if a specific version of this file is required, please see the [Custom glslang Version](#custom-glslang-version) section below.
@@ -71,16 +76,17 @@ Windows 7+ with the following software packages:
 
 1. Open a Developer Command Prompt for VS201x
 2. Change directory to `Vulkan-Tools` -- the root of the cloned git repository
-3. Run 'git submodule update --init --recursive' -- this will download in-tree external dependencies
-4. Create a `build` directory, change into that directory, and run cmake
+3. Create a `build` directory, change into that directory, and run cmake
 
 For example, assuming an SDK is installed, for VS2017 (generators for other versions are [specified here](#cmake-visual-studio-generators)):
 
-    cmake "Visual Studio 15 2017 Win64" ..
+    cmake -G "Visual Studio 15 2017 Win64" ..
 
-If a specific version of the Loader is requred, specify the root of the loader repository, like so:
+If a specific version of the Headers or Loader is requred, specify the install dirs of these repositories, like so:
 
-    cmake -DLOADER_REPO_ROOT=c:/absolute_path_to/Vulkan-Loader -G "Visual Studio 15 2017 Win64" ..
+    cmake -DVULKAN_HEADERS_INSTALL_PATH=c:/absolute_path_to/Vulkan-Headers install dir
+          -DVULKAN_LOADER_INSTALL_PATH=c:/absolute_path_to/Vulkan-Loader install dir
+          -G "Visual Studio 15 2017 Win64" ..
 
 This will create a Windows solution file named `Vulkan-Tools.sln` in the build directory.
 
@@ -89,6 +95,10 @@ You may select "Debug" or "Release" from the Solution Configurations drop-down l
 Start a build by selecting the Build->Build Solution menu item.
 This solution copies the loader it built to each program's build directory
 to ensure that the program uses the loader built from this solution.
+
+You can also build from the command line with:
+
+    cmake --build . --config (Release or Debug)
 
 #### Windows Install Target
 
@@ -136,12 +146,23 @@ It should be straightforward to adapt this repository to other Linux distributio
     However, if a specific version of this file is required, please see the [Custom glslang Version](#custom-glslang-version) section below.
 
 Vulkan Loader Library
-  - Building the cube and vulkaninfo applications require linking to the Vulkan Loader Library (libvulkan.so.1).
-      - The following option should be used on the cmake command line to specify a vulkan loader library:
-             LOADER_REPO_ROOT=/absolute_path_to/Vulkan-Loader
-         making sure to specify an absoute path, like so:
-             cmake -DLOADER_REPO_ROOT=/absolute_path_to/Vulkan-Loader ....
-    Currently, the build directory *must* be named either 'build' or 'build32'.
+
+- Vulkan Headers and Loader Library
+  - Building the cube and vulkaninfo applications require access to the Vulkan headers and linking to the Vulkan Loader Library (libvulkan.so.1).
+    Locating these components can be done in two different ways:
+      -  The Vulkan SDK can be installed. In this case, cmake should be able to locate the headers and loader through the VulkanSDK
+         environment variable.
+      -  The headers are built with the [Vulkan-Headers](https://github.com/KhronosGroup/Vulkan-Headers.git) repository and the
+         loader library can be built from the [Vulkan-Loader](https://github.com/KhronosGroup/Vulkan-Loader.git) repository.
+         Follow the instructions in those repositories to build the `install` targets.
+         When building this repo,  the following options should be used on the cmake command line:
+
+             VULKAN_HEADERS_INSTALL_DIR=absolute_path_to Vulkan-Headers install dir
+             VULKAN_LOADER_INSTALL_DIR=absolute_path_to Vulkan-Loader install dir
+
+         Be sure to use absolute (not relative) paths, like so:
+
+             cmake -DVULKAN_LOADER_INSTALL_DIR=~/src/Vulkan-Loader/build/install
 
 ### Linux Build
 
@@ -150,15 +171,16 @@ Example debug build
 See **Loader and Validation Layer Dependencies** for more information and other options:
 
 1. In a Linux terminal, `cd Vulkan-Tools` -- the root of the cloned git repository
-2. Execute 'git submodule update --init --recursive' -- this will download in-tree external components
-3. Create a `build` directory, change into that directory, and run cmake:
+2. Create a `build` directory, change into that directory, and run cmake:
 
         mkdir build
         cd build
         # If an SDK is installed and the setup-env.sh script has been run,
         cmake -DCMAKE_BUILD_TYPE=Debug ..
         # Else if a specific version of the loader is desired, indicate the root of the loader repository like so:
-        cmake -DLOADER_REPO_ROOT=/absolute_path_to/Vulkan-Loader -DCMAKE_BUILD_TYPE=Debug ..
+        cmake -DVULKAN_HEADERS_INSTALL_DIR=/absolute_path_to/Vulkan-Headers/build/install \
+              -DVULKAN_LOADER_INSTALL_DIR=/absolute_path_to/Vulkan-Loader/build/install \
+              -DCMAKE_BUILD_TYPE=Debug ..
 
 4. Run `make -j8` to begin the build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,21 @@ project (Vulkan-Tools)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-# If CMAKE 3.7+, use FindVulkan
-if (NOT CMAKE_VERSION VERSION_LESS 3.7.0)
-    message(STATUS "Using find_package to locate Vulkan")
-    find_package(Vulkan)
-endif()
+# Find Vulkan Headers and Loader
+# Search order:
+#  User-supplied CMAKE_PREFIX_PATH containing paths to the header and/or loader install dirs
+#  CMake options VULKAN_HEADERS_INSTALL_DIR and/or VULKAN_LOADER_INSTALL_DIR
+#  Env vars VULKAN_HEADERS_INSTALL_DIR and/or VULKAN_LOADER_INSTALL_DIR
+#  Fallback to FindVulkan operation using SDK install or system installed components.
+set(VULKAN_HEADERS_INSTALL_DIR "HEADERS-NOTFOUND" CACHE PATH "Absolute path to a Vulkan-Headers install directory")
+set(VULKAN_LOADER_INSTALL_DIR "LOADER-NOTFOUND" CACHE PATH "Absolute path to a Vulkan-Loader install directory")
+set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH};${VULKAN_HEADERS_INSTALL_DIR};${VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR})
+message(STATUS "Using find_package to locate Vulkan")
+find_package(Vulkan)
+set(LIBVK "Vulkan::Vulkan")
+message(STATUS "Vulkan FOUND = ${Vulkan_FOUND}")
+message(STATUS "Vulkan Include = ${Vulkan_INCLUDE_DIR}")
+message(STATUS "Vulkan Lib = ${Vulkan_LIBRARY}")
 
 include(GNUInstallDirs)
 # Set a better default install location for Windows only if the user did not provide one.
@@ -30,15 +40,7 @@ endif()
 
 # Enable cmake folders
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-set(TOOLS_TARGET_FOLDER lvl_cmake_targets)
-
-# Output warning if vulkan headers submodule contents are not present
-if (NOT EXISTS "${PROJECT_SOURCE_DIR}/Vulkan-Headers/include/vulkan/vulkan_core.h")
-    message(FATAL_ERROR "Please run 'git submodule update --init' before running cmake")
-endif()
-
-# Header file for CMake settings
-include_directories("${PROJECT_SOURCE_DIR}/Vulkan-Headers/include")
+set(TOOLS_TARGET_FOLDER "Helper Targets")
 
 if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers")
@@ -109,6 +111,7 @@ configure_file(
 
 add_custom_target(uninstall-Vulkan-Tools
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+set_target_properties(uninstall-Vulkan-Tools PROPERTIES FOLDER ${TOOLS_TARGET_FOLDER})
 
 if(APPLE)
     include(mac_common.cmake)

--- a/cube/CMakeLists.txt
+++ b/cube/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(CUBE_INCLUDE_DIRS
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}/..
+    ${Vulkan_INCLUDE_DIR}
 )
 
 find_package(PythonInterp 3 REQUIRED)
@@ -136,14 +137,10 @@ else()
     message(FATAL_ERROR "Unsupported Platform!")
 endif()
 
-file(GLOB TEXTURES
-  "${PROJECT_SOURCE_DIR}/cube/*.ppm"
-  )
-file(COPY ${TEXTURES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
+# LOADER_REPO_ROOT is going away soon
 # Predefine loader root as a cmake cache variable for cmake-gui
 set(LOADER_REPO_ROOT "LOADER-NOTFOUND" CACHE PATH "Absolute path to the root of the loader repository")
 
@@ -168,10 +165,6 @@ if(LOADER_REPO_ROOT)
         HINTS ${LOADER_SEARCH_PATHS}
         )
     message(STATUS "Found Vulkan: ${LIBVK}")
-else()
-    message(STATUS "Using find_package to locate Vulkan")
-    find_package(Vulkan)
-    set (LIBVK "Vulkan::Vulkan")
 endif()
 
 if(WIN32)

--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -160,8 +160,7 @@ endif()
 
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/../loader
-    ${CMAKE_CURRENT_SOURCE_DIR}/../Vulkan-Headers/include/vulkan
+    ${Vulkan_INCLUDE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
     ${PROJECT_BINARY_DIR}
     ${CMAKE_BINARY_DIR}

--- a/vulkaninfo/CMakeLists.txt
+++ b/vulkaninfo/CMakeLists.txt
@@ -42,6 +42,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     endif()
 endif()
 
+# LOADER_REPO_ROOT is going away soon
 # Predefine loader root as a cmake cache variable for cmake-gui
 set(LOADER_REPO_ROOT "LOADER-NOTFOUND" CACHE PATH "Absolute path to the root of the loader repository")
 
@@ -62,22 +63,13 @@ if(LOADER_REPO_ROOT)
         HINTS ${LOADER_SEARCH_PATHS}
         )
     message(STATUS "Found Vulkan: ${LIBVK}")
-    if(APPLE)
-        target_link_libraries(vulkaninfo ${LIBVK} "-framework AppKit -framework QuartzCore")
-        target_include_directories(vulkaninfo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo)
-    else()
-        target_link_libraries(vulkaninfo ${LIBVK})
-    endif()
- else()
-    message(STATUS "Using find_package to locate Vulkan")
-    find_package(Vulkan)
-    set (LIBVK "Vulkan::Vulkan")
-    if(APPLE)
-        target_link_libraries(vulkaninfo ${LIBVK} "-framework AppKit -framework QuartzCore")
-        target_include_directories(vulkaninfo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo)
-    else()
-        target_link_libraries(vulkaninfo ${LIBVK})
-    endif()
+endif()
+
+if(APPLE)
+    target_link_libraries(vulkaninfo ${LIBVK} "-framework AppKit -framework QuartzCore")
+    target_include_directories(vulkaninfo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo)
+else()
+    target_link_libraries(vulkaninfo ${LIBVK})
 endif()
 
 # Create vulkaninfo application bundle for MacOS


### PR DESCRIPTION
- Remove Vulkan-Headers submodule
- Add CMake code to add VULKAN_HEADERS_INSTALL_DIR and
  VULKAN_LOADER_INSTALL_DIR to search when locating
  Vulkan headers and loader

(LOADER_REPO_ROOT still being honored for now)