### PR TITLE
mock_icd: fix vkGetEventStatus output

### DIFF
--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -1292,7 +1292,10 @@ class MockICDOutputGenerator(OutputGenerator):
 
         # Return result variable, if any.
         if (resulttype != None):
-            self.appendSection('command', '    return VK_SUCCESS;')
+            if api_function_name == 'vkGetEventStatus':
+                self.appendSection('command', '    return VK_EVENT_SET;')
+            else:
+                self.appendSection('command', '    return VK_SUCCESS;')
         self.appendSection('command', '}')
     #
     # override makeProtoName to drop the "vk" prefix


### PR DESCRIPTION
VK_SUCCESS is not a valid return value for this function.  VK_EVENT_SET
is used instead.