### PR TITLE
The window erases and draws cause flashing when resizing

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -2425,6 +2425,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
         case WM_GETMINMAXINFO:  // set window's minimum size
             ((MINMAXINFO *)lParam)->ptMinTrackSize = demo.minsize;
             return 0;
+        case WM_ERASEBKGND:
+            return 1;
         case WM_SIZE:
             // Resize the application to the new window size, except when
             // it was minimized. Vulkan doesn't support images or swapchains

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -2874,6 +2874,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
         case WM_GETMINMAXINFO:  // set window's minimum size
             ((MINMAXINFO *)lParam)->ptMinTrackSize = demo.minsize;
             return 0;
+        case WM_ERASEBKGND:
+            return 1;
         case WM_SIZE:
             // Resize the application to the new window size, except when
             // it was minimized. Vulkan doesn't support images or swapchains


### PR DESCRIPTION
This PR proposes ignoring the erases to the window in the cube app. 

When resizing the window the erases and the Draw() get called intermittently which causes a flashing effect to occur.  