### PR TITLE
ci: Clean up AppVeyor config file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,11 +18,6 @@ environment:
   PYTHON_PATH: "C:/Python35"
   PYTHON_PACKAGE_PATH: "C:/Python35/Scripts"
 
-# Cache the external directory to improve build times.
-# If the appveyor config file changes, invalidate the cache.
-cache:
-    - external -> .appveyor.yml
-
 branches:
   only:
     - master
@@ -39,40 +34,30 @@ before_build:
   - glslangValidator.exe --version
   - echo.
   - echo Starting build for %APPVEYOR_REPO_NAME% in %APPVEYOR_BUILD_FOLDER%
-  # Determine the appropriate CMake generator for the current version of Visual Studio
-  - echo Determining VS version
-  - python .\scripts\determine_vs_version.py > vsversion.tmp
-  - set /p VS_VERSION=< vsversion.tmp
-  - echo Detected Visual Studio Version as %VS_VERSION%
-  - del /Q /F vsversion.tmp
-  - if %PLATFORM% == Win32 (set GENERATOR="Visual Studio %VS_VERSION%")
-  - if %PLATFORM% == x64 (set GENERATOR="Visual Studio %VS_VERSION% Win64")
-  - if %PLATFORM% == Win32 (set BUILD_DIR="build32")
-  - if %PLATFORM% == x64 (set BUILD_DIR="build")
   # Build Vulkan-Headers
   - echo Building Vulkan-Headers for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%
   - git clone https://github.com/KhronosGroup/Vulkan-Headers.git
   - cd Vulkan-Headers
-  - mkdir %BUILD_DIR%
-  - cd %BUILD_DIR%
-  - cmake -G %GENERATOR% -DCMAKE_INSTALL_PREFIX=install ..
+  - mkdir build
+  - cd build
+  - cmake -A %PLATFORM% -DCMAKE_INSTALL_PREFIX=install ..
   - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
   # Build Vulkan-Loader
   - echo Building Vulkan-Loader for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%
   - git clone https://github.com/KhronosGroup/Vulkan-Loader.git
   - cd Vulkan-Loader
-  - mkdir %BUILD_DIR%
-  - cd %BUILD_DIR%
-  - cmake -G %GENERATOR% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/%BUILD_DIR%/install -DCMAKE_INSTALL_PREFIX=install ..
+  - mkdir build
+  - cd build
+  - cmake -A %PLATFORM% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/build/install -DCMAKE_INSTALL_PREFIX=install ..
   - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
   # Generate build files using CMake for the build step.
   - echo Generating Vulkan-Tools CMake files for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build
   - cd build
-  - cmake -G %GENERATOR% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/%BUILD_DIR%/install -DVULKAN_LOADER_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Loader/%BUILD_DIR%/install ..
+  - cmake -A %PLATFORM% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/build/install -DVULKAN_LOADER_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Loader/build/install ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
 
 platform:
@@ -82,6 +67,16 @@ platform:
 configuration:
   - Release
   - Debug
+
+# Build only x64 Release and Win32(x86) Debug to reduce build time.
+# This should still provide adequate 32-bit vs 64-bit and
+# Release vs Debug coverage.
+matrix:
+  exclude:
+    - configuration: Release
+      platform: Win32
+    - configuration: Debug
+      platform: x64
 
 build:
   parallel: true                  # enable MSBuild parallel builds


### PR DESCRIPTION
- Use -A CMake argument instead of creating a generator string
  based on the worker image and architecture. Instead, set the
  architecture (platform Win32 or x64) with -A and take whatever
  Visual Studio version is provided by the worker image.  The
  worker image is specified by the "os" config property.
- Reduce jobs from 4 to 2
- Remove AppVeyor caching of the external directory; this
  directory was not being used anyway.