### PR TITLE
Temporarily rename uninstall target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,14 +46,16 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND WIN32)
 endif()
 
 # uninstall target
-configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-    IMMEDIATE @ONLY)
+if (NOT TARGET uninstall)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY)
 
-add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-set_target_properties(uninstall PROPERTIES FOLDER ${TOOLS_TARGET_FOLDER})
+    add_custom_target(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+    set_target_properties(uninstall PROPERTIES FOLDER ${TOOLS_TARGET_FOLDER})
+endif()
 
 if(APPLE)
     # CMake versions 3 or later need CMAKE_MACOSX_RPATH defined.


### PR DESCRIPTION
Rename uninstall target until downstream repos have been modified to remove submodules.  

Target is renamed to uninstall-Vulkan-Tools, this commit can be reverted once the VulkanTools repository rework is complete.

This is required to get VulkanTools working with the new repos.