### PR TITLE
build: add missing wayland-client search path for mock_icd build

### DIFF
--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -158,6 +158,7 @@ endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}
                     ${VulkanHeaders_INCLUDE_DIR}
+                    ${WAYLAND_CLIENT_INCLUDE_DIR}
                     ${CMAKE_CURRENT_BINARY_DIR}
                     ${PROJECT_BINARY_DIR}
                     ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
Fix issues #1444 and #1989 of Vulkan-LoaderAndValidationLayers **again**.

    [ 82%] Building CXX object icd/CMakeFiles/VkICD_mock_icd.dir/mock_icd.cpp.o
    cd $HOME/Vulkan-Tools/icd && /usr/bin/c++
    -DVK_USE_PLATFORM_WAYLAND_KHR -DVK_USE_PLATFORM_WAYLAND_KHX
    -DVK_USE_PLATFORM_XCB_KHR -DVK_USE_PLATFORM_XCB_KHX
    -DVK_USE_PLATFORM_XLIB_KHR -DVK_USE_PLATFORM_XLIB_KHX
    -DVK_USE_PLATFORM_XLIB_XRANDR_EXT -DVkICD_mock_icd_EXPORTS
    -I$HOME/Vulkan-Tools/icd -I$HOME/Vulkan-Tools -Wall -Wextra
    -Wno-unused-parameter -Wno-missing-field-initializers
    -fno-strict-aliasing -fno-builtin-memcmp -Wimplicit-fallthrough=0
    -std=c++11 -fno-rtti -fvisibility=hidden -Wpointer-arith
    -Wno-unused-function -Wno-sign-compare -fPIC -o
    CMakeFiles/VkICD_mock_icd.dir/mock_icd.cpp.o -c
    $HOME/Vulkan-Tools/icd/mock_icd.cpp
    In file included from /usr/include/vulkan/vk_icd.h:26,
                     from $HOME/Vulkan-Tools/icd/mock_icd.h:29,
                     from $HOME/Vulkan-Tools/icd/mock_icd.cpp:22:
    /usr/include/vulkan/vulkan.h:48:10: fatal error: wayland-client.h: No such file or directory
     #include <wayland-client.h>