### PR TITLE
issue 126: fix vulkaninfo segfault on 1.0 devices

### DIFF
--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -1982,8 +1982,10 @@ static struct FormatRange {
 
 // Helper function to determine whether a format range is currently supported.
 bool FormatRangeSupported(const struct FormatRange *format_range, const struct AppGpu *gpu) {
-    // True if standard and supported by this instance
-    if (format_range->minimum_instance_version > 0 && gpu->inst->instance_version >= format_range->minimum_instance_version) {
+    // True if standard and supported by both this instance and this GPU
+    if (format_range->minimum_instance_version > 0 &&
+        gpu->inst->instance_version >= format_range->minimum_instance_version &&
+        gpu->props.apiVersion >= format_range->minimum_instance_version) {
         return true;
     }
 


### PR DESCRIPTION
We didn't quite get the check on whether a format can be legally
queried on a particular GPU quite right.  We were checking against
the instance version only.  We need to check agains the driver's
supported API version as well.