### PR TITLE
vulkaninfo: only query supported formats

### DIFF
--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -2009,7 +2009,7 @@ static void AppDevDump(const struct AppGpu *gpu, FILE *out) {
     }
 
     bool first_in_list = true;   // Used for commas in json output
-    for (unsigned int i = 0; i < sizeof(supported_format_ranges)/sizeof(supported_format_ranges[0]); i++) {
+    for (uint32_t i = 0; i < sizeof(supported_format_ranges)/sizeof(supported_format_ranges[0]); i++) {
         struct FormatRange format_range = supported_format_ranges[i];
         if (FormatRangeSupported(&format_range, gpu)) {
             for (VkFormat fmt = format_range.first_format; fmt <= format_range.last_format; ++fmt) {


### PR DESCRIPTION
vulkaninfo must not query formats that are not supported on a
given instance, as this provokes undefined behavior (it could
appear to work, or it could segfault in the driver).

These changes ensure that a format is only queried if it
is supported in either the base Vulkan instance or, if it is an
extension format, if that extension is supported by the Vulkan
instance.

- Moved instance version information to the AppInstance struct
  (initialized by AppCreateInstance()), which makes sense and
  allows lower-level code to determine whether a format is
  supported on the current instance version
- Formats are now encoded with their owning Vulkan version
  and extension name, so they can be checked for validity
  before making a query.

Note that this change can cause behavior changes; instances
that didn't crash on unsupported formats (and thus appeared to
support more formats than they actually did) will no longer
report those formats.  Instances that would segfault when
an unsupported formatn was queried should no longer crash.