### PR TITLE
cube: Fix new validation error

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -2046,7 +2046,7 @@ static void demo_prepare_descriptor_set(struct demo *demo) {
     for (unsigned int i = 0; i < DEMO_TEXTURE_COUNT; i++) {
         tex_descs[i].sampler = demo->textures[i].sampler;
         tex_descs[i].imageView = demo->textures[i].view;
-        tex_descs[i].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+        tex_descs[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     }
 
     memset(&writes, 0, sizeof(writes));

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -1825,7 +1825,7 @@ void Demo::prepare_descriptor_set() {
     for (uint32_t i = 0; i < texture_count; i++) {
         tex_descs[i].setSampler(textures[i].sampler);
         tex_descs[i].setImageView(textures[i].view);
-        tex_descs[i].setImageLayout(vk::ImageLayout::eGeneral);
+        tex_descs[i].setImageLayout(vk::ImageLayout::eShaderReadOnlyOptimal);
     }
 
     vk::WriteDescriptorSet writes[2];


### PR DESCRIPTION
As of Vulkan-ValidationLayers commit 2872f4a, the layers now check that
image layouts specified in descriptors match the current image layout
state.  LAYOUT_GENERAL is not a wildcard for this matching.

Change the image layouts for the combined image sampler descriptors
from LAYOUT_GENERAL to LAYOUT_SHADER_READ_ONLY_OPTIMAL.