### PR TITLE
vulkaninfo:  Fix memory init/leak

### DIFF
--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -509,6 +509,7 @@ static void buildpNextChain(struct VkStructureHeader *first, const struct pNextC
         if (!place->pNext) {
             ERR_EXIT(VK_ERROR_OUT_OF_HOST_MEMORY);
         }
+        memset(place->pNext, 0, chain_info[i].mem_size);
         place = place->pNext;
         place->sType = chain_info[i].sType;
     }
@@ -1206,6 +1207,7 @@ static void AppCreateXlibWindow(struct AppInstance *inst) {
                 visualInfo->visual, 0, NULL);
 
     XSync(inst->xlib_display,false);
+    XFree(visualInfo);
 }
 
 static void AppCreateXlibSurface(struct AppInstance *inst) {


### PR DESCRIPTION
- Clear the structures allocated for the pNext chains.  While this
  is not strictly necessary, any pNext structure that is not
  filled in by a driver (because the extension isn't there) gets
  left in an untouched state.  This can be a false positive flagged
  by valgrind.
- Use XFree to free storage allocated by Xlib's XGetVisualInfo().
  This fixes an actual leak.