### PR TITLE
Rename cube and cubepp exes to vkcube and vkcubepp

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -24,7 +24,7 @@ in this repository for more details.
 This repository contains the source code necessary to build the following components:
 
 - vulkaninfo
-- cube and cubepp demos
+- vkcube and vkcubepp demos
 - mock ICD
 
 ### Installed Files
@@ -32,7 +32,7 @@ This repository contains the source code necessary to build the following compon
 The `install` target installs the following files under the directory
 indicated by *install_dir*:
 
-- *install_dir*`/bin` : The vulkaninfo, cube and cubepp executables
+- *install_dir*`/bin` : The vulkaninfo, vkcube and vkcubepp executables
 - *install_dir*`/lib` : The mock ICD library and JSON (Windows) (If INSTALL_ICD=ON)
 - *install_dir*`/share/vulkan/icd.d` : mock ICD JSON (Linux/MacOS) (If INSTALL_ICD=ON)
 
@@ -84,7 +84,7 @@ Note that this dependency can be ignored if not building the mock ICD
 #### glslang
 
 This repository has a required dependency on the `glslangValidator` (shader
-compiler) for compiling the shader programs for the cube demos.
+compiler) for compiling the shader programs for the vkcube demos.
 
 The CMake code in this repository downloads release binaries of glslang if a
 build glslang repository is not provided. The glslangValidator is obtained
@@ -99,7 +99,7 @@ of building glslang. You must also take note of the glslang install directory
 and pass it on the CMake command line for building this repository, as
 described below.
 
-Note that this dependency can be ignored if not building the cube demo
+Note that this dependency can be ignored if not building the vkcube demo
 (CMake option: `-DBUILD_CUBE=OFF`).
 
 ### Build and Install Directories
@@ -166,7 +166,7 @@ on/off options currently supported by this repository:
 
 | Option | Platform | Default | Description |
 | ------ | -------- | ------- | ----------- |
-| BUILD_CUBE | All | `ON` | Controls whether or not the cube demo is built. |
+| BUILD_CUBE | All | `ON` | Controls whether or not the vkcube demo is built. |
 | BUILD_VULKANINFO | All | `ON` | Controls whether or not the vulkaninfo utility is built. |
 | BUILD_ICD | All | `ON` | Controls whether or not the mock ICD is built. |
 | INSTALL_ICD | All | `OFF` | Controls whether or not the mock ICD is installed as part of the install target. |
@@ -423,11 +423,11 @@ CMake option of the form `BUILD_WSI_xxx_SUPPORT` can be set to `OFF`.
 Note vulkaninfo currently only supports Xcb and Xlib WSI display servers. See
 the CMakeLists.txt file in `Vulkan-Tools/vulkaninfo` for more info.
 
-You can select which WSI subsystem is used to execute the cube applications
+You can select which WSI subsystem is used to execute the vkcube applications
 using a CMake option called DEMOS_WSI_SELECTION. Supported options are XCB
 (default), XLIB, and WAYLAND. Note that you must build using the corresponding
 BUILD_WSI_*_SUPPORT enabled at the base repository level. For instance,
-creating a build that will use Xlib when running the cube demos, your CMake
+creating a build that will use Xlib when running the vkcube demos, your CMake
 command line might look like:
 
     cmake -DCMAKE_BUILD_TYPE=Debug -DDEMOS_WSI_SELECTION=XLIB ..
@@ -486,12 +486,12 @@ To uninstall the files from the system directories, you can execute:
 ### Linux Tests
 
 After making any changes to the repository, you should perform some quick
-sanity tests, such as running the cube demo with validation enabled.
+sanity tests, such as running the vkcube demo with validation enabled.
 
-To run the **Cube application** with validation, in a terminal change to the
+To run the **vkcube application** with validation, in a terminal change to the
 `build/cube` directory and run:
 
-    VK_LAYER_PATH=../path/to/validation/layers ./cube --validate
+    VK_LAYER_PATH=../path/to/validation/layers ./vkcube --validate
 
 If you have an SDK installed and have run the setup script to set the
 `VULKAN_SDK` environment variable, it may be unnecessary to specify a
@@ -636,8 +636,8 @@ for VS2013:
 ### Android Tests and Demos
 
 After making any changes to the repository you should perform some quick
-sanity tests, including the layer validation tests and the cube and smoke
-demos with validation enabled.
+sanity tests, including the layer validation tests and the vkcube 
+demo with validation enabled.
 
 #### Run Layer Validation Tests
 
@@ -654,15 +654,15 @@ validation tests:
 
     test_APK.sh -s <serial number> -p <platform name> -f <gtest_filter>
 
-#### Run Cube with Validation
+#### Run vkcube with Validation
 
 TODO: This must be reworked to pull in layers from the ValidationLayers repo
 
-Use the following steps to build, install, and run Cube for Android:
+Use the following steps to build, install, and run vkcube for Android:
 
     cd build-android
     ./build_all.sh
-    adb install -r ../demos/android/cube/bin/cube.apk
+    adb install -r ../demos/android/cube/bin/vkcube.apk
     adb shell am start com.example.Cube/android.app.NativeActivity
 
 To build, install, and run Cube with validation layers,
@@ -710,7 +710,7 @@ section.
 
 [MoltenVK](https://github.com/KhronosGroup/MoltenVK) Library
 
-- Building the cube and vulkaninfo applications require linking to the
+- Building the vkcube and vulkaninfo applications require linking to the
   MoltenVK Library (libMoltenVK.dylib)
   - The following option should be used on the cmake command line to specify a
     vulkan loader library: MOLTENVK_REPO_ROOT=/absolute_path_to/MoltenVK
@@ -719,7 +719,7 @@ section.
 
 Vulkan Loader Library
 
-- Building the cube and vulkaninfo applications require linking to the Vulkan
+- Building the vkcube and vulkaninfo applications require linking to the Vulkan
   Loader Library (libvulkan.1.dylib)
   - The following option should be used on the cmake command line to specify a
     vulkan loader library:
@@ -757,8 +757,8 @@ to specify the number of cores to use for the build. For example:
 
 You can now run the demo applications from the command line:
 
-    open cube/cube.app
-    open cube/cubepp.app
+    open cube/vkcube.app
+    open cube/vkcubepp.app
     open vulkaninfo/vulkaninfo.app
 
 Or you can locate them from `Finder` and launch them from there.
@@ -771,9 +771,9 @@ that are still in your build tree.
 
 To see this, run this command from your `build` directory:
 
-    otool -l cube/cube.app/Contents/MacOS/cube
+    otool -l cube/cube.app/Contents/MacOS/vkcube
 
-and note that the `cube` executable contains loader commands:
+and note that the `vkcube` executable contains loader commands:
 
 - `LC_LOAD_DYLIB` to load `libvulkan.1.dylib` via an `@rpath`
 - `LC_RPATH` that contains an absolute path to the build location of the Vulkan loader
@@ -830,4 +830,4 @@ To create and open an Xcode project:
 
 Within Xcode, you can select Debug or Release builds in the project's Build
 Settings. You can also select individual schemes for working with specific
-applications like `cube`.
+applications like `vkcube`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,10 +67,10 @@ that to be accepted into the repository, the pull request must [pass all tests](
 * Run the repository components with the Vulkan Validation Layers before and after each if your commits to check for any regressions.
 
   (These instructions are for Linux)
-* In the `demos` directory, run:
-
->        cube
->        cube --validate
+* In the `cube` directory, run:
+>        vkcube
+>        vkcube --validate
+* In the `vulkaninfo` directory, run:
 >        vulkaninfo
 
 * Run tests that explicitly exercise your changes.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ verify their applications correct use of the Vulkan API.
 
 The following components are available in this repository:
 - [*Mock ICD*](icd/)
-- [*Cube and Cube++ Demo*](cube/)
+- [*Vkcube and Vkcube++ Demo*](cube/)
 - [*VulkanInfo*](vulkaninfo/)
 - [*Windows Runtime*](winrt/)
 
@@ -32,7 +32,7 @@ Please see the [GOVERNANCE.md](GOVERNANCE.md) file in this repository for reposi
 ## How to Build and Run
 
 [BUILD.md](BUILD.md)
-Includes directions for building all components as well as running the cube demo applications.
+Includes directions for building all components as well as running the vkcube demo applications.
 
 ## License
 This work is released as open source under a Apache-style license from Khronos including a Khronos copyright.

--- a/build-android/build_all.sh
+++ b/build-android/build_all.sh
@@ -57,7 +57,7 @@ function create_APK() {
 ./update_external_sources_android.sh --no-build
 
 #
-# build cube APK
+# build vkcube APK
 #
 (
 pushd $DEMO_BUILD_DIR
@@ -65,7 +65,7 @@ ndk-build -j $cores
 mkdir -p $DEMO_BUILD_DIR/cube/bin/libs/lib
 cp -r $DEMO_BUILD_DIR/libs/* $DEMO_BUILD_DIR/cube/bin/libs/lib/
 cd $DEMO_BUILD_DIR/cube
-create_APK cube
+create_APK vkcube
 popd
 )
 

--- a/build-android/install_all.sh
+++ b/build-android/install_all.sh
@@ -70,7 +70,7 @@ else
 fi
 
 # Install everything built by build_all.sh
-echo "adb $serialFlag install -r ../cube/android/cube/bin/cube.apk"
-adb $serialFlag install -r ../cube/android/cube/bin/cube.apk
+echo "adb $serialFlag install -r ../cube/android/cube/bin/vkcube.apk"
+adb $serialFlag install -r ../cube/android/cube/bin/vkcube.apk
 
 exit $?

--- a/cube/CMakeLists.txt
+++ b/cube/CMakeLists.txt
@@ -46,7 +46,7 @@ if(UNIX AND NOT APPLE) # i.e. Linux
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
     option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
     option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
-    set(CUBE_WSI_SELECTION "XCB" CACHE STRING "Select WSI target for cube (XCB, XLIB, WAYLAND, DISPLAY)")
+    set(CUBE_WSI_SELECTION "XCB" CACHE STRING "Select WSI target for vkcube (XCB, XLIB, WAYLAND, DISPLAY)")
 
     if(BUILD_WSI_XCB_SUPPORT)
         find_package(XCB REQUIRED)
@@ -66,7 +66,7 @@ if(WIN32)
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
     if(NOT MSVC_VERSION LESS 1900)
         # Enable control flow guard
-        message(STATUS "Building cube with control flow guard")
+        message(STATUS "Building vkcube with control flow guard")
         add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/guard:cf>")
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf")
@@ -82,21 +82,21 @@ elseif(UNIX AND NOT APPLE) # i.e. Linux
 
     if(CUBE_WSI_SELECTION STREQUAL "XCB")
         if(NOT BUILD_WSI_XCB_SUPPORT)
-            message(FATAL_ERROR "Selected XCB for cube build but not building Xcb support")
+            message(FATAL_ERROR "Selected XCB for vkcube build but not building Xcb support")
         endif()
         set(CUBE_INCLUDE_DIRS ${XCB_INCLUDE_DIRS} ${CUBE_INCLUDE_DIRS})
         link_libraries(${XCB_LIBRARIES})
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
     elseif(CUBE_WSI_SELECTION STREQUAL "XLIB")
         if(NOT BUILD_WSI_XLIB_SUPPORT)
-            message(FATAL_ERROR "Selected XLIB for cube build but not building Xlib support")
+            message(FATAL_ERROR "Selected XLIB for vkcube build but not building Xlib support")
         endif()
         set(CUBE_INCLUDE_DIRS ${X11_INCLUDE_DIR} ${CUBE_INCLUDE_DIRS})
         link_libraries(${X11_LIBRARIES})
         add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
     elseif(CUBE_WSI_SELECTION STREQUAL "WAYLAND")
         if(NOT BUILD_WSI_WAYLAND_SUPPORT)
-            message(FATAL_ERROR "Selected Wayland for cube build but not building Wayland support")
+            message(FATAL_ERROR "Selected Wayland for vkcube build but not building Wayland support")
         endif()
         set(CUBE_INCLUDE_DIRS ${WAYLAND_CLIENT_INCLUDE_DIR} ${CUBE_INCLUDE_DIRS})
         link_libraries(${WAYLAND_CLIENT_LIBRARIES})
@@ -161,19 +161,19 @@ endif()
 include_directories(${CUBE_INCLUDE_DIRS})
 
 # ----------------------------------------------------------------------------
-# cube
+# vkcube
 
 if(APPLE)
     include(macOS/cube/cube.cmake)
 elseif(NOT WIN32)
     if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL ${CMAKE_HOST_SYSTEM_PROCESSOR})
-        add_executable(cube
+        add_executable(vkcube
                        cube.c
                        ${PROJECT_SOURCE_DIR}/cube/cube.vert
                        ${PROJECT_SOURCE_DIR}/cube/cube.frag
                        cube.vert.inc
                        cube.frag.inc)
-        target_link_libraries(cube Vulkan::Vulkan)
+        target_link_libraries(vkcube Vulkan::Vulkan)
     endif()
 else()
     if(CMAKE_CL_64)
@@ -182,43 +182,43 @@ else()
         set(LIB_DIR "Win32")
     endif()
 
-    add_executable(cube
+    add_executable(vkcube
                    WIN32
                    cube.c
                    ${PROJECT_SOURCE_DIR}/cube/cube.vert
                    ${PROJECT_SOURCE_DIR}/cube/cube.frag
                    cube.vert.inc
                    cube.frag.inc)
-    target_link_libraries(cube Vulkan::Vulkan)
+    target_link_libraries(vkcube Vulkan::Vulkan)
 endif()
 
 if(APPLE)
     # Keep RPATH so fixup_bundle can use it to find libraries
-    set_target_properties(cube PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-    install(TARGETS cube BUNDLE DESTINATION "cube")
+    set_target_properties(vkcube PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+    install(TARGETS vkcube BUNDLE DESTINATION "cube")
     # Fix up the library references to be self-contained within the bundle.
     install(CODE "
         include(BundleUtilities)
         fixup_bundle(\${CMAKE_INSTALL_PREFIX}/cube/cube.app \"\" \"\")
         ")
 else()
-    install(TARGETS cube RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(TARGETS vkcube RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 # ----------------------------------------------------------------------------
-# cubepp
+# vkcubepp
 
 if(APPLE)
     include(macOS/cubepp/cubepp.cmake)
 elseif(NOT WIN32)
     if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL ${CMAKE_HOST_SYSTEM_PROCESSOR})
-        add_executable(cubepp
+        add_executable(vkcubepp
                        cube.cpp
                        ${PROJECT_SOURCE_DIR}/cube/cube.vert
                        ${PROJECT_SOURCE_DIR}/cube/cube.frag
                        cube.vert.inc
                        cube.frag.inc)
-        target_link_libraries(cubepp Vulkan::Vulkan)
+        target_link_libraries(vkcubepp Vulkan::Vulkan)
     endif()
 else()
     if(CMAKE_CL_64)
@@ -227,25 +227,25 @@ else()
         set(LIB_DIR "Win32")
     endif()
 
-    add_executable(cubepp
+    add_executable(vkcubepp
                    WIN32
                    cube.cpp
                    ${PROJECT_SOURCE_DIR}/cube/cube.vert
                    ${PROJECT_SOURCE_DIR}/cube/cube.frag
                    cube.vert.inc
                    cube.frag.inc)
-    target_link_libraries(cubepp Vulkan::Vulkan)
+    target_link_libraries(vkcubepp Vulkan::Vulkan)
 endif()
 
 if(APPLE)
     # Keep RPATH so fixup_bundle can use it to find libraries
-    set_target_properties(cubepp PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-    install(TARGETS cubepp BUNDLE DESTINATION "cube")
+    set_target_properties(vkcubepp PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+    install(TARGETS vkcubepp BUNDLE DESTINATION "cube")
     # Fix up the library references to be self-contained within the bundle.
     install(CODE "
         include(BundleUtilities)
         fixup_bundle(\${CMAKE_INSTALL_PREFIX}/cube/cubepp.app \"\" \"\")
         ")
 else()
-    install(TARGETS cubepp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(TARGETS vkcubepp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/cube/android/cube-with-layers/AndroidManifest.xml
+++ b/cube/android/cube-with-layers/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.CubeWithLayers" android:versionCode="1" android:versionName="1.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.VkCubeWithLayers" android:versionCode="1" android:versionName="1.0">
 
     <!-- Allow this app to read and write files (for use by tracing libraries). -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
@@ -16,7 +16,7 @@
              This will take care of integrating with our NDK code. -->
         <activity android:name="android.app.NativeActivity" android:label="@string/app_name" android:exported="true">
             <!-- Tell NativeActivity the name of or .so -->
-            <meta-data android:name="android.app.lib_name" android:value="Cube"/>
+            <meta-data android:name="android.app.lib_name" android:value="VkCube"/>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/cube/android/cube-with-layers/custom_rules.xml
+++ b/cube/android/cube-with-layers/custom_rules.xml
@@ -5,21 +5,21 @@
 <property name="cubeDir" location="../libs" />
 <property name="layersDir" location="../../../build-android/libs" />
 
-<echo>CubeWithLayers: Creating libs-with-layers</echo>
+<echo>VkCubeWithLayers: Creating libs-with-layers</echo>
 <mkdir dir="${cubeWithLayersDir}"/>
 
-<echo>CubeWithLayers: Copying libs from demos/android</echo>
+<echo>VkCubeWithLayers: Copying libs from demos/android</echo>
 <copy todir="${cubeWithLayersDir}">
 <fileset dir="${cubeDir}"/>
 </copy>
 
-<echo>CubeWithLayers: Copying layers from build-android</echo>
+<echo>VkCubeWithLayers: Copying layers from build-android</echo>
 <copy todir="${cubeWithLayersDir}">
 <fileset dir="${layersDir}"/>
 </copy>
 
 <!-- Point ndk-build at the libs-with-layers common dir -->
-<echo>CubeWithLayers: Overriding native.libs.absolute.dir with ${cubeWithLayersDir}</echo>
+<echo>VkCubeWithLayers: Overriding native.libs.absolute.dir with ${cubeWithLayersDir}</echo>
 <property name="native.libs.absolute.dir" location="${cubeWithLayersDir}" />
 
 </project>

--- a/cube/android/cube-with-layers/res/values/strings.xml
+++ b/cube/android/cube-with-layers/res/values/strings.xml
@@ -19,6 +19,6 @@
 
 <resources>
     <!-- Simple strings. -->
-    <string name="app_name">CubeWithLayers</string>
+    <string name="app_name">VkCubeWithLayers</string>
 
 </resources>

--- a/cube/android/cube/AndroidManifest.xml
+++ b/cube/android/cube/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.Cube" android:versionCode="1" android:versionName="1.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.VkCube" android:versionCode="1" android:versionName="1.0">
 
     <!-- Allow this app to read and write files (for use by tracing libraries). -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
@@ -16,7 +16,7 @@
              This will take care of integrating with our NDK code. -->
         <activity android:name="android.app.NativeActivity" android:label="@string/app_name" android:exported="true">
             <!-- Tell NativeActivity the name of or .so -->
-            <meta-data android:name="android.app.lib_name" android:value="Cube"/>
+            <meta-data android:name="android.app.lib_name" android:value="VkCube"/>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/cube/android/cube/custom_rules.xml
+++ b/cube/android/cube/custom_rules.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="NativeActivity" default="help">
 <!-- Point ndk-build at the libs created in common dir -->
-<echo>cube: Overriding native.libs.absolute.dir with ../libs</echo>
+<echo>vkcube: Overriding native.libs.absolute.dir with ../libs</echo>
 <property name="native.libs.absolute.dir" location="../libs" />
 </project>

--- a/cube/android/cube/res/values/strings.xml
+++ b/cube/android/cube/res/values/strings.xml
@@ -19,6 +19,6 @@
 
 <resources>
     <!-- Simple strings. -->
-    <string name="app_name">Cube</string>
+    <string name="app_name">VkCube</string>
 
 </resources>

--- a/cube/android/jni/Android.mk
+++ b/cube/android/jni/Android.mk
@@ -18,7 +18,7 @@ SRC_DIR := $(LOCAL_PATH)/../../..
 DEMO_DIR := $(SRC_DIR)/cube
 
 include $(CLEAR_VARS)
-LOCAL_MODULE := Cube
+LOCAL_MODULE := VkCube
 LOCAL_SRC_FILES += $(DEMO_DIR)/cube.c \
                    $(SRC_DIR)/common/vulkan_wrapper.cpp \
                    $(SRC_DIR)/common/android_util.cpp

--- a/cube/android/jni/Application.mk
+++ b/cube/android/jni/Application.mk
@@ -16,7 +16,7 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_PLATFORM := android-23
 APP_STL := gnustl_static
-APP_MODULES := Cube
+APP_MODULES := VkCube
 APP_CPPFLAGS += -std=c++11 -fexceptions -Wall -Werror -Wextra -Wno-unused-parameter -DVK_NO_PROTOTYES -DGLM_FORCE_RADIANS
 APP_CFLAGS += -Wall -Werror -Wextra -Wno-unused-parameter -DVK_NO_PROTOTYES -DGLM_FORCE_RADIANS
 NDK_TOOLCHAIN_VERSION := clang

--- a/cube/macOS/cube/Info.plist
+++ b/cube/macOS/cube/Info.plist
@@ -7,17 +7,17 @@
 	<key>CFBundleExecutable</key>
 	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
 	<key>CFBundleGetInfoString</key>
-	<string>Cube</string>
+	<string>VkCube</string>
 	<key>CFBundleIconFile</key>
 	<string>LunarGIcon.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.lunarg.cube</string>
+	<string>com.lunarg.vkcube</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleLongVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleName</key>
-	<string>Cube</string>
+	<string>VkCube</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/cube/macOS/cube/cube.cmake
+++ b/cube/macOS/cube/cube.cmake
@@ -15,7 +15,7 @@
 # limitations under the License.
 # ~~~
 
-# Cube Application Bundle
+# VkCube Application Bundle
 
 set(cube_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cube/main.m
@@ -32,32 +32,32 @@ if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
     set(cube_RESOURCES ${cube_RESOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cube/Resources/Main.storyboard)
 endif()
 
-add_executable(cube MACOSX_BUNDLE ${cube_SRCS} ${cube_HDRS} ${cube_RESOURCES} cube.vert.inc cube.frag.inc)
+add_executable(vkcube MACOSX_BUNDLE ${cube_SRCS} ${cube_HDRS} ${cube_RESOURCES} cube.vert.inc cube.frag.inc)
 
 # Handle the Storyboard ourselves
 if(NOT ${CMAKE_GENERATOR} MATCHES "^Xcode.*")
     # Compile the storyboard file with the ibtool.
-    add_custom_command(TARGET cube POST_BUILD
+    add_custom_command(TARGET vkcube POST_BUILD
                        COMMAND ${IBTOOL}
                                --errors
                                --warnings
                                --notices
                                --output-format human-readable-text
-                               --compile ${CMAKE_CURRENT_BINARY_DIR}/cube.app/Contents/Resources/Main.storyboardc
+                               --compile ${CMAKE_CURRENT_BINARY_DIR}/vkcube.app/Contents/Resources/Main.storyboardc
                                          ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cube/Resources/Main.storyboard
                        COMMENT "Compiling storyboard")
 endif()
 
-add_dependencies(cube MoltenVK_icd-staging-json)
+add_dependencies(vkcube MoltenVK_icd-staging-json)
 
 # Include demo source code dir because the MacOS cube's Objective-C source includes the "original" cube application C source code.
 # Also include the MoltenVK helper files.
-target_include_directories(cube PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${MOLTENVK_DIR}/MoltenVK/include)
+target_include_directories(vkcube PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${MOLTENVK_DIR}/MoltenVK/include)
 
 # We do this so vulkaninfo is linked to an individual library and NOT a framework.
-target_link_libraries(cube ${Vulkan_LIBRARY} "-framework Cocoa -framework QuartzCore")
+target_link_libraries(vkcube ${Vulkan_LIBRARY} "-framework Cocoa -framework QuartzCore")
 
-set_target_properties(cube PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cube/Info.plist)
+set_target_properties(vkcube PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cube/Info.plist)
 
 # The RESOURCE target property cannot be used in conjunction with the MACOSX_PACKAGE_LOCATION property.  We need fine-grained
 # control over the Resource directory, so we have to specify the destination of all the resource files on a per-destination-
@@ -71,13 +71,13 @@ set_source_files_properties("${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json"
 
 # Copy the MoltenVK lib into the bundle.
 if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
-    add_custom_command(TARGET cube POST_BUILD
+    add_custom_command(TARGET vkcube POST_BUILD
                        COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/macOS/libMoltenVK.dylib"
-                               ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/cube.app/Contents/Frameworks/libMoltenVK.dylib
+                               ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/vkcube.app/Contents/Frameworks/libMoltenVK.dylib
                        DEPENDS vulkan)
 else()
-    add_custom_command(TARGET cube POST_BUILD
+    add_custom_command(TARGET vkcube POST_BUILD
                        COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/macOS/libMoltenVK.dylib"
-                               ${CMAKE_CURRENT_BINARY_DIR}/cube.app/Contents/Frameworks/libMoltenVK.dylib
+                               ${CMAKE_CURRENT_BINARY_DIR}/vkcube.app/Contents/Frameworks/libMoltenVK.dylib
                        DEPENDS vulkan)
 endif()

--- a/cube/macOS/cubepp/Info.plist
+++ b/cube/macOS/cubepp/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
 	<key>CFBundleGetInfoString</key>
-	<string>Cubepp</string>
+	<string>VkCubepp</string>
 	<key>CFBundleIconFile</key>
 	<string>LunarGIcon.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -17,7 +17,7 @@
 	<key>CFBundleLongVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleName</key>
-	<string>Cubepp</string>
+	<string>VkCubepp</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/cube/macOS/cubepp/cubepp.cmake
+++ b/cube/macOS/cubepp/cubepp.cmake
@@ -15,7 +15,7 @@
 # limitations under the License.
 # ~~~
 
-# Cube Application Bundle
+# VkCube Application Bundle
 
 set(cubepp_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cubepp/main.mm
@@ -34,32 +34,32 @@ if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
     set(cubepp_RESOURCES ${cubepp_RESOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cubepp/Resources/Main.storyboard)
 endif()
 
-add_executable(cubepp MACOSX_BUNDLE ${cubepp_SRCS} ${cubepp_HDRS} ${cubepp_RESOURCES} cube.vert.inc cube.frag.inc)
+add_executable(vkcubepp MACOSX_BUNDLE ${cubepp_SRCS} ${cubepp_HDRS} ${cubepp_RESOURCES} cube.vert.inc cube.frag.inc)
 
 # Handle the Storyboard ourselves
 if(NOT ${CMAKE_GENERATOR} MATCHES "^Xcode.*")
     # Compile the storyboard file with the ibtool.
-    add_custom_command(TARGET cubepp POST_BUILD
+    add_custom_command(TARGET vkcubepp POST_BUILD
                        COMMAND ${IBTOOL}
                                --errors
                                --warnings
                                --notices
                                --output-format human-readable-text
-                               --compile ${CMAKE_CURRENT_BINARY_DIR}/cubepp.app/Contents/Resources/Main.storyboardc
+                               --compile ${CMAKE_CURRENT_BINARY_DIR}/vkcubepp.app/Contents/Resources/Main.storyboardc
                                          ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cubepp/Resources/Main.storyboard
                        COMMENT "Compiling storyboard")
 endif()
 
-add_dependencies(cubepp MoltenVK_icd-staging-json)
+add_dependencies(vkcubepp MoltenVK_icd-staging-json)
 
-# Include demo source code dir because the MacOS cubepp's Objective-C source includes the "original" cubepp application C++ source
+# Include demo source code dir because the MacOS vkcubepp's Objective-C source includes the "original" vkcubepp application C++ source
 # code. Also include the MoltenVK helper files.
-target_include_directories(cubepp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${MOLTENVK_DIR}/MoltenVK/include)
+target_include_directories(vkcubepp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${MOLTENVK_DIR}/MoltenVK/include)
 
 # We do this so vulkaninfo is linked to an individual library and NOT a framework.
-target_link_libraries(cubepp ${Vulkan_LIBRARY} "-framework Cocoa -framework QuartzCore")
+target_link_libraries(vkcubepp ${Vulkan_LIBRARY} "-framework Cocoa -framework QuartzCore")
 
-set_target_properties(cubepp PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cubepp/Info.plist)
+set_target_properties(vkcubepp PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cubepp/Info.plist)
 
 # The RESOURCE target property cannot be used in conjunction with the MACOSX_PACKAGE_LOCATION property.  We need fine-grained
 # control over the Resource directory, so we have to specify the destination of all the resource files on a per-destination-
@@ -73,13 +73,13 @@ set_source_files_properties("${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json"
 
 # Copy the MoltenVK lib into the bundle.
 if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
-    add_custom_command(TARGET cubepp POST_BUILD
+    add_custom_command(TARGET vkcubepp POST_BUILD
                        COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/macOS/libMoltenVK.dylib"
-                               ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/cubepp.app/Contents/Frameworks/libMoltenVK.dylib
+                               ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/vkcubepp.app/Contents/Frameworks/libMoltenVK.dylib
                        DEPENDS vulkan)
 else()
-    add_custom_command(TARGET cubepp POST_BUILD
+    add_custom_command(TARGET vkcubepp POST_BUILD
                        COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/macOS/libMoltenVK.dylib"
-                               ${CMAKE_CURRENT_BINARY_DIR}/cubepp.app/Contents/Frameworks/libMoltenVK.dylib
+                               ${CMAKE_CURRENT_BINARY_DIR}/vkcubepp.app/Contents/Frameworks/libMoltenVK.dylib
                        DEPENDS vulkan)
 endif()

--- a/scripts/fetch_glslangvalidator.py
+++ b/scripts/fetch_glslangvalidator.py
@@ -20,7 +20,7 @@
 
 
 # This script will download the latest glslang release binary and extract the
-# glslangValidator binary needed by the cube and cubepp applications.
+# glslangValidator binary needed by the vkcube and vkcubepp applications.
 #
 # It takes as its lone argument the filname (no path) describing the release
 # binary name from the glslang github releases page.


### PR DESCRIPTION
Move to a more consistent naming scheme for Vulkan apps.