### PR TITLE
vulkaninfo: Remove warning messages from json output

### DIFF
--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -210,8 +210,8 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DbgCallback(VkFlags msgFlags, VkDebugRepor
         sprintf(message, "DEBUG: [%s] Code %d : %s", pLayerPrefix, msgCode, pMsg);
     }
 
-    printf("%s\n", message);
-    fflush(stdout);
+    fprintf(stderr, "%s\n", message);
+    fflush(stderr);
     free(message);
 
     /*


### PR DESCRIPTION
Messages emitted from the DbgCallback function were previously sent to stdout. These messages are now sent to stderr and no longer affect the validity of json output.