### PR TITLE
vulkaninfo: Add extensions

### DIFF
--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -1093,7 +1093,9 @@ static void AppGpuInit(struct AppGpu *gpu, struct AppInstance *inst, uint32_t id
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR,
              .mem_size = sizeof(VkPhysicalDeviceMultiviewFeaturesKHR)},
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR,
-             .mem_size = sizeof(VkPhysicalDeviceFloat16Int8FeaturesKHR)}};
+             .mem_size = sizeof(VkPhysicalDeviceFloat16Int8FeaturesKHR)},
+            {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR,
+             .mem_size = sizeof(VkPhysicalDeviceShaderAtomicInt64FeaturesKHR)}};
 
         uint32_t chain_info_len = ARRAY_SIZE(chain_info);
 
@@ -2317,12 +2319,23 @@ static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
                     fprintf(out, "\t\t\t\t\t\t<details><summary>shaderFloat16 = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_int_features->shaderFloat16);
                     fprintf(out, "\t\t\t\t\t\t<details><summary>shaderInt8    = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_int_features->shaderInt8);
                     fprintf(out, "\t\t\t\t\t</details>\n");
-                }
-                else if (human_readable_output) {
+                } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceFloat16Int8Features:\n");
                     printf("====================================\n");
                     printf("\tshaderFloat16 = %" PRIuLEAST32 "\n", float_int_features->shaderFloat16);
                     printf("\tshaderInt8    = %" PRIuLEAST32 "\n", float_int_features->shaderInt8);
+                }
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
+                VkPhysicalDeviceShaderAtomicInt64FeaturesKHR *shader_atomic_int64_features = (VkPhysicalDeviceShaderAtomicInt64FeaturesKHR*)structure;
+                if (html_output) {
+                    fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceShaderAtomicInt64Features</summary>\n");
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderBufferInt64Atomics = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", shader_atomic_int64_features->shaderBufferInt64Atomics);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderSharedInt64Atomics = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", shader_atomic_int64_features->shaderSharedInt64Atomics);
+                } else if (human_readable_output) {
+                    printf("\nVkPhysicalDeviceShaderAtomicInt64Features:\n");
+                    printf("==========================================\n");
+                    printf("\tshaderBufferInt64Atomics = %" PRIuLEAST32 "\n", shader_atomic_int64_features->shaderBufferInt64Atomics);
+                    printf("\tshaderSharedInt64Atomics = %" PRIuLEAST32 "\n", shader_atomic_int64_features->shaderSharedInt64Atomics);
                 }
             }
             place = structure->pNext;

--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -995,7 +995,9 @@ static void AppGpuInit(struct AppGpu *gpu, struct AppInstance *inst, uint32_t id
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT,
              .mem_size = sizeof(VkPhysicalDevicePCIBusInfoPropertiesEXT)},
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT,
-             .mem_size = sizeof(VkPhysicalDeviceTransformFeedbackPropertiesEXT)}};
+             .mem_size = sizeof(VkPhysicalDeviceTransformFeedbackPropertiesEXT)},
+            {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT,
+             .mem_size = sizeof(VkPhysicalDeviceFragmentDensityMapPropertiesEXT)}};
 
         uint32_t chain_info_len = ARRAY_SIZE(chain_info);
 
@@ -1101,7 +1103,9 @@ static void AppGpuInit(struct AppGpu *gpu, struct AppInstance *inst, uint32_t id
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT,
              .mem_size = sizeof(VkPhysicalDeviceTransformFeedbackFeaturesEXT)},
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT,
-             .mem_size = sizeof(VkPhysicalDeviceScalarBlockLayoutFeaturesEXT)}};
+             .mem_size = sizeof(VkPhysicalDeviceScalarBlockLayoutFeaturesEXT)},
+            {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT,
+             .mem_size = sizeof(VkPhysicalDeviceFragmentDensityMapFeaturesEXT)}};
 
         uint32_t chain_info_len = ARRAY_SIZE(chain_info);
 
@@ -2367,6 +2371,21 @@ static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
                     printf("==========================================\n");
                     printf("\tscalarBlockLayout = %" PRIuLEAST32 "\n", scalar_block_layout_features->scalarBlockLayout);
                 }
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
+                VkPhysicalDeviceFragmentDensityMapFeaturesEXT *fragment_density_map_features = (VkPhysicalDeviceFragmentDensityMapFeaturesEXT*)structure;
+                if (html_output) {
+                    fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceFragmentDensityMapFeatures</summary>\n");
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>fragmentDensityMap                    = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_features->fragmentDensityMap);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>fragmentDensityMapDynamic             = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_features->fragmentDensityMapDynamic);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>fragmentDensityMapNonSubsampledImages = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_features->fragmentDensityMapNonSubsampledImages);
+                }
+                else if (human_readable_output) {
+                    printf("\nVkPhysicalDeviceFragmentDensityMapFeatures:\n");
+                    printf("==========================================\n");
+                    printf("\tfragmentDensityMap                    = %" PRIuLEAST32 "\n", fragment_density_map_features->fragmentDensityMap);
+                    printf("\tfragmentDensityMapDynamic             = %" PRIuLEAST32 "\n", fragment_density_map_features->fragmentDensityMapDynamic);
+                    printf("\tfragmentDensityMapNonSubsampledImages = %" PRIuLEAST32 "\n", fragment_density_map_features->fragmentDensityMapNonSubsampledImages);
+                }
             }
             place = structure->pNext;
         }
@@ -3151,6 +3170,28 @@ static void AppGpuDumpProps(const struct AppGpu *gpu, FILE *out) {
                     printf("\ttransformFeedbackStreamsLinesTriangles     = %" PRIuLEAST32 "\n", transform_feedback_properties->transformFeedbackStreamsLinesTriangles);
                     printf("\ttransformFeedbackRasterizationStreamSelect = %" PRIuLEAST32 "\n", transform_feedback_properties->transformFeedbackRasterizationStreamSelect);
                     printf("\ttransformFeedbackDraw                      = %" PRIuLEAST32 "\n", transform_feedback_properties->transformFeedbackDraw);
+                }
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
+                VkPhysicalDeviceFragmentDensityMapPropertiesEXT *fragment_density_map_properties = (VkPhysicalDeviceFragmentDensityMapPropertiesEXT*)structure;
+                if (html_output) {
+                    fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceFragmentDensityMapProperties</summary>\n");
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>minFragmentDensityTexelSize</summary>\n");
+                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_properties->minFragmentDensityTexelSize.width);
+                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_properties->minFragmentDensityTexelSize.height);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxFragmentDensityTexelSize</summary>\n");
+                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_properties->maxFragmentDensityTexelSize.width);
+                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_properties->maxFragmentDensityTexelSize.height);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>fragmentDensityInvocations = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_properties->fragmentDensityInvocations);
+                } else if (human_readable_output) {
+                    printf("\nVkPhysicalDeviceFragmentDensityMapProperties\n");
+                    printf("============================================\n");
+                    printf("\tminFragmentDensityTexelSize\n");
+                    printf("\t\twidth = %" PRIuLEAST32 "\n", fragment_density_map_properties->minFragmentDensityTexelSize.width);
+                    printf("\t\theight = %" PRIuLEAST32 "\n", fragment_density_map_properties->minFragmentDensityTexelSize.height);
+                    printf("\tmaxFragmentDensityTexelSize\n");
+                    printf("\t\twidth = %" PRIuLEAST32 "\n", fragment_density_map_properties->maxFragmentDensityTexelSize.width);
+                    printf("\t\theight = %" PRIuLEAST32 "\n", fragment_density_map_properties->maxFragmentDensityTexelSize.height);
+                    printf("\tfragmentDensityInvocations = %" PRIuLEAST32 "\n", fragment_density_map_properties->fragmentDensityInvocations);
                 }
             }
             place = structure->pNext;

--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -1099,7 +1099,9 @@ static void AppGpuInit(struct AppGpu *gpu, struct AppInstance *inst, uint32_t id
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR,
              .mem_size = sizeof(VkPhysicalDeviceShaderAtomicInt64FeaturesKHR)},
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT,
-             .mem_size = sizeof(VkPhysicalDeviceTransformFeedbackFeaturesEXT)}};
+             .mem_size = sizeof(VkPhysicalDeviceTransformFeedbackFeaturesEXT)},
+            {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT,
+             .mem_size = sizeof(VkPhysicalDeviceScalarBlockLayoutFeaturesEXT)}};
 
         uint32_t chain_info_len = ARRAY_SIZE(chain_info);
 
@@ -2353,6 +2355,17 @@ static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
                     printf("==========================================\n");
                     printf("\ttransformFeedback = %" PRIuLEAST32 "\n", transform_feedback_features->transformFeedback);
                     printf("\tgeometryStreams   = %" PRIuLEAST32 "\n", transform_feedback_features->geometryStreams);
+                }
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
+                VkPhysicalDeviceScalarBlockLayoutFeaturesEXT *scalar_block_layout_features = (VkPhysicalDeviceScalarBlockLayoutFeaturesEXT*)structure;
+                if (html_output) {
+                    fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceScalarBlockLayoutFeatures</summary>\n");
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>scalarBlockLayout = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", scalar_block_layout_features->scalarBlockLayout);
+                }
+                else if (human_readable_output) {
+                    printf("\nVkPhysicalDeviceScalarBlockLayoutFeatures:\n");
+                    printf("==========================================\n");
+                    printf("\tscalarBlockLayout = %" PRIuLEAST32 "\n", scalar_block_layout_features->scalarBlockLayout);
                 }
             }
             place = structure->pNext;

--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -993,7 +993,9 @@ static void AppGpuInit(struct AppGpu *gpu, struct AppInstance *inst, uint32_t id
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR,
              .mem_size = sizeof(VkPhysicalDeviceFloatControlsPropertiesKHR)},
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT,
-             .mem_size = sizeof(VkPhysicalDevicePCIBusInfoPropertiesEXT)}};
+             .mem_size = sizeof(VkPhysicalDevicePCIBusInfoPropertiesEXT)},
+            {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT,
+             .mem_size = sizeof(VkPhysicalDeviceTransformFeedbackPropertiesEXT)}};
 
         uint32_t chain_info_len = ARRAY_SIZE(chain_info);
 
@@ -1095,7 +1097,9 @@ static void AppGpuInit(struct AppGpu *gpu, struct AppInstance *inst, uint32_t id
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR,
              .mem_size = sizeof(VkPhysicalDeviceFloat16Int8FeaturesKHR)},
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR,
-             .mem_size = sizeof(VkPhysicalDeviceShaderAtomicInt64FeaturesKHR)}};
+             .mem_size = sizeof(VkPhysicalDeviceShaderAtomicInt64FeaturesKHR)},
+            {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT,
+             .mem_size = sizeof(VkPhysicalDeviceTransformFeedbackFeaturesEXT)}};
 
         uint32_t chain_info_len = ARRAY_SIZE(chain_info);
 
@@ -2337,6 +2341,19 @@ static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
                     printf("\tshaderBufferInt64Atomics = %" PRIuLEAST32 "\n", shader_atomic_int64_features->shaderBufferInt64Atomics);
                     printf("\tshaderSharedInt64Atomics = %" PRIuLEAST32 "\n", shader_atomic_int64_features->shaderSharedInt64Atomics);
                 }
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
+                VkPhysicalDeviceTransformFeedbackFeaturesEXT *transform_feedback_features = (VkPhysicalDeviceTransformFeedbackFeaturesEXT*)structure;
+                if (html_output) {
+                    fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceTransformFeedbackFeatures</summary>\n");
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>transformFeedback = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_features->transformFeedback);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>geometryStreams   = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_features->geometryStreams);
+                }
+                else if (human_readable_output) {
+                    printf("\nVkPhysicalDeviceTransformFeedbackFeatures:\n");
+                    printf("==========================================\n");
+                    printf("\ttransformFeedback = %" PRIuLEAST32 "\n", transform_feedback_features->transformFeedback);
+                    printf("\tgeometryStreams   = %" PRIuLEAST32 "\n", transform_feedback_features->geometryStreams);
+                }
             }
             place = structure->pNext;
         }
@@ -3093,6 +3110,34 @@ static void AppGpuDumpProps(const struct AppGpu *gpu, FILE *out) {
                     printf("\tpciBus      = %" PRIuLEAST32 "\n", pci_bus_properties->pciBus);
                     printf("\tpciDevice   = %" PRIuLEAST32 "\n", pci_bus_properties->pciDevice);
                     printf("\tpciFunction = %" PRIuLEAST32 "\n", pci_bus_properties->pciFunction);
+                }
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
+                VkPhysicalDeviceTransformFeedbackPropertiesEXT *transform_feedback_properties = (VkPhysicalDeviceTransformFeedbackPropertiesEXT*)structure;
+                if (html_output) {
+                    fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceTransformFeedbackProperties</summary>\n");
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackStreams                = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackStreams);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBuffers                = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackBuffers);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBufferSize             = <div class='val'>%" PRIuLEAST64 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackBufferSize);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackStreamDataSize         = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackStreamDataSize);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBufferDataSize         = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackBufferDataSize);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBufferDataStride       = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackBufferDataStride);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>transformFeedbackQueries                   = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->transformFeedbackQueries);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>transformFeedbackStreamsLinesTriangles     = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->transformFeedbackStreamsLinesTriangles);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>transformFeedbackRasterizationStreamSelect = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->transformFeedbackRasterizationStreamSelect);
+                    fprintf(out, "\t\t\t\t\t\t<details><summary>transformFeedbackDraw                      = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->transformFeedbackDraw);
+                } else if (human_readable_output) {
+                    printf("\nVkPhysicalDeviceTransformFeedbackProperties\n");
+                    printf("===========================================\n");
+                    printf("\tmaxTransformFeedbackStreams                = %" PRIuLEAST32 "\n", transform_feedback_properties->maxTransformFeedbackStreams);
+                    printf("\tmaxTransformFeedbackBuffers                = %" PRIuLEAST32 "\n", transform_feedback_properties->maxTransformFeedbackBuffers);
+                    printf("\tmaxTransformFeedbackBufferSize             = %" PRIuLEAST64 "\n", transform_feedback_properties->maxTransformFeedbackBufferSize);
+                    printf("\tmaxTransformFeedbackStreamDataSize         = %" PRIuLEAST32 "\n", transform_feedback_properties->maxTransformFeedbackStreamDataSize);
+                    printf("\tmaxTransformFeedbackBufferDataSize         = %" PRIuLEAST32 "\n", transform_feedback_properties->maxTransformFeedbackBufferDataSize);
+                    printf("\tmaxTransformFeedbackBufferDataStride       = %" PRIuLEAST32 "\n", transform_feedback_properties->maxTransformFeedbackBufferDataStride);
+                    printf("\ttransformFeedbackQueries                   = %" PRIuLEAST32 "\n", transform_feedback_properties->transformFeedbackQueries);
+                    printf("\ttransformFeedbackStreamsLinesTriangles     = %" PRIuLEAST32 "\n", transform_feedback_properties->transformFeedbackStreamsLinesTriangles);
+                    printf("\ttransformFeedbackRasterizationStreamSelect = %" PRIuLEAST32 "\n", transform_feedback_properties->transformFeedbackRasterizationStreamSelect);
+                    printf("\ttransformFeedbackDraw                      = %" PRIuLEAST32 "\n", transform_feedback_properties->transformFeedbackDraw);
                 }
             }
             place = structure->pNext;


### PR DESCRIPTION
Added the following extensions and structures
to the Vulkan Info output:

    VK_KHR_shader_atomic_int64:
        VkPhysicalDeviceShaderAtomicInt64FeaturesKHR

    VK_EXT_transform_feedback:
        VkPhysicalDeviceTransformFeedbackFeaturesEXT
        VkPhysicalDeviceTransformFeedbackPropertiesEXT

    VK_EXT_scalar_block_layout:
        VkPhysicalDeviceScalarBlockLayoutFeaturesEXT

    VK_EXT_fragment_density_map:
        VkPhysicalDeviceFragmentDensityMapFeaturesEXT
        VkPhysicalDeviceFragmentDensityMapPropertiesEXT