### PR TITLE
cmake: Fix macOS CMake files to include dylib file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(VULKAN_LOADER_INSTALL_DIR "LOADER-NOTFOUND" CACHE PATH "Absolute path to a V
 set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH};${VULKAN_HEADERS_INSTALL_DIR};${VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR})
 message(STATUS "Using find_package to locate Vulkan")
 find_package(Vulkan)
+# "Vulkan::Vulkan" on macOS causes the framework to be linked to the app instead of an individual library
 set(LIBVK "Vulkan::Vulkan")
 message(STATUS "Vulkan FOUND = ${Vulkan_FOUND}")
 message(STATUS "Vulkan Include = ${Vulkan_INCLUDE_DIR}")

--- a/cube/macOS/cube/cube.cmake
+++ b/cube/macOS/cube/cube.cmake
@@ -49,7 +49,8 @@ target_include_directories(cube PRIVATE
     ${MOLTENVK_DIR}/MoltenVK/include
 )
 
-target_link_libraries(cube ${LIBVK} "-framework Cocoa -framework QuartzCore")
+# We do this so vulkaninfo is linked to an individual library and NOT a framework.
+target_link_libraries(cube ${Vulkan_LIBRARY} "-framework Cocoa -framework QuartzCore")
 
 set_target_properties(cube PROPERTIES
     MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cube/Info.plist

--- a/cube/macOS/cubepp/cubepp.cmake
+++ b/cube/macOS/cubepp/cubepp.cmake
@@ -49,7 +49,8 @@ target_include_directories(cubepp PRIVATE
     ${MOLTENVK_DIR}/MoltenVK/include
 )
 
-target_link_libraries(cubepp ${LIBVK} "-framework Cocoa -framework QuartzCore")
+# We do this so vulkaninfo is linked to an individual library and NOT a framework.
+target_link_libraries(cubepp ${Vulkan_LIBRARY} "-framework Cocoa -framework QuartzCore")
 
 set_target_properties(cubepp PROPERTIES
     MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cubepp/Info.plist

--- a/vulkaninfo/CMakeLists.txt
+++ b/vulkaninfo/CMakeLists.txt
@@ -66,8 +66,9 @@ if(LOADER_REPO_ROOT)
 endif()
 
 if(APPLE)
-    target_link_libraries(vulkaninfo ${LIBVK} "-framework AppKit -framework QuartzCore")
-    target_include_directories(vulkaninfo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo)
+    # We do this so vulkaninfo is linked to an individual library and NOT a framework.
+    target_link_libraries(vulkaninfo ${Vulkan_LIBRARY} "-framework AppKit -framework QuartzCore")
+    target_include_directories(vulkaninfo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo ${Vulkan_INCLUDE_DIR})
 else()
     target_link_libraries(vulkaninfo ${LIBVK})
 endif()

--- a/vulkaninfo/macOS/vulkaninfo.cmake
+++ b/vulkaninfo/macOS/vulkaninfo.cmake
@@ -16,8 +16,9 @@ set_target_properties(vulkaninfo-bundle PROPERTIES
     OUTPUT_NAME vulkaninfo
     MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/Info.plist
 )
-target_link_libraries(vulkaninfo-bundle ${LIBVK} "-framework AppKit -framework QuartzCore")
-target_include_directories(vulkaninfo-bundle PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo)
+# We do this so vulkaninfo is linked to an individual library and NOT a framework.
+target_link_libraries(vulkaninfo-bundle ${Vulkan_LIBRARY} "-framework AppKit -framework QuartzCore")
+target_include_directories(vulkaninfo-bundle PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo ${Vulkan_INCLUDE_DIR})
 add_dependencies(vulkaninfo-bundle MoltenVK_icd-staging-json)
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo.sh PROPERTIES
     MACOSX_PACKAGE_LOCATION "MacOS"


### PR DESCRIPTION
Fixed CMake files for macOS to include the vulkan dylib loader
file in the bundles instead of the vulkan framework file.