### PR TITLE
vulkaninfo: Fix warnings in maintenance3 printing

### DIFF
--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -2555,14 +2555,14 @@ static void AppGpuDumpProps(const struct AppGpu *gpu, FILE *out) {
                 VkPhysicalDeviceMaintenance3PropertiesKHR *maintenance3_props = (VkPhysicalDeviceMaintenance3PropertiesKHR*)structure;
                 if (html_output) {
                     fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceMaintenance3Properties</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxPerSetDescriptors    = <div class='val'>" PRIuLEAST32 "</div></summary></details>\n", maintenance3_props->maxPerSetDescriptors);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxMemoryAllocationSize = <div class='val'>" PRIuLEAST32 "</div></summary></details>\n", maintenance3_props->maxMemoryAllocationSize);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxPerSetDescriptors    = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", maintenance3_props->maxPerSetDescriptors);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxMemoryAllocationSize = <div class='val'>%" PRIuLEAST64 "</div></summary></details>\n", maintenance3_props->maxMemoryAllocationSize);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceMaintenance3Properties:\n");
                     printf("=======================================\n");
-                    printf("\tmaxPerSetDescriptors    = " PRIuLEAST32 "\n", maintenance3_props->maxPerSetDescriptors   );
-                    printf("\tmaxMemoryAllocationSize = " PRIuLEAST32 "\n", maintenance3_props->maxMemoryAllocationSize);
+                    printf("\tmaxPerSetDescriptors    = %" PRIuLEAST32 "\n", maintenance3_props->maxPerSetDescriptors   );
+                    printf("\tmaxMemoryAllocationSize = %" PRIuLEAST64 "\n", maintenance3_props->maxMemoryAllocationSize);
                 }
             }
             place = structure->pNext;


### PR DESCRIPTION
Fixed incorrect number of arguments in print statements
for VkPhysicalDeviceMaintenance3PropertiesKHR.