### PR TITLE
vulkaninfo: Remove clang-format off

### DIFF
--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -1134,17 +1134,13 @@ static void AppGpuDestroy(struct AppGpu *gpu) {
     }
 }
 
-// clang-format off
-
 //-----------------------------------------------------------
 
 //---------------------------Win32---------------------------
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 
 // MS-Windows event handling function:
-LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
-    return (DefWindowProc(hWnd, uMsg, wParam, lParam));
-}
+LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) { return (DefWindowProc(hWnd, uMsg, wParam, lParam)); }
 
 static void AppCreateWin32Window(struct AppInstance *inst) {
     inst->h_instance = GetModuleHandle(NULL);
@@ -1172,20 +1168,20 @@ static void AppCreateWin32Window(struct AppInstance *inst) {
         exit(1);
     }
     // Create window with the registered class:
-    RECT wr = { 0, 0, inst->width, inst->height };
+    RECT wr = {0, 0, inst->width, inst->height};
     AdjustWindowRect(&wr, WS_OVERLAPPEDWINDOW, FALSE);
     inst->h_wnd = CreateWindowEx(0,
-        APP_SHORT_NAME,       // class name
-        APP_SHORT_NAME,       // app name
-        //WS_VISIBLE | WS_SYSMENU |
-        WS_OVERLAPPEDWINDOW,  // window style
-        100, 100,             // x/y coords
-        wr.right - wr.left,   // width
-        wr.bottom - wr.top,   // height
-        NULL,                 // handle to parent
-        NULL,                 // handle to menu
-        inst->h_instance,      // hInstance
-        NULL);                // no extra parameters
+                                 APP_SHORT_NAME,  // class name
+                                 APP_SHORT_NAME,  // app name
+                                 // WS_VISIBLE | WS_SYSMENU |
+                                 WS_OVERLAPPEDWINDOW,  // window style
+                                 100, 100,             // x/y coords
+                                 wr.right - wr.left,   // width
+                                 wr.bottom - wr.top,   // height
+                                 NULL,                 // handle to parent
+                                 NULL,                 // handle to menu
+                                 inst->h_instance,     // hInstance
+                                 NULL);                // no extra parameters
     if (!inst->h_wnd) {
         // It didn't work, so try to give a useful error:
         fprintf(stderr, "Failed to create a window!\n");
@@ -1205,18 +1201,13 @@ static void AppCreateWin32Surface(struct AppInstance *inst) {
     inst->surface_info2.surface = inst->surface;
 }
 
-static void AppDestroyWin32Window(struct AppInstance *inst) {
-    DestroyWindow(inst->h_wnd);
-}
-#endif //VK_USE_PLATFORM_WIN32_KHR
+static void AppDestroyWin32Window(struct AppInstance *inst) { DestroyWindow(inst->h_wnd); }
+#endif  // VK_USE_PLATFORM_WIN32_KHR
 //-----------------------------------------------------------
 
-#if defined(VK_USE_PLATFORM_XCB_KHR)     || \
-    defined(VK_USE_PLATFORM_XLIB_KHR)    || \
-    defined(VK_USE_PLATFORM_WIN32_KHR)   || \
-    defined(VK_USE_PLATFORM_MACOS_MVK)   || \
-    defined(VK_USE_PLATFORM_WAYLAND_KHR)
-static void AppDestroySurface(struct AppInstance *inst) { //same for all platforms
+#if defined(VK_USE_PLATFORM_XCB_KHR) || defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_WIN32_KHR) || \
+    defined(VK_USE_PLATFORM_MACOS_MVK) || defined(VK_USE_PLATFORM_WAYLAND_KHR)
+static void AppDestroySurface(struct AppInstance *inst) {  // same for all platforms
     vkDestroySurfaceKHR(inst->instance, inst->surface, NULL);
 }
 #endif
@@ -1249,13 +1240,11 @@ static void AppCreateXcbWindow(struct AppInstance *inst) {
     //-------------------
 
     inst->xcb_window = xcb_generate_id(inst->xcb_connection);
-    xcb_create_window(inst->xcb_connection, XCB_COPY_FROM_PARENT, inst->xcb_window,
-                      inst->xcb_screen->root, 0, 0, inst->width, inst->height, 0,
-                      XCB_WINDOW_CLASS_INPUT_OUTPUT, inst->xcb_screen->root_visual,
-                      0, NULL);
+    xcb_create_window(inst->xcb_connection, XCB_COPY_FROM_PARENT, inst->xcb_window, inst->xcb_screen->root, 0, 0, inst->width,
+                      inst->height, 0, XCB_WINDOW_CLASS_INPUT_OUTPUT, inst->xcb_screen->root_visual, 0, NULL);
 
     xcb_intern_atom_cookie_t cookie = xcb_intern_atom(inst->xcb_connection, 1, 12, "WM_PROTOCOLS");
-    xcb_intern_atom_reply_t *reply =  xcb_intern_atom_reply(inst->xcb_connection, cookie, 0);
+    xcb_intern_atom_reply_t *reply = xcb_intern_atom_reply(inst->xcb_connection, cookie, 0);
     free(reply);
 }
 
@@ -1265,11 +1254,11 @@ static void AppCreateXcbSurface(struct AppInstance *inst) {
     }
 
     VkXcbSurfaceCreateInfoKHR xcb_createInfo;
-    xcb_createInfo.sType      = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
-    xcb_createInfo.pNext      = NULL;
-    xcb_createInfo.flags      = 0;
+    xcb_createInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
+    xcb_createInfo.pNext = NULL;
+    xcb_createInfo.flags = 0;
     xcb_createInfo.connection = inst->xcb_connection;
-    xcb_createInfo.window     = inst->xcb_window;
+    xcb_createInfo.window = inst->xcb_window;
     VkResult err = vkCreateXcbSurfaceKHR(inst->instance, &xcb_createInfo, NULL, &inst->surface);
     if (err) ERR_EXIT(err);
     inst->surface_info2.surface = inst->surface;
@@ -1277,13 +1266,13 @@ static void AppCreateXcbSurface(struct AppInstance *inst) {
 
 static void AppDestroyXcbWindow(struct AppInstance *inst) {
     if (!inst->xcb_connection) {
-        return; // Nothing to destroy
+        return;  // Nothing to destroy
     }
 
     xcb_destroy_window(inst->xcb_connection, inst->xcb_window);
     xcb_disconnect(inst->xcb_connection);
 }
-#endif //VK_USE_PLATFORM_XCB_KHR
+#endif  // VK_USE_PLATFORM_XCB_KHR
 //-----------------------------------------------------------
 
 //----------------------------XLib---------------------------
@@ -1298,25 +1287,22 @@ static void AppCreateXlibWindow(struct AppInstance *inst) {
         exit(1);
     }
 
-    XVisualInfo vInfoTemplate={};
+    XVisualInfo vInfoTemplate = {};
     vInfoTemplate.screen = DefaultScreen(inst->xlib_display);
-    XVisualInfo *visualInfo = XGetVisualInfo(inst->xlib_display, visualMask,
-                                             &vInfoTemplate, &numberOfVisuals);
-    inst->xlib_window = XCreateWindow(
-                inst->xlib_display, RootWindow(inst->xlib_display, vInfoTemplate.screen), 0, 0,
-                inst->width, inst->height, 0, visualInfo->depth, InputOutput,
-                visualInfo->visual, 0, NULL);
+    XVisualInfo *visualInfo = XGetVisualInfo(inst->xlib_display, visualMask, &vInfoTemplate, &numberOfVisuals);
+    inst->xlib_window = XCreateWindow(inst->xlib_display, RootWindow(inst->xlib_display, vInfoTemplate.screen), 0, 0, inst->width,
+                                      inst->height, 0, visualInfo->depth, InputOutput, visualInfo->visual, 0, NULL);
 
-    XSync(inst->xlib_display,false);
+    XSync(inst->xlib_display, false);
     XFree(visualInfo);
 }
 
 static void AppCreateXlibSurface(struct AppInstance *inst) {
     VkXlibSurfaceCreateInfoKHR createInfo;
-    createInfo.sType  = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
-    createInfo.pNext  = NULL;
-    createInfo.flags  = 0;
-    createInfo.dpy    = inst->xlib_display;
+    createInfo.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = NULL;
+    createInfo.flags = 0;
+    createInfo.dpy = inst->xlib_display;
     createInfo.window = inst->xlib_window;
     VkResult err = vkCreateXlibSurfaceKHR(inst->instance, &createInfo, NULL, &inst->surface);
     if (err) ERR_EXIT(err);
@@ -1327,7 +1313,7 @@ static void AppDestroyXlibWindow(struct AppInstance *inst) {
     XDestroyWindow(inst->xlib_display, inst->xlib_window);
     XCloseDisplay(inst->xlib_display);
 }
-#endif //VK_USE_PLATFORM_XLIB_KHR
+#endif  // VK_USE_PLATFORM_XLIB_KHR
 //-----------------------------------------------------------
 
 #ifdef VK_USE_PLATFORM_MACOS_MVK
@@ -1352,27 +1338,22 @@ static void AppCreateMacOSSurface(struct AppInstance *inst) {
     inst->surface_info2.surface = inst->surface;
 }
 
-static void AppDestroyMacOSWindow(struct AppInstance *inst) {
-    DestroyMetalView(inst->window);
-}
-#endif //VK_USE_PLATFORM_MACOS_MVK
+static void AppDestroyMacOSWindow(struct AppInstance *inst) { DestroyMetalView(inst->window); }
+#endif  // VK_USE_PLATFORM_MACOS_MVK
 //-----------------------------------------------------------
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
 
-static void wayland_registry_global(void *data, struct wl_registry *registry, uint32_t id, const char *interface, uint32_t version) {
+static void wayland_registry_global(void *data, struct wl_registry *registry, uint32_t id, const char *interface,
+                                    uint32_t version) {
     struct AppInstance *inst = (struct AppInstance *)data;
     if (strcmp(interface, "wl_compositor") == 0) {
         struct wl_compositor *compositor = (struct wl_compositor *)wl_registry_bind(registry, id, &wl_compositor_interface, 1);
         inst->wayland_surface = wl_compositor_create_surface(compositor);
     }
 }
-static void wayland_registry_global_remove(void *data, struct wl_registry *registry, uint32_t id) {
-}
-static const struct wl_registry_listener wayland_registry_listener = {
-    wayland_registry_global,
-    wayland_registry_global_remove
-};
+static void wayland_registry_global_remove(void *data, struct wl_registry *registry, uint32_t id) {}
+static const struct wl_registry_listener wayland_registry_listener = {wayland_registry_global, wayland_registry_global_remove};
 
 static void AppCreateWaylandWindow(struct AppInstance *inst) {
     inst->wayland_display = wl_display_connect(NULL);
@@ -1384,9 +1365,9 @@ static void AppCreateWaylandWindow(struct AppInstance *inst) {
 
 static void AppCreateWaylandSurface(struct AppInstance *inst) {
     VkWaylandSurfaceCreateInfoKHR createInfo;
-    createInfo.sType   = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
-    createInfo.pNext   = NULL;
-    createInfo.flags   = 0;
+    createInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = NULL;
+    createInfo.flags = 0;
     createInfo.display = inst->wayland_display;
     createInfo.surface = inst->wayland_surface;
     VkResult err = vkCreateWaylandSurfaceKHR(inst->instance, &createInfo, NULL, &inst->surface);
@@ -1394,16 +1375,11 @@ static void AppCreateWaylandSurface(struct AppInstance *inst) {
     inst->surface_info2.surface = inst->surface;
 }
 
-static void AppDestroyWaylandWindow(struct AppInstance *inst) {
-    wl_display_disconnect(inst->wayland_display);
-}
-#endif //VK_USE_PLATFORM_WAYLAND_KHR
+static void AppDestroyWaylandWindow(struct AppInstance *inst) { wl_display_disconnect(inst->wayland_display); }
+#endif  // VK_USE_PLATFORM_WAYLAND_KHR
 
-#if defined(VK_USE_PLATFORM_XCB_KHR)     || \
-    defined(VK_USE_PLATFORM_XLIB_KHR)    || \
-    defined(VK_USE_PLATFORM_WIN32_KHR)   || \
-    defined(VK_USE_PLATFORM_MACOS_MVK)   || \
-    defined(VK_USE_PLATFORM_WAYLAND_KHR)
+#if defined(VK_USE_PLATFORM_XCB_KHR) || defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_WIN32_KHR) || \
+    defined(VK_USE_PLATFORM_MACOS_MVK) || defined(VK_USE_PLATFORM_WAYLAND_KHR)
 static int AppDumpSurfaceFormats(struct AppInstance *inst, struct AppGpu *gpu, FILE *out) {
     // Get the list of VkFormat's that are supported
     VkResult err;
@@ -1412,12 +1388,11 @@ static int AppDumpSurfaceFormats(struct AppInstance *inst, struct AppGpu *gpu, F
     VkSurfaceFormat2KHR *surf_formats2 = NULL;
 
     if (CheckExtensionEnabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
-        gpu->inst->inst_extensions_count)) {
+                              gpu->inst->inst_extensions_count)) {
         err = inst->vkGetPhysicalDeviceSurfaceFormats2KHR(gpu->obj, &inst->surface_info2, &format_count, NULL);
         if (err) ERR_EXIT(err);
         surf_formats2 = (VkSurfaceFormat2KHR *)malloc(format_count * sizeof(VkSurfaceFormat2KHR));
-        if (!surf_formats2)
-            ERR_EXIT(VK_ERROR_OUT_OF_HOST_MEMORY);
+        if (!surf_formats2) ERR_EXIT(VK_ERROR_OUT_OF_HOST_MEMORY);
         for (uint32_t i = 0; i < format_count; ++i) {
             surf_formats2[i].sType = VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR;
             surf_formats2[i].pNext = NULL;
@@ -1428,8 +1403,7 @@ static int AppDumpSurfaceFormats(struct AppInstance *inst, struct AppGpu *gpu, F
         err = inst->vkGetPhysicalDeviceSurfaceFormatsKHR(gpu->obj, inst->surface, &format_count, NULL);
         if (err) ERR_EXIT(err);
         surf_formats = (VkSurfaceFormatKHR *)malloc(format_count * sizeof(VkSurfaceFormatKHR));
-        if (!surf_formats)
-            ERR_EXIT(VK_ERROR_OUT_OF_HOST_MEMORY);
+        if (!surf_formats) ERR_EXIT(VK_ERROR_OUT_OF_HOST_MEMORY);
         err = inst->vkGetPhysicalDeviceSurfaceFormatsKHR(gpu->obj, inst->surface, &format_count, surf_formats);
         if (err) ERR_EXIT(err);
     }
@@ -1447,16 +1421,16 @@ static int AppDumpSurfaceFormats(struct AppInstance *inst, struct AppGpu *gpu, F
     for (uint32_t i = 0; i < format_count; ++i) {
         if (html_output) {
             if (CheckExtensionEnabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
-                gpu->inst->inst_extensions_count)) {
+                                      gpu->inst->inst_extensions_count)) {
                 fprintf(out, "\t\t\t\t\t\t<details><summary><div class='type'>%s</div></summary></details>\n",
-                    VkFormatString(surf_formats2[i].surfaceFormat.format));
+                        VkFormatString(surf_formats2[i].surfaceFormat.format));
             } else {
                 fprintf(out, "\t\t\t\t\t\t<details><summary><div class='type'>%s</div></summary></details>\n",
-                    VkFormatString(surf_formats[i].format));
+                        VkFormatString(surf_formats[i].format));
             }
         } else if (human_readable_output) {
             if (CheckExtensionEnabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
-                gpu->inst->inst_extensions_count)) {
+                                      gpu->inst->inst_extensions_count)) {
                 printf("\t%s\n", VkFormatString(surf_formats2[i].surfaceFormat.format));
             } else {
                 printf("\t%s\n", VkFormatString(surf_formats[i].format));
@@ -1470,7 +1444,7 @@ static int AppDumpSurfaceFormats(struct AppInstance *inst, struct AppGpu *gpu, F
     fflush(out);
     fflush(stdout);
     if (CheckExtensionEnabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
-        gpu->inst->inst_extensions_count)) {
+                              gpu->inst->inst_extensions_count)) {
         free(surf_formats2);
     } else {
         free(surf_formats);
@@ -1487,8 +1461,7 @@ static int AppDumpSurfacePresentModes(struct AppInstance *inst, struct AppGpu *g
     if (err) ERR_EXIT(err);
 
     VkPresentModeKHR *surf_present_modes = (VkPresentModeKHR *)malloc(present_mode_count * sizeof(VkPresentInfoKHR));
-    if (!surf_present_modes)
-        ERR_EXIT(VK_ERROR_OUT_OF_HOST_MEMORY);
+    if (!surf_present_modes) ERR_EXIT(VK_ERROR_OUT_OF_HOST_MEMORY);
     err = inst->vkGetPhysicalDeviceSurfacePresentModesKHR(gpu->obj, inst->surface, &present_mode_count, surf_present_modes);
     if (err) ERR_EXIT(err);
 
@@ -1529,51 +1502,78 @@ static void AppDumpSurfaceCapabilities(struct AppInstance *inst, struct AppGpu *
 
         if (html_output) {
             fprintf(out, "\t\t\t\t\t<details><summary>VkSurfaceCapabilitiesKHR</summary>\n");
-            fprintf(out, "\t\t\t\t\t\t<details><summary>minImageCount = <div class='val'>%u</div></summary></details>\n", inst->surface_capabilities.minImageCount);
-            fprintf(out, "\t\t\t\t\t\t<details><summary>maxImageCount = <div class='val'>%u</div></summary></details>\n", inst->surface_capabilities.maxImageCount);
+            fprintf(out, "\t\t\t\t\t\t<details><summary>minImageCount = <div class='val'>%u</div></summary></details>\n",
+                    inst->surface_capabilities.minImageCount);
+            fprintf(out, "\t\t\t\t\t\t<details><summary>maxImageCount = <div class='val'>%u</div></summary></details>\n",
+                    inst->surface_capabilities.maxImageCount);
             fprintf(out, "\t\t\t\t\t\t<details><summary>currentExtent</summary>\n");
-            fprintf(out, "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%u</div></summary></details>\n", inst->surface_capabilities.currentExtent.width);
-            fprintf(out, "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%u</div></summary></details>\n", inst->surface_capabilities.currentExtent.height);
+            fprintf(out, "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%u</div></summary></details>\n",
+                    inst->surface_capabilities.currentExtent.width);
+            fprintf(out, "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%u</div></summary></details>\n",
+                    inst->surface_capabilities.currentExtent.height);
             fprintf(out, "\t\t\t\t\t\t</details>\n");
             fprintf(out, "\t\t\t\t\t\t<details><summary>minImageExtent</summary>\n");
-            fprintf(out, "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%u</div></summary></details>\n", inst->surface_capabilities.minImageExtent.width);
-            fprintf(out, "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%u</div></summary></details>\n", inst->surface_capabilities.minImageExtent.height);
+            fprintf(out, "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%u</div></summary></details>\n",
+                    inst->surface_capabilities.minImageExtent.width);
+            fprintf(out, "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%u</div></summary></details>\n",
+                    inst->surface_capabilities.minImageExtent.height);
             fprintf(out, "\t\t\t\t\t\t</details>\n");
             fprintf(out, "\t\t\t\t\t\t<details><summary>maxImageExtent</summary>\n");
-            fprintf(out, "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%u</div></summary></details>\n", inst->surface_capabilities.maxImageExtent.width);
-            fprintf(out, "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%u</div></summary></details>\n", inst->surface_capabilities.maxImageExtent.height);
+            fprintf(out, "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%u</div></summary></details>\n",
+                    inst->surface_capabilities.maxImageExtent.width);
+            fprintf(out, "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%u</div></summary></details>\n",
+                    inst->surface_capabilities.maxImageExtent.height);
             fprintf(out, "\t\t\t\t\t\t</details>\n");
-            fprintf(out, "\t\t\t\t\t\t<details><summary>maxImageArrayLayers = <div class='val'>%u</div></summary></details>\n", inst->surface_capabilities.maxImageArrayLayers);
+            fprintf(out, "\t\t\t\t\t\t<details><summary>maxImageArrayLayers = <div class='val'>%u</div></summary></details>\n",
+                    inst->surface_capabilities.maxImageArrayLayers);
             fprintf(out, "\t\t\t\t\t\t<details><summary>supportedTransform</summary>\n");
             if (inst->surface_capabilities.supportedTransforms == 0) {
                 fprintf(out, "\t\t\t\t\t\t\t<details><summary>None</summary></details>\n");
             }
             if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR</div></summary></details>\n");
             }
             fprintf(out, "\t\t\t\t\t\t</details>\n");
             fprintf(out, "\t\t\t\t\t\t<details><summary>currentTransform</summary>\n");
@@ -1581,23 +1581,41 @@ static void AppDumpSurfaceCapabilities(struct AppInstance *inst, struct AppGpu *
                 fprintf(out, "\t\t\t\t\t\t\t<details><summary>None</summary></details>\n");
             }
             if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR</div></summary></details>\n");
             } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR</div></summary></details>\n");
             } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR</div></summary></details>\n");
             } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR</div></summary></details>\n");
             } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR</div></summary></details>\n");
             } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR</div></summary></details>\n");
             } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR</div></summary></details>\n");
             } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR</div></summary></details>\n");
             } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR</div></summary></details>\n");
             }
             fprintf(out, "\t\t\t\t\t\t</details>\n");
             fprintf(out, "\t\t\t\t\t\t<details><summary>supportedCompositeAlpha</summary>\n");
@@ -1605,16 +1623,24 @@ static void AppDumpSurfaceCapabilities(struct AppInstance *inst, struct AppGpu *
                 fprintf(out, "\t\t\t\t\t\t\t<details><summary>None</summary></details>\n");
             }
             if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR</div></summary></details>\n");
             }
             fprintf(out, "\t\t\t\t\t\t</details>\n");
             fprintf(out, "\t\t\t\t\t\t<details><summary>supportedUsageFlags</summary>\n");
@@ -1622,28 +1648,42 @@ static void AppDumpSurfaceCapabilities(struct AppInstance *inst, struct AppGpu *
                 fprintf(out, "\t\t\t\t\t\t\t<details><summary>None</summary></details>\n");
             }
             if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_TRANSFER_SRC_BIT</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_IMAGE_USAGE_TRANSFER_SRC_BIT</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_TRANSFER_DST_BIT</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_IMAGE_USAGE_TRANSFER_DST_BIT</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_SAMPLED_BIT) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_SAMPLED_BIT</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_SAMPLED_BIT</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_STORAGE_BIT) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_STORAGE_BIT</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_STORAGE_BIT</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT</div></summary></details>\n");
             }
             if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) {
-                fprintf(out, "\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT</div></summary></details>\n");
+                fprintf(out,
+                        "\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT</div></summary></details>\n");
             }
             fprintf(out, "\t\t\t\t\t\t</details>\n");
         } else if (human_readable_output) {
@@ -1661,47 +1701,108 @@ static void AppDumpSurfaceCapabilities(struct AppInstance *inst, struct AppGpu *
             printf("\t\theight      = %u\n", inst->surface_capabilities.maxImageExtent.height);
             printf("\tmaxImageArrayLayers = %u\n", inst->surface_capabilities.maxImageArrayLayers);
             printf("\tsupportedTransform:\n");
-            if (inst->surface_capabilities.supportedTransforms == 0) { printf("\t\tNone\n"); }
-            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR\n"); }
-            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR\n"); }
-            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR\n"); }
-            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR\n"); }
-            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR\n"); }
-            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR\n"); }
-            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR\n"); }
-            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR\n"); }
-            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_INHERIT_BIT_KHR\n"); }
+            if (inst->surface_capabilities.supportedTransforms == 0) {
+                printf("\t\tNone\n");
+            }
+            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR\n");
+            }
+            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR\n");
+            }
+            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR\n");
+            }
+            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR\n");
+            }
+            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR\n");
+            }
+            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR\n");
+            }
+            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR\n");
+            }
+            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR\n");
+            }
+            if (inst->surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_INHERIT_BIT_KHR\n");
+            }
             printf("\tcurrentTransform:\n");
-            if (inst->surface_capabilities.currentTransform == 0) { printf("\t\tNone\n"); }
-            if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR\n"); }
-            else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR\n"); }
-            else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR\n"); }
-            else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR\n"); }
-            else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR\n"); }
-            else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR\n"); }
-            else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR\n"); }
-            else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR\n"); }
-            else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR) { printf("\t\tVK_SURFACE_TRANSFORM_INHERIT_BIT_KHR\n"); }
+            if (inst->surface_capabilities.currentTransform == 0) {
+                printf("\t\tNone\n");
+            }
+            if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR\n");
+            } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR\n");
+            } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR\n");
+            } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR\n");
+            } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR\n");
+            } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR\n");
+            } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR\n");
+            } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR\n");
+            } else if (inst->surface_capabilities.currentTransform & VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR) {
+                printf("\t\tVK_SURFACE_TRANSFORM_INHERIT_BIT_KHR\n");
+            }
             printf("\tsupportedCompositeAlpha:\n");
-            if (inst->surface_capabilities.supportedCompositeAlpha == 0) { printf("\t\tNone\n"); }
-            if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR) { printf("\t\tVK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR\n"); }
-            if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR) { printf("\t\tVK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR\n"); }
-            if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR) { printf("\t\tVK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR\n"); }
-            if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) { printf("\t\tVK_COMPOSITE_ALPHA_INHERIT_BIT_KHR\n"); }
+            if (inst->surface_capabilities.supportedCompositeAlpha == 0) {
+                printf("\t\tNone\n");
+            }
+            if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR) {
+                printf("\t\tVK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR\n");
+            }
+            if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR) {
+                printf("\t\tVK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR\n");
+            }
+            if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR) {
+                printf("\t\tVK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR\n");
+            }
+            if (inst->surface_capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) {
+                printf("\t\tVK_COMPOSITE_ALPHA_INHERIT_BIT_KHR\n");
+            }
             printf("\tsupportedUsageFlags:\n");
-            if (inst->surface_capabilities.supportedUsageFlags == 0) { printf("\t\tNone\n"); }
-            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) { printf("\t\tVK_IMAGE_USAGE_TRANSFER_SRC_BIT\n"); }
-            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT) { printf("\t\tVK_IMAGE_USAGE_TRANSFER_DST_BIT\n"); }
-            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_SAMPLED_BIT) { printf("\t\tVK_IMAGE_USAGE_SAMPLED_BIT\n"); }
-            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_STORAGE_BIT) { printf("\t\tVK_IMAGE_USAGE_STORAGE_BIT\n"); }
-            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) { printf("\t\tVK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT\n"); }
-            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) { printf("\t\tVK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT\n"); }
-            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) { printf("\t\tVK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT\n"); }
-            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) { printf("\t\tVK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT\n"); }
+            if (inst->surface_capabilities.supportedUsageFlags == 0) {
+                printf("\t\tNone\n");
+            }
+            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) {
+                printf("\t\tVK_IMAGE_USAGE_TRANSFER_SRC_BIT\n");
+            }
+            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT) {
+                printf("\t\tVK_IMAGE_USAGE_TRANSFER_DST_BIT\n");
+            }
+            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_SAMPLED_BIT) {
+                printf("\t\tVK_IMAGE_USAGE_SAMPLED_BIT\n");
+            }
+            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_STORAGE_BIT) {
+                printf("\t\tVK_IMAGE_USAGE_STORAGE_BIT\n");
+            }
+            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) {
+                printf("\t\tVK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT\n");
+            }
+            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+                printf("\t\tVK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT\n");
+            }
+            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) {
+                printf("\t\tVK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT\n");
+            }
+            if (inst->surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) {
+                printf("\t\tVK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT\n");
+            }
         }
 
         // Get additional surface capability information from vkGetPhysicalDeviceSurfaceCapabilities2EXT
-        if (CheckExtensionEnabled(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME, gpu->inst->inst_extensions, gpu->inst->inst_extensions_count)) {
+        if (CheckExtensionEnabled(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME, gpu->inst->inst_extensions,
+                                  gpu->inst->inst_extensions_count)) {
             memset(&inst->surface_capabilities2_ext, 0, sizeof(VkSurfaceCapabilities2EXT));
             inst->surface_capabilities2_ext.sType = VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT;
             inst->surface_capabilities2_ext.pNext = NULL;
@@ -1716,7 +1817,9 @@ static void AppDumpSurfaceCapabilities(struct AppInstance *inst, struct AppGpu *
                     fprintf(out, "\t\t\t\t\t\t\t\t<details><summary>None</summary></details>\n");
                 }
                 if (inst->surface_capabilities2_ext.supportedSurfaceCounters & VK_SURFACE_COUNTER_VBLANK_EXT) {
-                    fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_SURFACE_COUNTER_VBLANK_EXT</div></summary></details>\n");
+                    fprintf(out,
+                            "\t\t\t\t\t\t\t\t<details><summary><div "
+                            "class='type'>VK_SURFACE_COUNTER_VBLANK_EXT</div></summary></details>\n");
                 }
                 fprintf(out, "\t\t\t\t\t\t\t</details>\n");
                 fprintf(out, "\t\t\t\t\t\t</details>\n");
@@ -1733,8 +1836,10 @@ static void AppDumpSurfaceCapabilities(struct AppInstance *inst, struct AppGpu *
         }
 
         // Get additional surface capability information from vkGetPhysicalDeviceSurfaceCapabilities2KHR
-        if (CheckExtensionEnabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, gpu->inst->inst_extensions, gpu->inst->inst_extensions_count)) {
-            if (CheckExtensionEnabled(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME, gpu->inst->inst_extensions, gpu->inst->inst_extensions_count)) {
+        if (CheckExtensionEnabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
+                                  gpu->inst->inst_extensions_count)) {
+            if (CheckExtensionEnabled(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME, gpu->inst->inst_extensions,
+                                      gpu->inst->inst_extensions_count)) {
                 inst->shared_surface_capabilities.sType = VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR;
                 inst->shared_surface_capabilities.pNext = NULL;
                 inst->surface_capabilities2.pNext = &inst->shared_surface_capabilities;
@@ -1754,9 +1859,10 @@ static void AppDumpSurfaceCapabilities(struct AppInstance *inst, struct AppGpu *
 
             void *place = inst->surface_capabilities2.pNext;
             while (place) {
-                struct VkStructureHeader* work = (struct VkStructureHeader*) place;
+                struct VkStructureHeader *work = (struct VkStructureHeader *)place;
                 if (work->sType == VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR) {
-                    VkSharedPresentSurfaceCapabilitiesKHR* shared_surface_capabilities = (VkSharedPresentSurfaceCapabilitiesKHR*)place;
+                    VkSharedPresentSurfaceCapabilitiesKHR *shared_surface_capabilities =
+                        (VkSharedPresentSurfaceCapabilitiesKHR *)place;
                     if (html_output) {
                         fprintf(out, "\t\t\t\t\t\t<details><summary>VkSharedPresentSurfaceCapabilitiesKHR</summary>\n");
                         fprintf(out, "\t\t\t\t\t\t\t<details><summary>sharedPresentSupportedUsageFlags</summary>\n");
@@ -1764,43 +1870,81 @@ static void AppDumpSurfaceCapabilities(struct AppInstance *inst, struct AppGpu *
                             fprintf(out, "\t\t\t\t\t\t\t\t<details><summary>None</summary></details>\n");
                         }
                         if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) {
-                            fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_TRANSFER_SRC_BIT</div></summary></details>\n");
+                            fprintf(out,
+                                    "\t\t\t\t\t\t\t\t<details><summary><div "
+                                    "class='type'>VK_IMAGE_USAGE_TRANSFER_SRC_BIT</div></summary></details>\n");
                         }
                         if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT) {
-                            fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_TRANSFER_DST_BIT</div></summary></details>\n");
+                            fprintf(out,
+                                    "\t\t\t\t\t\t\t\t<details><summary><div "
+                                    "class='type'>VK_IMAGE_USAGE_TRANSFER_DST_BIT</div></summary></details>\n");
                         }
                         if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_SAMPLED_BIT) {
-                            fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_SAMPLED_BIT</div></summary></details>\n");
+                            fprintf(out,
+                                    "\t\t\t\t\t\t\t\t<details><summary><div "
+                                    "class='type'>VK_IMAGE_USAGE_SAMPLED_BIT</div></summary></details>\n");
                         }
                         if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_STORAGE_BIT) {
-                            fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_STORAGE_BIT</div></summary></details>\n");
+                            fprintf(out,
+                                    "\t\t\t\t\t\t\t\t<details><summary><div "
+                                    "class='type'>VK_IMAGE_USAGE_STORAGE_BIT</div></summary></details>\n");
                         }
                         if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) {
-                            fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT</div></summary></details>\n");
+                            fprintf(out,
+                                    "\t\t\t\t\t\t\t\t<details><summary><div "
+                                    "class='type'>VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT</div></summary></details>\n");
                         }
-                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
-                            fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT</div></summary></details>\n");
+                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags &
+                            VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+                            fprintf(out,
+                                    "\t\t\t\t\t\t\t\t<details><summary><div "
+                                    "class='type'>VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT</div></summary></details>\n");
                         }
-                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) {
-                            fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT</div></summary></details>\n");
+                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags &
+                            VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) {
+                            fprintf(out,
+                                    "\t\t\t\t\t\t\t\t<details><summary><div "
+                                    "class='type'>VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT</div></summary></details>\n");
                         }
                         if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) {
-                            fprintf(out, "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT</div></summary></details>\n");
+                            fprintf(out,
+                                    "\t\t\t\t\t\t\t\t<details><summary><div "
+                                    "class='type'>VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT</div></summary></details>\n");
                         }
                         fprintf(out, "\t\t\t\t\t\t\t</details>\n");
                         fprintf(out, "\t\t\t\t\t\t</details>\n");
                     } else if (human_readable_output) {
                         printf("VkSharedPresentSurfaceCapabilitiesKHR:\n");
                         printf("\tsharedPresentSupportedUsageFlags:\n");
-                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags == 0) { printf("\t\tNone\n"); }
-                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) { printf("\t\tVK_IMAGE_USAGE_TRANSFER_SRC_BIT\n"); }
-                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT) { printf("\t\tVK_IMAGE_USAGE_TRANSFER_DST_BIT\n"); }
-                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_SAMPLED_BIT) { printf("\t\tVK_IMAGE_USAGE_SAMPLED_BIT\n"); }
-                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_STORAGE_BIT) { printf("\t\tVK_IMAGE_USAGE_STORAGE_BIT\n"); }
-                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) { printf("\t\tVK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT\n"); }
-                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) { printf("\t\tVK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT\n"); }
-                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) { printf("\t\tVK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT\n"); }
-                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) { printf("\t\tVK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT\n"); }
+                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags == 0) {
+                            printf("\t\tNone\n");
+                        }
+                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) {
+                            printf("\t\tVK_IMAGE_USAGE_TRANSFER_SRC_BIT\n");
+                        }
+                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT) {
+                            printf("\t\tVK_IMAGE_USAGE_TRANSFER_DST_BIT\n");
+                        }
+                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_SAMPLED_BIT) {
+                            printf("\t\tVK_IMAGE_USAGE_SAMPLED_BIT\n");
+                        }
+                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_STORAGE_BIT) {
+                            printf("\t\tVK_IMAGE_USAGE_STORAGE_BIT\n");
+                        }
+                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) {
+                            printf("\t\tVK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT\n");
+                        }
+                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags &
+                            VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+                            printf("\t\tVK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT\n");
+                        }
+                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags &
+                            VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) {
+                            printf("\t\tVK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT\n");
+                        }
+                        if (shared_surface_capabilities->sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) {
+                            printf("\t\tVK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT\n");
+                        }
                     }
                 }
                 place = work->pNext;
@@ -1822,7 +1966,6 @@ struct SurfaceExtensionInfo {
 static void AppDumpSurfaceExtension(struct AppInstance *inst, struct AppGpu *gpus, uint32_t gpu_count,
                                     struct SurfaceExtensionInfo *surface_extension, int *format_count, int *present_mode_count,
                                     FILE *out) {
-
     if (!CheckExtensionEnabled(surface_extension->name, inst->inst_extensions, inst->inst_extensions_count)) {
         return;
     }
@@ -1862,11 +2005,11 @@ static void AppDevDumpFormatProps(const struct AppGpu *gpu, VkFormat fmt, bool *
         VkFlags flags;
     } features[3];
 
-    features[0].name  = "linearTiling   FormatFeatureFlags";
+    features[0].name = "linearTiling   FormatFeatureFlags";
     features[0].flags = props.linearTilingFeatures;
-    features[1].name  = "optimalTiling  FormatFeatureFlags";
+    features[1].name = "optimalTiling  FormatFeatureFlags";
     features[1].flags = props.optimalTilingFeatures;
-    features[2].name  = "bufferFeatures FormatFeatureFlags";
+    features[2].name = "bufferFeatures FormatFeatureFlags";
     features[2].flags = props.bufferFeatures;
 
     if (html_output) {
@@ -1881,22 +2024,70 @@ static void AppDevDumpFormatProps(const struct AppGpu *gpu, VkFormat fmt, bool *
                 fprintf(out, "\t\t\t\t\t\t\t\t<details><summary>None</summary></details>\n");
             } else {
                 fprintf(out, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
-                        ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)                  ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT</div></summary></details>\n"                  : ""),  //0x0001
-                        ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)                  ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT</div></summary></details>\n"                  : ""),  //0x0002
-                        ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)           ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT</div></summary></details>\n"           : ""),  //0x0004
-                        ((features[i].flags & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)           ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT</div></summary></details>\n"           : ""),  //0x0008
-                        ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)           ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT</div></summary></details>\n"           : ""),  //0x0010
-                        ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)    ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT</div></summary></details>\n"    : ""),  //0x0020
-                        ((features[i].flags & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT)                  ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT</div></summary></details>\n"                  : ""),  //0x0040
-                        ((features[i].flags & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)               ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT</div></summary></details>\n"               : ""),  //0x0080
-                        ((features[i].flags & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT)         ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT</div></summary></details>\n"         : ""),  //0x0100
-                        ((features[i].flags & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)       ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT</div></summary></details>\n"       : ""),  //0x0200
-                        ((features[i].flags & VK_FORMAT_FEATURE_BLIT_SRC_BIT)                       ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_BLIT_SRC_BIT</div></summary></details>\n"                       : ""),  //0x0400
-                        ((features[i].flags & VK_FORMAT_FEATURE_BLIT_DST_BIT)                       ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_BLIT_DST_BIT</div></summary></details>\n"                       : ""),  //0x0800
-                        ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)    ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT</div></summary></details>\n"    : ""),  //0x1000
-                        ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG) ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG</div></summary></details>\n" : ""),  //0x2000
-                        ((features[i].flags & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR)               ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR</div></summary></details>\n"               : ""),  //0x4000
-                        ((features[i].flags & VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR)               ? "\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR</div></summary></details>\n"               : "")); //0x8000
+                        ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT) ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                                                                                     "class='type'>VK_FORMAT_FEATURE_SAMPLED_IMAGE_"
+                                                                                     "BIT</div></summary></details>\n"
+                                                                                   : ""),  // 0x0001
+                        ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT) ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                                                                                     "class='type'>VK_FORMAT_FEATURE_STORAGE_IMAGE_"
+                                                                                     "BIT</div></summary></details>\n"
+                                                                                   : ""),  // 0x0002
+                        ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)
+                             ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                               "class='type'>VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT</div></summary></details>\n"
+                             : ""),  // 0x0004
+                        ((features[i].flags & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)
+                             ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                               "class='type'>VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT</div></summary></details>\n"
+                             : ""),  // 0x0008
+                        ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)
+                             ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                               "class='type'>VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT</div></summary></details>\n"
+                             : ""),  // 0x0010
+                        ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)
+                             ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                               "class='type'>VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT</div></summary></details>\n"
+                             : ""),  // 0x0020
+                        ((features[i].flags & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                                                                                     "class='type'>VK_FORMAT_FEATURE_VERTEX_BUFFER_"
+                                                                                     "BIT</div></summary></details>\n"
+                                                                                   : ""),  // 0x0040
+                        ((features[i].flags & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                                                                                        "class='type'>VK_FORMAT_FEATURE_COLOR_"
+                                                                                        "ATTACHMENT_BIT</div></summary></details>\n"
+                                                                                      : ""),  // 0x0080
+                        ((features[i].flags & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT)
+                             ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                               "class='type'>VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT</div></summary></details>\n"
+                             : ""),  // 0x0100
+                        ((features[i].flags & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
+                             ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                               "class='type'>VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT</div></summary></details>\n"
+                             : ""),  // 0x0200
+                        ((features[i].flags & VK_FORMAT_FEATURE_BLIT_SRC_BIT) ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                                                                                "class='type'>VK_FORMAT_FEATURE_BLIT_SRC_BIT</"
+                                                                                "div></summary></details>\n"
+                                                                              : ""),  // 0x0400
+                        ((features[i].flags & VK_FORMAT_FEATURE_BLIT_DST_BIT) ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                                                                                "class='type'>VK_FORMAT_FEATURE_BLIT_DST_BIT</"
+                                                                                "div></summary></details>\n"
+                                                                              : ""),  // 0x0800
+                        ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)
+                             ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                               "class='type'>VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT</div></summary></details>\n"
+                             : ""),  // 0x1000
+                        ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG)
+                             ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                               "class='type'>VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG</div></summary></details>\n"
+                             : ""),  // 0x2000
+                        ((features[i].flags & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR) ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                                                                                        "class='type'>VK_FORMAT_FEATURE_TRANSFER_"
+                                                                                        "SRC_BIT_KHR</div></summary></details>\n"
+                                                                                      : ""),  // 0x4000
+                        ((features[i].flags & VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR) ? "\t\t\t\t\t\t\t\t<details><summary><div "
+                                                                                        "class='type'>VK_FORMAT_FEATURE_TRANSFER_"
+                                                                                        "DST_BIT_KHR</div></summary></details>\n"
+                                                                                      : ""));  // 0x8000
             }
             fprintf(out, "\t\t\t\t\t\t\t</details>\n");
         } else if (human_readable_output) {
@@ -1904,23 +2095,46 @@ static void AppDevDumpFormatProps(const struct AppGpu *gpu, VkFormat fmt, bool *
             if (features[i].flags == 0) {
                 printf("\n\t\tNone");
             } else {
-                printf("%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
-                       ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)                  ? "\n\t\tVK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT"                  : ""),  //0x0001
-                       ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)                  ? "\n\t\tVK_FORMAT_FEATURE_STORAGE_IMAGE_BIT"                  : ""),  //0x0002
-                       ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)           ? "\n\t\tVK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT"           : ""),  //0x0004
-                       ((features[i].flags & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)           ? "\n\t\tVK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT"           : ""),  //0x0008
-                       ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)           ? "\n\t\tVK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT"           : ""),  //0x0010
-                       ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)    ? "\n\t\tVK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT"    : ""),  //0x0020
-                       ((features[i].flags & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT)                  ? "\n\t\tVK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"                  : ""),  //0x0040
-                       ((features[i].flags & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)               ? "\n\t\tVK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT"               : ""),  //0x0080
-                       ((features[i].flags & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT)         ? "\n\t\tVK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT"         : ""),  //0x0100
-                       ((features[i].flags & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)       ? "\n\t\tVK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT"       : ""),  //0x0200
-                       ((features[i].flags & VK_FORMAT_FEATURE_BLIT_SRC_BIT)                       ? "\n\t\tVK_FORMAT_FEATURE_BLIT_SRC_BIT"                       : ""),  //0x0400
-                       ((features[i].flags & VK_FORMAT_FEATURE_BLIT_DST_BIT)                       ? "\n\t\tVK_FORMAT_FEATURE_BLIT_DST_BIT"                       : ""),  //0x0800
-                       ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)    ? "\n\t\tVK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT"    : ""),  //0x1000
-                       ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG) ? "\n\t\tVK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG" : ""),  //0x2000
-                       ((features[i].flags & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR)               ? "\n\t\tVK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR"               : ""),  //0x4000
-                       ((features[i].flags & VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR)               ? "\n\t\tVK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR"               : "")); //0x8000
+                printf(
+                    "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
+                    ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT) ? "\n\t\tVK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT"
+                                                                               : ""),  // 0x0001
+                    ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT) ? "\n\t\tVK_FORMAT_FEATURE_STORAGE_IMAGE_BIT"
+                                                                               : ""),  // 0x0002
+                    ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)
+                         ? "\n\t\tVK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT"
+                         : ""),  // 0x0004
+                    ((features[i].flags & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)
+                         ? "\n\t\tVK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT"
+                         : ""),  // 0x0008
+                    ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)
+                         ? "\n\t\tVK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT"
+                         : ""),  // 0x0010
+                    ((features[i].flags & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)
+                         ? "\n\t\tVK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT"
+                         : ""),  // 0x0020
+                    ((features[i].flags & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) ? "\n\t\tVK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+                                                                               : ""),  // 0x0040
+                    ((features[i].flags & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) ? "\n\t\tVK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT"
+                                                                                  : ""),  // 0x0080
+                    ((features[i].flags & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT)
+                         ? "\n\t\tVK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT"
+                         : ""),  // 0x0100
+                    ((features[i].flags & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
+                         ? "\n\t\tVK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT"
+                         : ""),                                                                                            // 0x0200
+                    ((features[i].flags & VK_FORMAT_FEATURE_BLIT_SRC_BIT) ? "\n\t\tVK_FORMAT_FEATURE_BLIT_SRC_BIT" : ""),  // 0x0400
+                    ((features[i].flags & VK_FORMAT_FEATURE_BLIT_DST_BIT) ? "\n\t\tVK_FORMAT_FEATURE_BLIT_DST_BIT" : ""),  // 0x0800
+                    ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)
+                         ? "\n\t\tVK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT"
+                         : ""),  // 0x1000
+                    ((features[i].flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG)
+                         ? "\n\t\tVK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG"
+                         : ""),  // 0x2000
+                    ((features[i].flags & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR) ? "\n\t\tVK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR"
+                                                                                  : ""),  // 0x4000
+                    ((features[i].flags & VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR) ? "\n\t\tVK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR"
+                                                                                  : ""));  // 0x8000
             }
         }
     }
@@ -1972,7 +2186,7 @@ static struct FormatRange {
     {
         // YCBCR extension, standard in Vulkan 1.1
         VK_MAKE_VERSION(1, 1, 0),
-        VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME, 
+        VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME,
         VK_FORMAT_G8B8G8R8_422_UNORM,
         VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM,
     },
@@ -1988,8 +2202,7 @@ static struct FormatRange {
 // Helper function to determine whether a format range is currently supported.
 bool FormatRangeSupported(const struct FormatRange *format_range, const struct AppGpu *gpu) {
     // True if standard and supported by both this instance and this GPU
-    if (format_range->minimum_instance_version > 0 &&
-        gpu->inst->instance_version >= format_range->minimum_instance_version &&
+    if (format_range->minimum_instance_version > 0 && gpu->inst->instance_version >= format_range->minimum_instance_version &&
         gpu->props.apiVersion >= format_range->minimum_instance_version) {
         return true;
     }
@@ -2202,16 +2415,16 @@ static void AppDevDump(const struct AppGpu *gpu, FILE *out) {
 }
 
 #ifdef _WIN32
-#define PRINTF_SIZE_T_SPECIFIER    "%Iu"
+#define PRINTF_SIZE_T_SPECIFIER "%Iu"
 #else
-#define PRINTF_SIZE_T_SPECIFIER    "%zu"
+#define PRINTF_SIZE_T_SPECIFIER "%zu"
 #endif
 
 static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
     VkPhysicalDeviceFeatures features;
 
     if (CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
-        gpu->inst->inst_extensions_count)) {
+                              gpu->inst->inst_extensions_count)) {
         const VkPhysicalDeviceFeatures *features2_const = &gpu->features2.features;
         features = *features2_const;
     } else {
@@ -2221,276 +2434,505 @@ static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
 
     if (html_output) {
         fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceFeatures</summary>\n");
-        fprintf(out, "\t\t\t\t\t\t<details><summary>robustBufferAccess                      = <div class='val'>%u</div></summary></details>\n", features.robustBufferAccess                     );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>fullDrawIndexUint32                     = <div class='val'>%u</div></summary></details>\n", features.fullDrawIndexUint32                    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>imageCubeArray                          = <div class='val'>%u</div></summary></details>\n", features.imageCubeArray                         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>independentBlend                        = <div class='val'>%u</div></summary></details>\n", features.independentBlend                       );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>geometryShader                          = <div class='val'>%u</div></summary></details>\n", features.geometryShader                         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>tessellationShader                      = <div class='val'>%u</div></summary></details>\n", features.tessellationShader                     );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sampleRateShading                       = <div class='val'>%u</div></summary></details>\n", features.sampleRateShading                      );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>dualSrcBlend                            = <div class='val'>%u</div></summary></details>\n", features.dualSrcBlend                           );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>logicOp                                 = <div class='val'>%u</div></summary></details>\n", features.logicOp                                );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>multiDrawIndirect                       = <div class='val'>%u</div></summary></details>\n", features.multiDrawIndirect                      );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>drawIndirectFirstInstance               = <div class='val'>%u</div></summary></details>\n", features.drawIndirectFirstInstance              );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>depthClamp                              = <div class='val'>%u</div></summary></details>\n", features.depthClamp                             );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>depthBiasClamp                          = <div class='val'>%u</div></summary></details>\n", features.depthBiasClamp                         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>fillModeNonSolid                        = <div class='val'>%u</div></summary></details>\n", features.fillModeNonSolid                       );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>depthBounds                             = <div class='val'>%u</div></summary></details>\n", features.depthBounds                            );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>wideLines                               = <div class='val'>%u</div></summary></details>\n", features.wideLines                              );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>largePoints                             = <div class='val'>%u</div></summary></details>\n", features.largePoints                            );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>alphaToOne                              = <div class='val'>%u</div></summary></details>\n", features.alphaToOne                             );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>multiViewport                           = <div class='val'>%u</div></summary></details>\n", features.multiViewport                          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>samplerAnisotropy                       = <div class='val'>%u</div></summary></details>\n", features.samplerAnisotropy                      );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>textureCompressionETC2                  = <div class='val'>%u</div></summary></details>\n", features.textureCompressionETC2                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>textureCompressionASTC_LDR              = <div class='val'>%u</div></summary></details>\n", features.textureCompressionASTC_LDR             );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>textureCompressionBC                    = <div class='val'>%u</div></summary></details>\n", features.textureCompressionBC                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>occlusionQueryPrecise                   = <div class='val'>%u</div></summary></details>\n", features.occlusionQueryPrecise                  );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>pipelineStatisticsQuery                 = <div class='val'>%u</div></summary></details>\n", features.pipelineStatisticsQuery                );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>vertexPipelineStoresAndAtomics          = <div class='val'>%u</div></summary></details>\n", features.vertexPipelineStoresAndAtomics         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>fragmentStoresAndAtomics                = <div class='val'>%u</div></summary></details>\n", features.fragmentStoresAndAtomics               );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderTessellationAndGeometryPointSize  = <div class='val'>%u</div></summary></details>\n", features.shaderTessellationAndGeometryPointSize );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderImageGatherExtended               = <div class='val'>%u</div></summary></details>\n", features.shaderImageGatherExtended              );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderStorageImageExtendedFormats       = <div class='val'>%u</div></summary></details>\n", features.shaderStorageImageExtendedFormats      );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderStorageImageMultisample           = <div class='val'>%u</div></summary></details>\n", features.shaderStorageImageMultisample          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderStorageImageReadWithoutFormat     = <div class='val'>%u</div></summary></details>\n", features.shaderStorageImageReadWithoutFormat    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderStorageImageWriteWithoutFormat    = <div class='val'>%u</div></summary></details>\n", features.shaderStorageImageWriteWithoutFormat   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderUniformBufferArrayDynamicIndexing = <div class='val'>%u</div></summary></details>\n", features.shaderUniformBufferArrayDynamicIndexing);
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderSampledImageArrayDynamicIndexing  = <div class='val'>%u</div></summary></details>\n", features.shaderSampledImageArrayDynamicIndexing );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderStorageBufferArrayDynamicIndexing = <div class='val'>%u</div></summary></details>\n", features.shaderStorageBufferArrayDynamicIndexing);
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderStorageImageArrayDynamicIndexing  = <div class='val'>%u</div></summary></details>\n", features.shaderStorageImageArrayDynamicIndexing );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderClipDistance                      = <div class='val'>%u</div></summary></details>\n", features.shaderClipDistance                     );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderCullDistance                      = <div class='val'>%u</div></summary></details>\n", features.shaderCullDistance                     );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderFloat64                           = <div class='val'>%u</div></summary></details>\n", features.shaderFloat64                          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderInt64                             = <div class='val'>%u</div></summary></details>\n", features.shaderInt64                            );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderInt16                             = <div class='val'>%u</div></summary></details>\n", features.shaderInt16                            );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderResourceResidency                 = <div class='val'>%u</div></summary></details>\n", features.shaderResourceResidency                );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>shaderResourceMinLod                    = <div class='val'>%u</div></summary></details>\n", features.shaderResourceMinLod                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sparseBinding                           = <div class='val'>%u</div></summary></details>\n", features.sparseBinding                          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sparseResidencyBuffer                   = <div class='val'>%u</div></summary></details>\n", features.sparseResidencyBuffer                  );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sparseResidencyImage2D                  = <div class='val'>%u</div></summary></details>\n", features.sparseResidencyImage2D                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sparseResidencyImage3D                  = <div class='val'>%u</div></summary></details>\n", features.sparseResidencyImage3D                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sparseResidency2Samples                 = <div class='val'>%u</div></summary></details>\n", features.sparseResidency2Samples                );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sparseResidency4Samples                 = <div class='val'>%u</div></summary></details>\n", features.sparseResidency4Samples                );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sparseResidency8Samples                 = <div class='val'>%u</div></summary></details>\n", features.sparseResidency8Samples                );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sparseResidency16Samples                = <div class='val'>%u</div></summary></details>\n", features.sparseResidency16Samples               );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sparseResidencyAliased                  = <div class='val'>%u</div></summary></details>\n", features.sparseResidencyAliased                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>variableMultisampleRate                 = <div class='val'>%u</div></summary></details>\n", features.variableMultisampleRate                );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>inheritedQueries                        = <div class='val'>%u</div></summary></details>\n", features.inheritedQueries                       );
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>robustBufferAccess                      = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.robustBufferAccess);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>fullDrawIndexUint32                     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.fullDrawIndexUint32);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>imageCubeArray                          = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.imageCubeArray);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>independentBlend                        = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.independentBlend);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>geometryShader                          = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.geometryShader);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>tessellationShader                      = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.tessellationShader);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sampleRateShading                       = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.sampleRateShading);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>dualSrcBlend                            = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.dualSrcBlend);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>logicOp                                 = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.logicOp);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>multiDrawIndirect                       = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.multiDrawIndirect);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>drawIndirectFirstInstance               = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.drawIndirectFirstInstance);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>depthClamp                              = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.depthClamp);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>depthBiasClamp                          = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.depthBiasClamp);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>fillModeNonSolid                        = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.fillModeNonSolid);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>depthBounds                             = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.depthBounds);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>wideLines                               = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.wideLines);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>largePoints                             = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.largePoints);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>alphaToOne                              = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.alphaToOne);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>multiViewport                           = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.multiViewport);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>samplerAnisotropy                       = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.samplerAnisotropy);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>textureCompressionETC2                  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.textureCompressionETC2);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>textureCompressionASTC_LDR              = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.textureCompressionASTC_LDR);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>textureCompressionBC                    = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.textureCompressionBC);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>occlusionQueryPrecise                   = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.occlusionQueryPrecise);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>pipelineStatisticsQuery                 = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.pipelineStatisticsQuery);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>vertexPipelineStoresAndAtomics          = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.vertexPipelineStoresAndAtomics);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>fragmentStoresAndAtomics                = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.fragmentStoresAndAtomics);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderTessellationAndGeometryPointSize  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderTessellationAndGeometryPointSize);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderImageGatherExtended               = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderImageGatherExtended);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderStorageImageExtendedFormats       = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderStorageImageExtendedFormats);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderStorageImageMultisample           = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderStorageImageMultisample);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderStorageImageReadWithoutFormat     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderStorageImageReadWithoutFormat);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderStorageImageWriteWithoutFormat    = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderStorageImageWriteWithoutFormat);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderUniformBufferArrayDynamicIndexing = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderUniformBufferArrayDynamicIndexing);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderSampledImageArrayDynamicIndexing  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderSampledImageArrayDynamicIndexing);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderStorageBufferArrayDynamicIndexing = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderStorageBufferArrayDynamicIndexing);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderStorageImageArrayDynamicIndexing  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderStorageImageArrayDynamicIndexing);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderClipDistance                      = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderClipDistance);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderCullDistance                      = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderCullDistance);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderFloat64                           = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderFloat64);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderInt64                             = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderInt64);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderInt16                             = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderInt16);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderResourceResidency                 = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderResourceResidency);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>shaderResourceMinLod                    = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.shaderResourceMinLod);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sparseBinding                           = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.sparseBinding);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sparseResidencyBuffer                   = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.sparseResidencyBuffer);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sparseResidencyImage2D                  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.sparseResidencyImage2D);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sparseResidencyImage3D                  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.sparseResidencyImage3D);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sparseResidency2Samples                 = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.sparseResidency2Samples);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sparseResidency4Samples                 = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.sparseResidency4Samples);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sparseResidency8Samples                 = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.sparseResidency8Samples);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sparseResidency16Samples                = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.sparseResidency16Samples);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sparseResidencyAliased                  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.sparseResidencyAliased);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>variableMultisampleRate                 = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.variableMultisampleRate);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>inheritedQueries                        = <div "
+                "class='val'>%u</div></summary></details>\n",
+                features.inheritedQueries);
         fprintf(out, "\t\t\t\t\t</details>\n");
     } else if (human_readable_output) {
         printf("VkPhysicalDeviceFeatures:\n");
         printf("=========================\n");
-        printf("\trobustBufferAccess                      = %u\n", features.robustBufferAccess                     );
-        printf("\tfullDrawIndexUint32                     = %u\n", features.fullDrawIndexUint32                    );
-        printf("\timageCubeArray                          = %u\n", features.imageCubeArray                         );
-        printf("\tindependentBlend                        = %u\n", features.independentBlend                       );
-        printf("\tgeometryShader                          = %u\n", features.geometryShader                         );
-        printf("\ttessellationShader                      = %u\n", features.tessellationShader                     );
-        printf("\tsampleRateShading                       = %u\n", features.sampleRateShading                      );
-        printf("\tdualSrcBlend                            = %u\n", features.dualSrcBlend                           );
-        printf("\tlogicOp                                 = %u\n", features.logicOp                                );
-        printf("\tmultiDrawIndirect                       = %u\n", features.multiDrawIndirect                      );
-        printf("\tdrawIndirectFirstInstance               = %u\n", features.drawIndirectFirstInstance              );
-        printf("\tdepthClamp                              = %u\n", features.depthClamp                             );
-        printf("\tdepthBiasClamp                          = %u\n", features.depthBiasClamp                         );
-        printf("\tfillModeNonSolid                        = %u\n", features.fillModeNonSolid                       );
-        printf("\tdepthBounds                             = %u\n", features.depthBounds                            );
-        printf("\twideLines                               = %u\n", features.wideLines                              );
-        printf("\tlargePoints                             = %u\n", features.largePoints                            );
-        printf("\talphaToOne                              = %u\n", features.alphaToOne                             );
-        printf("\tmultiViewport                           = %u\n", features.multiViewport                          );
-        printf("\tsamplerAnisotropy                       = %u\n", features.samplerAnisotropy                      );
-        printf("\ttextureCompressionETC2                  = %u\n", features.textureCompressionETC2                 );
-        printf("\ttextureCompressionASTC_LDR              = %u\n", features.textureCompressionASTC_LDR             );
-        printf("\ttextureCompressionBC                    = %u\n", features.textureCompressionBC                   );
-        printf("\tocclusionQueryPrecise                   = %u\n", features.occlusionQueryPrecise                  );
-        printf("\tpipelineStatisticsQuery                 = %u\n", features.pipelineStatisticsQuery                );
-        printf("\tvertexPipelineStoresAndAtomics          = %u\n", features.vertexPipelineStoresAndAtomics         );
-        printf("\tfragmentStoresAndAtomics                = %u\n", features.fragmentStoresAndAtomics               );
-        printf("\tshaderTessellationAndGeometryPointSize  = %u\n", features.shaderTessellationAndGeometryPointSize );
-        printf("\tshaderImageGatherExtended               = %u\n", features.shaderImageGatherExtended              );
-        printf("\tshaderStorageImageExtendedFormats       = %u\n", features.shaderStorageImageExtendedFormats      );
-        printf("\tshaderStorageImageMultisample           = %u\n", features.shaderStorageImageMultisample          );
-        printf("\tshaderStorageImageReadWithoutFormat     = %u\n", features.shaderStorageImageReadWithoutFormat    );
-        printf("\tshaderStorageImageWriteWithoutFormat    = %u\n", features.shaderStorageImageWriteWithoutFormat   );
+        printf("\trobustBufferAccess                      = %u\n", features.robustBufferAccess);
+        printf("\tfullDrawIndexUint32                     = %u\n", features.fullDrawIndexUint32);
+        printf("\timageCubeArray                          = %u\n", features.imageCubeArray);
+        printf("\tindependentBlend                        = %u\n", features.independentBlend);
+        printf("\tgeometryShader                          = %u\n", features.geometryShader);
+        printf("\ttessellationShader                      = %u\n", features.tessellationShader);
+        printf("\tsampleRateShading                       = %u\n", features.sampleRateShading);
+        printf("\tdualSrcBlend                            = %u\n", features.dualSrcBlend);
+        printf("\tlogicOp                                 = %u\n", features.logicOp);
+        printf("\tmultiDrawIndirect                       = %u\n", features.multiDrawIndirect);
+        printf("\tdrawIndirectFirstInstance               = %u\n", features.drawIndirectFirstInstance);
+        printf("\tdepthClamp                              = %u\n", features.depthClamp);
+        printf("\tdepthBiasClamp                          = %u\n", features.depthBiasClamp);
+        printf("\tfillModeNonSolid                        = %u\n", features.fillModeNonSolid);
+        printf("\tdepthBounds                             = %u\n", features.depthBounds);
+        printf("\twideLines                               = %u\n", features.wideLines);
+        printf("\tlargePoints                             = %u\n", features.largePoints);
+        printf("\talphaToOne                              = %u\n", features.alphaToOne);
+        printf("\tmultiViewport                           = %u\n", features.multiViewport);
+        printf("\tsamplerAnisotropy                       = %u\n", features.samplerAnisotropy);
+        printf("\ttextureCompressionETC2                  = %u\n", features.textureCompressionETC2);
+        printf("\ttextureCompressionASTC_LDR              = %u\n", features.textureCompressionASTC_LDR);
+        printf("\ttextureCompressionBC                    = %u\n", features.textureCompressionBC);
+        printf("\tocclusionQueryPrecise                   = %u\n", features.occlusionQueryPrecise);
+        printf("\tpipelineStatisticsQuery                 = %u\n", features.pipelineStatisticsQuery);
+        printf("\tvertexPipelineStoresAndAtomics          = %u\n", features.vertexPipelineStoresAndAtomics);
+        printf("\tfragmentStoresAndAtomics                = %u\n", features.fragmentStoresAndAtomics);
+        printf("\tshaderTessellationAndGeometryPointSize  = %u\n", features.shaderTessellationAndGeometryPointSize);
+        printf("\tshaderImageGatherExtended               = %u\n", features.shaderImageGatherExtended);
+        printf("\tshaderStorageImageExtendedFormats       = %u\n", features.shaderStorageImageExtendedFormats);
+        printf("\tshaderStorageImageMultisample           = %u\n", features.shaderStorageImageMultisample);
+        printf("\tshaderStorageImageReadWithoutFormat     = %u\n", features.shaderStorageImageReadWithoutFormat);
+        printf("\tshaderStorageImageWriteWithoutFormat    = %u\n", features.shaderStorageImageWriteWithoutFormat);
         printf("\tshaderUniformBufferArrayDynamicIndexing = %u\n", features.shaderUniformBufferArrayDynamicIndexing);
-        printf("\tshaderSampledImageArrayDynamicIndexing  = %u\n", features.shaderSampledImageArrayDynamicIndexing );
+        printf("\tshaderSampledImageArrayDynamicIndexing  = %u\n", features.shaderSampledImageArrayDynamicIndexing);
         printf("\tshaderStorageBufferArrayDynamicIndexing = %u\n", features.shaderStorageBufferArrayDynamicIndexing);
-        printf("\tshaderStorageImageArrayDynamicIndexing  = %u\n", features.shaderStorageImageArrayDynamicIndexing );
-        printf("\tshaderClipDistance                      = %u\n", features.shaderClipDistance                     );
-        printf("\tshaderCullDistance                      = %u\n", features.shaderCullDistance                     );
-        printf("\tshaderFloat64                           = %u\n", features.shaderFloat64                          );
-        printf("\tshaderInt64                             = %u\n", features.shaderInt64                            );
-        printf("\tshaderInt16                             = %u\n", features.shaderInt16                            );
-        printf("\tshaderResourceResidency                 = %u\n", features.shaderResourceResidency                );
-        printf("\tshaderResourceMinLod                    = %u\n", features.shaderResourceMinLod                   );
-        printf("\tsparseBinding                           = %u\n", features.sparseBinding                          );
-        printf("\tsparseResidencyBuffer                   = %u\n", features.sparseResidencyBuffer                  );
-        printf("\tsparseResidencyImage2D                  = %u\n", features.sparseResidencyImage2D                 );
-        printf("\tsparseResidencyImage3D                  = %u\n", features.sparseResidencyImage3D                 );
-        printf("\tsparseResidency2Samples                 = %u\n", features.sparseResidency2Samples                );
-        printf("\tsparseResidency4Samples                 = %u\n", features.sparseResidency4Samples                );
-        printf("\tsparseResidency8Samples                 = %u\n", features.sparseResidency8Samples                );
-        printf("\tsparseResidency16Samples                = %u\n", features.sparseResidency16Samples               );
-        printf("\tsparseResidencyAliased                  = %u\n", features.sparseResidencyAliased                 );
-        printf("\tvariableMultisampleRate                 = %u\n", features.variableMultisampleRate                );
-        printf("\tinheritedQueries                        = %u\n", features.inheritedQueries                       );
+        printf("\tshaderStorageImageArrayDynamicIndexing  = %u\n", features.shaderStorageImageArrayDynamicIndexing);
+        printf("\tshaderClipDistance                      = %u\n", features.shaderClipDistance);
+        printf("\tshaderCullDistance                      = %u\n", features.shaderCullDistance);
+        printf("\tshaderFloat64                           = %u\n", features.shaderFloat64);
+        printf("\tshaderInt64                             = %u\n", features.shaderInt64);
+        printf("\tshaderInt16                             = %u\n", features.shaderInt16);
+        printf("\tshaderResourceResidency                 = %u\n", features.shaderResourceResidency);
+        printf("\tshaderResourceMinLod                    = %u\n", features.shaderResourceMinLod);
+        printf("\tsparseBinding                           = %u\n", features.sparseBinding);
+        printf("\tsparseResidencyBuffer                   = %u\n", features.sparseResidencyBuffer);
+        printf("\tsparseResidencyImage2D                  = %u\n", features.sparseResidencyImage2D);
+        printf("\tsparseResidencyImage3D                  = %u\n", features.sparseResidencyImage3D);
+        printf("\tsparseResidency2Samples                 = %u\n", features.sparseResidency2Samples);
+        printf("\tsparseResidency4Samples                 = %u\n", features.sparseResidency4Samples);
+        printf("\tsparseResidency8Samples                 = %u\n", features.sparseResidency8Samples);
+        printf("\tsparseResidency16Samples                = %u\n", features.sparseResidency16Samples);
+        printf("\tsparseResidencyAliased                  = %u\n", features.sparseResidencyAliased);
+        printf("\tvariableMultisampleRate                 = %u\n", features.variableMultisampleRate);
+        printf("\tinheritedQueries                        = %u\n", features.inheritedQueries);
     }
     if (json_output) {
         printf(",\n");
         printf("\t\"VkPhysicalDeviceFeatures\": {\n");
-        printf("\t\t\"robustBufferAccess\": %u,\n",                      features.robustBufferAccess);
-        printf("\t\t\"fullDrawIndexUint32\": %u,\n",                     features.fullDrawIndexUint32);
-        printf("\t\t\"imageCubeArray\": %u,\n",                          features.imageCubeArray);
-        printf("\t\t\"independentBlend\": %u,\n",                        features.independentBlend);
-        printf("\t\t\"geometryShader\": %u,\n",                          features.geometryShader);
-        printf("\t\t\"tessellationShader\": %u,\n",                      features.tessellationShader);
-        printf("\t\t\"sampleRateShading\": %u,\n",                       features.sampleRateShading);
-        printf("\t\t\"dualSrcBlend\": %u,\n",                            features.dualSrcBlend);
-        printf("\t\t\"logicOp\": %u,\n",                                 features.logicOp);
-        printf("\t\t\"multiDrawIndirect\": %u,\n",                       features.multiDrawIndirect);
-        printf("\t\t\"drawIndirectFirstInstance\": %u,\n",               features.drawIndirectFirstInstance);
-        printf("\t\t\"depthClamp\": %u,\n",                              features.depthClamp);
-        printf("\t\t\"depthBiasClamp\": %u,\n",                          features.depthBiasClamp);
-        printf("\t\t\"fillModeNonSolid\": %u,\n",                        features.fillModeNonSolid);
-        printf("\t\t\"depthBounds\": %u,\n",                             features.depthBounds);
-        printf("\t\t\"wideLines\": %u,\n",                               features.wideLines);
-        printf("\t\t\"largePoints\": %u,\n",                             features.largePoints);
-        printf("\t\t\"alphaToOne\": %u,\n",                              features.alphaToOne);
-        printf("\t\t\"multiViewport\": %u,\n",                           features.multiViewport);
-        printf("\t\t\"samplerAnisotropy\": %u,\n",                       features.samplerAnisotropy);
-        printf("\t\t\"textureCompressionETC2\": %u,\n",                  features.textureCompressionETC2);
-        printf("\t\t\"textureCompressionASTC_LDR\": %u,\n",              features.textureCompressionASTC_LDR);
-        printf("\t\t\"textureCompressionBC\": %u,\n",                    features.textureCompressionBC);
-        printf("\t\t\"occlusionQueryPrecise\": %u,\n",                   features.occlusionQueryPrecise);
-        printf("\t\t\"pipelineStatisticsQuery\": %u,\n",                 features.pipelineStatisticsQuery);
-        printf("\t\t\"vertexPipelineStoresAndAtomics\": %u,\n",          features.vertexPipelineStoresAndAtomics);
-        printf("\t\t\"fragmentStoresAndAtomics\": %u,\n",                features.fragmentStoresAndAtomics);
-        printf("\t\t\"shaderTessellationAndGeometryPointSize\": %u,\n",  features.shaderTessellationAndGeometryPointSize);
-        printf("\t\t\"shaderImageGatherExtended\": %u,\n",               features.shaderImageGatherExtended);
-        printf("\t\t\"shaderStorageImageExtendedFormats\": %u,\n",       features.shaderStorageImageExtendedFormats);
-        printf("\t\t\"shaderStorageImageMultisample\": %u,\n",           features.shaderStorageImageMultisample);
-        printf("\t\t\"shaderStorageImageReadWithoutFormat\": %u,\n",     features.shaderStorageImageReadWithoutFormat);
-        printf("\t\t\"shaderStorageImageWriteWithoutFormat\": %u,\n",    features.shaderStorageImageWriteWithoutFormat);
+        printf("\t\t\"robustBufferAccess\": %u,\n", features.robustBufferAccess);
+        printf("\t\t\"fullDrawIndexUint32\": %u,\n", features.fullDrawIndexUint32);
+        printf("\t\t\"imageCubeArray\": %u,\n", features.imageCubeArray);
+        printf("\t\t\"independentBlend\": %u,\n", features.independentBlend);
+        printf("\t\t\"geometryShader\": %u,\n", features.geometryShader);
+        printf("\t\t\"tessellationShader\": %u,\n", features.tessellationShader);
+        printf("\t\t\"sampleRateShading\": %u,\n", features.sampleRateShading);
+        printf("\t\t\"dualSrcBlend\": %u,\n", features.dualSrcBlend);
+        printf("\t\t\"logicOp\": %u,\n", features.logicOp);
+        printf("\t\t\"multiDrawIndirect\": %u,\n", features.multiDrawIndirect);
+        printf("\t\t\"drawIndirectFirstInstance\": %u,\n", features.drawIndirectFirstInstance);
+        printf("\t\t\"depthClamp\": %u,\n", features.depthClamp);
+        printf("\t\t\"depthBiasClamp\": %u,\n", features.depthBiasClamp);
+        printf("\t\t\"fillModeNonSolid\": %u,\n", features.fillModeNonSolid);
+        printf("\t\t\"depthBounds\": %u,\n", features.depthBounds);
+        printf("\t\t\"wideLines\": %u,\n", features.wideLines);
+        printf("\t\t\"largePoints\": %u,\n", features.largePoints);
+        printf("\t\t\"alphaToOne\": %u,\n", features.alphaToOne);
+        printf("\t\t\"multiViewport\": %u,\n", features.multiViewport);
+        printf("\t\t\"samplerAnisotropy\": %u,\n", features.samplerAnisotropy);
+        printf("\t\t\"textureCompressionETC2\": %u,\n", features.textureCompressionETC2);
+        printf("\t\t\"textureCompressionASTC_LDR\": %u,\n", features.textureCompressionASTC_LDR);
+        printf("\t\t\"textureCompressionBC\": %u,\n", features.textureCompressionBC);
+        printf("\t\t\"occlusionQueryPrecise\": %u,\n", features.occlusionQueryPrecise);
+        printf("\t\t\"pipelineStatisticsQuery\": %u,\n", features.pipelineStatisticsQuery);
+        printf("\t\t\"vertexPipelineStoresAndAtomics\": %u,\n", features.vertexPipelineStoresAndAtomics);
+        printf("\t\t\"fragmentStoresAndAtomics\": %u,\n", features.fragmentStoresAndAtomics);
+        printf("\t\t\"shaderTessellationAndGeometryPointSize\": %u,\n", features.shaderTessellationAndGeometryPointSize);
+        printf("\t\t\"shaderImageGatherExtended\": %u,\n", features.shaderImageGatherExtended);
+        printf("\t\t\"shaderStorageImageExtendedFormats\": %u,\n", features.shaderStorageImageExtendedFormats);
+        printf("\t\t\"shaderStorageImageMultisample\": %u,\n", features.shaderStorageImageMultisample);
+        printf("\t\t\"shaderStorageImageReadWithoutFormat\": %u,\n", features.shaderStorageImageReadWithoutFormat);
+        printf("\t\t\"shaderStorageImageWriteWithoutFormat\": %u,\n", features.shaderStorageImageWriteWithoutFormat);
         printf("\t\t\"shaderUniformBufferArrayDynamicIndexing\": %u,\n", features.shaderUniformBufferArrayDynamicIndexing);
-        printf("\t\t\"shaderSampledImageArrayDynamicIndexing\": %u,\n",  features.shaderSampledImageArrayDynamicIndexing);
+        printf("\t\t\"shaderSampledImageArrayDynamicIndexing\": %u,\n", features.shaderSampledImageArrayDynamicIndexing);
         printf("\t\t\"shaderStorageBufferArrayDynamicIndexing\": %u,\n", features.shaderStorageBufferArrayDynamicIndexing);
-        printf("\t\t\"shaderStorageImageArrayDynamicIndexing\": %u,\n",  features.shaderStorageImageArrayDynamicIndexing);
-        printf("\t\t\"shaderClipDistance\": %u,\n",                      features.shaderClipDistance);
-        printf("\t\t\"shaderCullDistance\": %u,\n",                      features.shaderCullDistance);
-        printf("\t\t\"shaderFloat64\": %u,\n",                           features.shaderFloat64);
-        printf("\t\t\"shaderInt64\": %u,\n",                             features.shaderInt64);
-        printf("\t\t\"shaderInt16\": %u,\n",                             features.shaderInt16);
-        printf("\t\t\"shaderResourceResidency\": %u,\n",                 features.shaderResourceResidency);
-        printf("\t\t\"shaderResourceMinLod\": %u,\n",                    features.shaderResourceMinLod);
-        printf("\t\t\"sparseBinding\": %u,\n",                           features.sparseBinding);
-        printf("\t\t\"sparseResidencyBuffer\": %u,\n",                   features.sparseResidencyBuffer);
-        printf("\t\t\"sparseResidencyImage2D\": %u,\n",                  features.sparseResidencyImage2D);
-        printf("\t\t\"sparseResidencyImage3D\": %u,\n",                  features.sparseResidencyImage3D);
-        printf("\t\t\"sparseResidency2Samples\": %u,\n",                 features.sparseResidency2Samples);
-        printf("\t\t\"sparseResidency4Samples\": %u,\n",                 features.sparseResidency4Samples);
-        printf("\t\t\"sparseResidency8Samples\": %u,\n",                 features.sparseResidency8Samples);
-        printf("\t\t\"sparseResidency16Samples\": %u,\n",                features.sparseResidency16Samples);
-        printf("\t\t\"sparseResidencyAliased\": %u,\n",                  features.sparseResidencyAliased);
-        printf("\t\t\"variableMultisampleRate\": %u,\n",                 features.variableMultisampleRate);
-        printf("\t\t\"inheritedQueries\": %u\n",                         features.inheritedQueries);
+        printf("\t\t\"shaderStorageImageArrayDynamicIndexing\": %u,\n", features.shaderStorageImageArrayDynamicIndexing);
+        printf("\t\t\"shaderClipDistance\": %u,\n", features.shaderClipDistance);
+        printf("\t\t\"shaderCullDistance\": %u,\n", features.shaderCullDistance);
+        printf("\t\t\"shaderFloat64\": %u,\n", features.shaderFloat64);
+        printf("\t\t\"shaderInt64\": %u,\n", features.shaderInt64);
+        printf("\t\t\"shaderInt16\": %u,\n", features.shaderInt16);
+        printf("\t\t\"shaderResourceResidency\": %u,\n", features.shaderResourceResidency);
+        printf("\t\t\"shaderResourceMinLod\": %u,\n", features.shaderResourceMinLod);
+        printf("\t\t\"sparseBinding\": %u,\n", features.sparseBinding);
+        printf("\t\t\"sparseResidencyBuffer\": %u,\n", features.sparseResidencyBuffer);
+        printf("\t\t\"sparseResidencyImage2D\": %u,\n", features.sparseResidencyImage2D);
+        printf("\t\t\"sparseResidencyImage3D\": %u,\n", features.sparseResidencyImage3D);
+        printf("\t\t\"sparseResidency2Samples\": %u,\n", features.sparseResidency2Samples);
+        printf("\t\t\"sparseResidency4Samples\": %u,\n", features.sparseResidency4Samples);
+        printf("\t\t\"sparseResidency8Samples\": %u,\n", features.sparseResidency8Samples);
+        printf("\t\t\"sparseResidency16Samples\": %u,\n", features.sparseResidency16Samples);
+        printf("\t\t\"sparseResidencyAliased\": %u,\n", features.sparseResidencyAliased);
+        printf("\t\t\"variableMultisampleRate\": %u,\n", features.variableMultisampleRate);
+        printf("\t\t\"inheritedQueries\": %u\n", features.inheritedQueries);
         printf("\t}");
     }
 
     if (CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
-        gpu->inst->inst_extensions_count)) {
+                              gpu->inst->inst_extensions_count)) {
         void *place = gpu->features2.pNext;
         while (place) {
-            struct VkStructureHeader *structure = (struct VkStructureHeader*) place;
-            if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_8BIT_STORAGE_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDevice8BitStorageFeaturesKHR *b8_store_features = (VkPhysicalDevice8BitStorageFeaturesKHR*)structure;
+            struct VkStructureHeader *structure = (struct VkStructureHeader *)place;
+            if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR &&
+                CheckPhysicalDeviceExtensionIncluded(VK_KHR_8BIT_STORAGE_EXTENSION_NAME, gpu->device_extensions,
+                                                     gpu->device_extension_count)) {
+                VkPhysicalDevice8BitStorageFeaturesKHR *b8_store_features = (VkPhysicalDevice8BitStorageFeaturesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDevice8BitStorageFeatures</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>storageBuffer8BitAccess           = <div class='val'>%u</div></summary></details>\n", b8_store_features->storageBuffer8BitAccess);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>uniformAndStorageBuffer8BitAccess = <div class='val'>%u</div></summary></details>\n", b8_store_features->uniformAndStorageBuffer8BitAccess);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>storagePushConstant8              = <div class='val'>%u</div></summary></details>\n", b8_store_features->storagePushConstant8);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>storageBuffer8BitAccess           = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            b8_store_features->storageBuffer8BitAccess);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>uniformAndStorageBuffer8BitAccess = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            b8_store_features->uniformAndStorageBuffer8BitAccess);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>storagePushConstant8              = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            b8_store_features->storagePushConstant8);
                     fprintf(out, "\t\t\t\t\t</details>\n");
-                }
-                else if (human_readable_output) {
+                } else if (human_readable_output) {
                     printf("\nVkPhysicalDevice8BitStorageFeatures:\n");
                     printf("=====================================\n");
                     printf("\tstorageBuffer8BitAccess           = %u\n", b8_store_features->storageBuffer8BitAccess);
                     printf("\tuniformAndStorageBuffer8BitAccess = %u\n", b8_store_features->uniformAndStorageBuffer8BitAccess);
                     printf("\tstoragePushConstant8              = %u\n", b8_store_features->storagePushConstant8);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_16BIT_STORAGE_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDevice16BitStorageFeaturesKHR *b16_store_features = (VkPhysicalDevice16BitStorageFeaturesKHR*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES_KHR &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_KHR_16BIT_STORAGE_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDevice16BitStorageFeaturesKHR *b16_store_features = (VkPhysicalDevice16BitStorageFeaturesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDevice16BitStorageFeatures</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>storageBuffer16BitAccess           = <div class='val'>%u</div></summary></details>\n", b16_store_features->storageBuffer16BitAccess          );
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>uniformAndStorageBuffer16BitAccess = <div class='val'>%u</div></summary></details>\n", b16_store_features->uniformAndStorageBuffer16BitAccess);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>storagePushConstant16              = <div class='val'>%u</div></summary></details>\n", b16_store_features->storagePushConstant16             );
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>storageInputOutput16               = <div class='val'>%u</div></summary></details>\n", b16_store_features->storageInputOutput16              );
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>storageBuffer16BitAccess           = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            b16_store_features->storageBuffer16BitAccess);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>uniformAndStorageBuffer16BitAccess = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            b16_store_features->uniformAndStorageBuffer16BitAccess);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>storagePushConstant16              = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            b16_store_features->storagePushConstant16);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>storageInputOutput16               = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            b16_store_features->storageInputOutput16);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDevice16BitStorageFeatures:\n");
                     printf("=====================================\n");
-                    printf("\tstorageBuffer16BitAccess           = %u\n", b16_store_features->storageBuffer16BitAccess          );
+                    printf("\tstorageBuffer16BitAccess           = %u\n", b16_store_features->storageBuffer16BitAccess);
                     printf("\tuniformAndStorageBuffer16BitAccess = %u\n", b16_store_features->uniformAndStorageBuffer16BitAccess);
-                    printf("\tstoragePushConstant16              = %u\n", b16_store_features->storagePushConstant16             );
-                    printf("\tstorageInputOutput16               = %u\n", b16_store_features->storageInputOutput16              );
+                    printf("\tstoragePushConstant16              = %u\n", b16_store_features->storagePushConstant16);
+                    printf("\tstorageInputOutput16               = %u\n", b16_store_features->storageInputOutput16);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR *sampler_ycbcr_features = (VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES_KHR &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR *sampler_ycbcr_features =
+                    (VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceSamplerYcbcrConversionFeatures</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>samplerYcbcrConversion = <div class='val'>%u</div></summary></details>\n", sampler_ycbcr_features->samplerYcbcrConversion);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>samplerYcbcrConversion = <div class='val'>%u</div></summary></details>\n",
+                        sampler_ycbcr_features->samplerYcbcrConversion);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceSamplerYcbcrConversionFeatures:\n");
                     printf("===============================================\n");
                     printf("\tsamplerYcbcrConversion = %u\n", sampler_ycbcr_features->samplerYcbcrConversion);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceVariablePointerFeaturesKHR *var_pointer_features = (VkPhysicalDeviceVariablePointerFeaturesKHR*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES_KHR &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceVariablePointerFeaturesKHR *var_pointer_features =
+                    (VkPhysicalDeviceVariablePointerFeaturesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceVariablePointerFeatures</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>variablePointersStorageBuffer = <div class='val'>%u</div></summary></details>\n", var_pointer_features->variablePointersStorageBuffer);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>variablePointers              = <div class='val'>%u</div></summary></details>\n", var_pointer_features->variablePointers             );
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>variablePointersStorageBuffer = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            var_pointer_features->variablePointersStorageBuffer);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>variablePointers              = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            var_pointer_features->variablePointers);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceVariablePointerFeatures:\n");
                     printf("========================================\n");
                     printf("\tvariablePointersStorageBuffer = %u\n", var_pointer_features->variablePointersStorageBuffer);
-                    printf("\tvariablePointers              = %u\n", var_pointer_features->variablePointers             );
+                    printf("\tvariablePointers              = %u\n", var_pointer_features->variablePointers);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *blend_op_adv_features = (VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *blend_op_adv_features =
+                    (VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceBlendOperationAdvancedFeatures</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>advancedBlendCoherentOperations = <div class='val'>%u</div></summary></details>\n", blend_op_adv_features->advancedBlendCoherentOperations);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>advancedBlendCoherentOperations = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            blend_op_adv_features->advancedBlendCoherentOperations);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceBlendOperationAdvancedFeatures:\n");
                     printf("===============================================\n");
                     printf("\tadvancedBlendCoherentOperations = %u\n", blend_op_adv_features->advancedBlendCoherentOperations);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_MULTIVIEW_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceMultiviewFeaturesKHR *multiview_features = (VkPhysicalDeviceMultiviewFeaturesKHR*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_KHR_MULTIVIEW_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceMultiviewFeaturesKHR *multiview_features = (VkPhysicalDeviceMultiviewFeaturesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceMultiviewFeatures</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>multiview                   = <div class='val'>%u</div></summary></details>\n", multiview_features->multiview                  );
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>multiviewGeometryShader     = <div class='val'>%u</div></summary></details>\n", multiview_features->multiviewGeometryShader    );
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>multiviewTessellationShader = <div class='val'>%u</div></summary></details>\n", multiview_features->multiviewTessellationShader);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>multiview                   = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            multiview_features->multiview);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>multiviewGeometryShader     = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            multiview_features->multiviewGeometryShader);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>multiviewTessellationShader = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            multiview_features->multiviewTessellationShader);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceMultiviewFeatures:\n");
                     printf("==================================\n");
-                    printf("\tmultiview                   = %u\n", multiview_features->multiview                  );
-                    printf("\tmultiviewGeometryShader     = %u\n", multiview_features->multiviewGeometryShader    );
+                    printf("\tmultiview                   = %u\n", multiview_features->multiview);
+                    printf("\tmultiviewGeometryShader     = %u\n", multiview_features->multiviewGeometryShader);
                     printf("\tmultiviewTessellationShader = %u\n", multiview_features->multiviewTessellationShader);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceFloat16Int8FeaturesKHR *float_int_features = (VkPhysicalDeviceFloat16Int8FeaturesKHR*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceFloat16Int8FeaturesKHR *float_int_features = (VkPhysicalDeviceFloat16Int8FeaturesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceFloat16Int8Features</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderFloat16 = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_int_features->shaderFloat16);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderInt8    = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_int_features->shaderInt8);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderFloat16 = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_int_features->shaderFloat16);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderInt8    = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_int_features->shaderInt8);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceFloat16Int8Features:\n");
@@ -2498,56 +2940,94 @@ static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
                     printf("\tshaderFloat16 = %" PRIuLEAST32 "\n", float_int_features->shaderFloat16);
                     printf("\tshaderInt8    = %" PRIuLEAST32 "\n", float_int_features->shaderInt8);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceShaderAtomicInt64FeaturesKHR *shader_atomic_int64_features = (VkPhysicalDeviceShaderAtomicInt64FeaturesKHR*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceShaderAtomicInt64FeaturesKHR *shader_atomic_int64_features =
+                    (VkPhysicalDeviceShaderAtomicInt64FeaturesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceShaderAtomicInt64Features</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderBufferInt64Atomics = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", shader_atomic_int64_features->shaderBufferInt64Atomics);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderSharedInt64Atomics = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", shader_atomic_int64_features->shaderSharedInt64Atomics);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderBufferInt64Atomics = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            shader_atomic_int64_features->shaderBufferInt64Atomics);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderSharedInt64Atomics = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            shader_atomic_int64_features->shaderSharedInt64Atomics);
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceShaderAtomicInt64Features:\n");
                     printf("==========================================\n");
-                    printf("\tshaderBufferInt64Atomics = %" PRIuLEAST32 "\n", shader_atomic_int64_features->shaderBufferInt64Atomics);
-                    printf("\tshaderSharedInt64Atomics = %" PRIuLEAST32 "\n", shader_atomic_int64_features->shaderSharedInt64Atomics);
+                    printf("\tshaderBufferInt64Atomics = %" PRIuLEAST32 "\n",
+                           shader_atomic_int64_features->shaderBufferInt64Atomics);
+                    printf("\tshaderSharedInt64Atomics = %" PRIuLEAST32 "\n",
+                           shader_atomic_int64_features->shaderSharedInt64Atomics);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceTransformFeedbackFeaturesEXT *transform_feedback_features = (VkPhysicalDeviceTransformFeedbackFeaturesEXT*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceTransformFeedbackFeaturesEXT *transform_feedback_features =
+                    (VkPhysicalDeviceTransformFeedbackFeaturesEXT *)structure;
                 if (html_output) {
                     fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceTransformFeedbackFeatures</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>transformFeedback = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_features->transformFeedback);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>geometryStreams   = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_features->geometryStreams);
-                }
-                else if (human_readable_output) {
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>transformFeedback = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            transform_feedback_features->transformFeedback);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>geometryStreams   = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            transform_feedback_features->geometryStreams);
+                } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceTransformFeedbackFeatures:\n");
                     printf("==========================================\n");
                     printf("\ttransformFeedback = %" PRIuLEAST32 "\n", transform_feedback_features->transformFeedback);
                     printf("\tgeometryStreams   = %" PRIuLEAST32 "\n", transform_feedback_features->geometryStreams);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceScalarBlockLayoutFeaturesEXT *scalar_block_layout_features = (VkPhysicalDeviceScalarBlockLayoutFeaturesEXT*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceScalarBlockLayoutFeaturesEXT *scalar_block_layout_features =
+                    (VkPhysicalDeviceScalarBlockLayoutFeaturesEXT *)structure;
                 if (html_output) {
                     fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceScalarBlockLayoutFeatures</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>scalarBlockLayout = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", scalar_block_layout_features->scalarBlockLayout);
-                }
-                else if (human_readable_output) {
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>scalarBlockLayout = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            scalar_block_layout_features->scalarBlockLayout);
+                } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceScalarBlockLayoutFeatures:\n");
                     printf("==========================================\n");
                     printf("\tscalarBlockLayout = %" PRIuLEAST32 "\n", scalar_block_layout_features->scalarBlockLayout);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceFragmentDensityMapFeaturesEXT *fragment_density_map_features = (VkPhysicalDeviceFragmentDensityMapFeaturesEXT*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceFragmentDensityMapFeaturesEXT *fragment_density_map_features =
+                    (VkPhysicalDeviceFragmentDensityMapFeaturesEXT *)structure;
                 if (html_output) {
                     fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceFragmentDensityMapFeatures</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>fragmentDensityMap                    = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_features->fragmentDensityMap);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>fragmentDensityMapDynamic             = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_features->fragmentDensityMapDynamic);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>fragmentDensityMapNonSubsampledImages = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_features->fragmentDensityMapNonSubsampledImages);
-                }
-                else if (human_readable_output) {
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>fragmentDensityMap                    = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            fragment_density_map_features->fragmentDensityMap);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>fragmentDensityMapDynamic             = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            fragment_density_map_features->fragmentDensityMapDynamic);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>fragmentDensityMapNonSubsampledImages = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            fragment_density_map_features->fragmentDensityMapNonSubsampledImages);
+                } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceFragmentDensityMapFeatures:\n");
                     printf("==========================================\n");
-                    printf("\tfragmentDensityMap                    = %" PRIuLEAST32 "\n", fragment_density_map_features->fragmentDensityMap);
-                    printf("\tfragmentDensityMapDynamic             = %" PRIuLEAST32 "\n", fragment_density_map_features->fragmentDensityMapDynamic);
-                    printf("\tfragmentDensityMapNonSubsampledImages = %" PRIuLEAST32 "\n", fragment_density_map_features->fragmentDensityMapNonSubsampledImages);
+                    printf("\tfragmentDensityMap                    = %" PRIuLEAST32 "\n",
+                           fragment_density_map_features->fragmentDensityMap);
+                    printf("\tfragmentDensityMapDynamic             = %" PRIuLEAST32 "\n",
+                           fragment_density_map_features->fragmentDensityMapDynamic);
+                    printf("\tfragmentDensityMapNonSubsampledImages = %" PRIuLEAST32 "\n",
+                           fragment_density_map_features->fragmentDensityMapNonSubsampledImages);
                 }
             }
             place = structure->pNext;
@@ -2558,29 +3038,44 @@ static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
 static void AppDumpSparseProps(const VkPhysicalDeviceSparseProperties *sparse_props, FILE *out) {
     if (html_output) {
         fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceSparseProperties</summary>\n");
-        fprintf(out, "\t\t\t\t\t\t<details><summary>residencyStandard2DBlockShape            = <div class='val'>%u</div></summary></details>\n", sparse_props->residencyStandard2DBlockShape           );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>residencyStandard2DMultisampleBlockShape = <div class='val'>%u</div></summary></details>\n", sparse_props->residencyStandard2DMultisampleBlockShape);
-        fprintf(out, "\t\t\t\t\t\t<details><summary>residencyStandard3DBlockShape            = <div class='val'>%u</div></summary></details>\n", sparse_props->residencyStandard3DBlockShape           );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>residencyAlignedMipSize                  = <div class='val'>%u</div></summary></details>\n", sparse_props->residencyAlignedMipSize                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>residencyNonResidentStrict               = <div class='val'>%u</div></summary></details>\n", sparse_props->residencyNonResidentStrict              );
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>residencyStandard2DBlockShape            = <div "
+                "class='val'>%u</div></summary></details>\n",
+                sparse_props->residencyStandard2DBlockShape);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>residencyStandard2DMultisampleBlockShape = <div "
+                "class='val'>%u</div></summary></details>\n",
+                sparse_props->residencyStandard2DMultisampleBlockShape);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>residencyStandard3DBlockShape            = <div "
+                "class='val'>%u</div></summary></details>\n",
+                sparse_props->residencyStandard3DBlockShape);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>residencyAlignedMipSize                  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                sparse_props->residencyAlignedMipSize);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>residencyNonResidentStrict               = <div "
+                "class='val'>%u</div></summary></details>\n",
+                sparse_props->residencyNonResidentStrict);
         fprintf(out, "\t\t\t\t\t</details>\n");
     } else if (human_readable_output) {
         printf("\tVkPhysicalDeviceSparseProperties:\n");
         printf("\t---------------------------------\n");
-        printf("\t\tresidencyStandard2DBlockShape            = %u\n", sparse_props->residencyStandard2DBlockShape           );
+        printf("\t\tresidencyStandard2DBlockShape            = %u\n", sparse_props->residencyStandard2DBlockShape);
         printf("\t\tresidencyStandard2DMultisampleBlockShape = %u\n", sparse_props->residencyStandard2DMultisampleBlockShape);
-        printf("\t\tresidencyStandard3DBlockShape            = %u\n", sparse_props->residencyStandard3DBlockShape           );
-        printf("\t\tresidencyAlignedMipSize                  = %u\n", sparse_props->residencyAlignedMipSize                 );
-        printf("\t\tresidencyNonResidentStrict               = %u\n", sparse_props->residencyNonResidentStrict              );
+        printf("\t\tresidencyStandard3DBlockShape            = %u\n", sparse_props->residencyStandard3DBlockShape);
+        printf("\t\tresidencyAlignedMipSize                  = %u\n", sparse_props->residencyAlignedMipSize);
+        printf("\t\tresidencyNonResidentStrict               = %u\n", sparse_props->residencyNonResidentStrict);
     }
     if (json_output) {
         printf(",\n");
         printf("\t\t\"sparseProperties\": {\n");
-        printf("\t\t\t\"residencyStandard2DBlockShape\": %u,\n",            sparse_props->residencyStandard2DBlockShape);
+        printf("\t\t\t\"residencyStandard2DBlockShape\": %u,\n", sparse_props->residencyStandard2DBlockShape);
         printf("\t\t\t\"residencyStandard2DMultisampleBlockShape\": %u,\n", sparse_props->residencyStandard2DMultisampleBlockShape);
-        printf("\t\t\t\"residencyStandard3DBlockShape\": %u,\n",             sparse_props->residencyStandard3DBlockShape);
-        printf("\t\t\t\"residencyAlignedMipSize\": %u,\n",                  sparse_props->residencyAlignedMipSize);
-        printf("\t\t\t\"residencyNonResidentStrict\": %u\n",               sparse_props->residencyNonResidentStrict);
+        printf("\t\t\t\"residencyStandard3DBlockShape\": %u,\n", sparse_props->residencyStandard3DBlockShape);
+        printf("\t\t\t\"residencyAlignedMipSize\": %u,\n", sparse_props->residencyAlignedMipSize);
+        printf("\t\t\t\"residencyNonResidentStrict\": %u\n", sparse_props->residencyNonResidentStrict);
         printf("\t\t}");
     }
 }
@@ -2588,377 +3083,726 @@ static void AppDumpSparseProps(const VkPhysicalDeviceSparseProperties *sparse_pr
 static void AppDumpLimits(const VkPhysicalDeviceLimits *limits, FILE *out) {
     if (html_output) {
         fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceLimits</summary>\n");
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxImageDimension1D                     = <div class='val'>%u</div></summary></details>\n",                 limits->maxImageDimension1D                    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxImageDimension2D                     = <div class='val'>%u</div></summary></details>\n",                 limits->maxImageDimension2D                    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxImageDimension3D                     = <div class='val'>%u</div></summary></details>\n",                 limits->maxImageDimension3D                    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxImageDimensionCube                   = <div class='val'>%u</div></summary></details>\n",                 limits->maxImageDimensionCube                  );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxImageArrayLayers                     = <div class='val'>%u</div></summary></details>\n",                 limits->maxImageArrayLayers                    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxTexelBufferElements                  = <div class='val'>0x%" PRIxLEAST32 "</div></summary></details>\n", limits->maxTexelBufferElements                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxUniformBufferRange                   = <div class='val'>0x%" PRIxLEAST32 "</div></summary></details>\n", limits->maxUniformBufferRange                  );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxStorageBufferRange                   = <div class='val'>0x%" PRIxLEAST32 "</div></summary></details>\n", limits->maxStorageBufferRange                  );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxPushConstantsSize                    = <div class='val'>%u</div></summary></details>\n",                 limits->maxPushConstantsSize                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxMemoryAllocationCount                = <div class='val'>%u</div></summary></details>\n",                 limits->maxMemoryAllocationCount               );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxSamplerAllocationCount               = <div class='val'>%u</div></summary></details>\n",                 limits->maxSamplerAllocationCount              );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>bufferImageGranularity                  = <div class='val'>0x%" PRIxLEAST64 "</div></summary></details>\n", limits->bufferImageGranularity                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sparseAddressSpaceSize                  = <div class='val'>0x%" PRIxLEAST64 "</div></summary></details>\n", limits->sparseAddressSpaceSize                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxBoundDescriptorSets                  = <div class='val'>%u</div></summary></details>\n",                 limits->maxBoundDescriptorSets                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorSamplers           = <div class='val'>%u</div></summary></details>\n",                 limits->maxPerStageDescriptorSamplers          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorUniformBuffers     = <div class='val'>%u</div></summary></details>\n",                 limits->maxPerStageDescriptorUniformBuffers    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorStorageBuffers     = <div class='val'>%u</div></summary></details>\n",                 limits->maxPerStageDescriptorStorageBuffers    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorSampledImages      = <div class='val'>%u</div></summary></details>\n",                 limits->maxPerStageDescriptorSampledImages     );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorStorageImages      = <div class='val'>%u</div></summary></details>\n",                 limits->maxPerStageDescriptorStorageImages     );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorInputAttachments   = <div class='val'>%u</div></summary></details>\n",                 limits->maxPerStageDescriptorInputAttachments  );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxPerStageResources                    = <div class='val'>%u</div></summary></details>\n",                 limits->maxPerStageResources                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxDescriptorSetSamplers                = <div class='val'>%u</div></summary></details>\n",                 limits->maxDescriptorSetSamplers               );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxDescriptorSetUniformBuffers          = <div class='val'>%u</div></summary></details>\n",                 limits->maxDescriptorSetUniformBuffers         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxDescriptorSetUniformBuffersDynamic   = <div class='val'>%u</div></summary></details>\n",                 limits->maxDescriptorSetUniformBuffersDynamic  );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxDescriptorSetStorageBuffers          = <div class='val'>%u</div></summary></details>\n",                 limits->maxDescriptorSetStorageBuffers         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxDescriptorSetStorageBuffersDynamic   = <div class='val'>%u</div></summary></details>\n",                 limits->maxDescriptorSetStorageBuffersDynamic  );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxDescriptorSetSampledImages           = <div class='val'>%u</div></summary></details>\n",                 limits->maxDescriptorSetSampledImages          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxDescriptorSetStorageImages           = <div class='val'>%u</div></summary></details>\n",                 limits->maxDescriptorSetStorageImages          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxDescriptorSetInputAttachments        = <div class='val'>%u</div></summary></details>\n",                 limits->maxDescriptorSetInputAttachments       );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxVertexInputAttributes                = <div class='val'>%u</div></summary></details>\n",                 limits->maxVertexInputAttributes               );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxVertexInputBindings                  = <div class='val'>%u</div></summary></details>\n",                 limits->maxVertexInputBindings                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxVertexInputAttributeOffset           = <div class='val'>0x%" PRIxLEAST32 "</div></summary></details>\n", limits->maxVertexInputAttributeOffset          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxVertexInputBindingStride             = <div class='val'>0x%" PRIxLEAST32 "</div></summary></details>\n", limits->maxVertexInputBindingStride            );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxVertexOutputComponents               = <div class='val'>%u</div></summary></details>\n",                 limits->maxVertexOutputComponents              );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxTessellationGenerationLevel          = <div class='val'>%u</div></summary></details>\n",                 limits->maxTessellationGenerationLevel         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxTessellationPatchSize                        = <div class='val'>%u</div></summary></details>\n",                 limits->maxTessellationPatchSize                       );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxTessellationControlPerVertexInputComponents  = <div class='val'>%u</div></summary></details>\n",                 limits->maxTessellationControlPerVertexInputComponents );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxTessellationControlPerVertexOutputComponents = <div class='val'>%u</div></summary></details>\n",                 limits->maxTessellationControlPerVertexOutputComponents);
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxTessellationControlPerPatchOutputComponents  = <div class='val'>%u</div></summary></details>\n",                 limits->maxTessellationControlPerPatchOutputComponents );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxTessellationControlTotalOutputComponents     = <div class='val'>%u</div></summary></details>\n",                 limits->maxTessellationControlTotalOutputComponents    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxTessellationEvaluationInputComponents        = <div class='val'>%u</div></summary></details>\n",                 limits->maxTessellationEvaluationInputComponents       );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxTessellationEvaluationOutputComponents       = <div class='val'>%u</div></summary></details>\n",                 limits->maxTessellationEvaluationOutputComponents      );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxGeometryShaderInvocations            = <div class='val'>%u</div></summary></details>\n",                 limits->maxGeometryShaderInvocations           );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxGeometryInputComponents              = <div class='val'>%u</div></summary></details>\n",                 limits->maxGeometryInputComponents             );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxGeometryOutputComponents             = <div class='val'>%u</div></summary></details>\n",                 limits->maxGeometryOutputComponents            );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxGeometryOutputVertices               = <div class='val'>%u</div></summary></details>\n",                 limits->maxGeometryOutputVertices              );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxGeometryTotalOutputComponents        = <div class='val'>%u</div></summary></details>\n",                 limits->maxGeometryTotalOutputComponents       );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxFragmentInputComponents              = <div class='val'>%u</div></summary></details>\n",                 limits->maxFragmentInputComponents             );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxFragmentOutputAttachments            = <div class='val'>%u</div></summary></details>\n",                 limits->maxFragmentOutputAttachments           );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxFragmentDualSrcAttachments           = <div class='val'>%u</div></summary></details>\n",                 limits->maxFragmentDualSrcAttachments          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxFragmentCombinedOutputResources      = <div class='val'>%u</div></summary></details>\n",                 limits->maxFragmentCombinedOutputResources     );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxComputeSharedMemorySize              = <div class='val'>0x%" PRIxLEAST32 "</div></summary></details>\n", limits->maxComputeSharedMemorySize             );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupCount[0]             = <div class='val'>%u</div></summary></details>\n",                 limits->maxComputeWorkGroupCount[0]            );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupCount[1]             = <div class='val'>%u</div></summary></details>\n",                 limits->maxComputeWorkGroupCount[1]            );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupCount[2]             = <div class='val'>%u</div></summary></details>\n",                 limits->maxComputeWorkGroupCount[2]            );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupInvocations          = <div class='val'>%u</div></summary></details>\n",                 limits->maxComputeWorkGroupInvocations         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupSize[0]              = <div class='val'>%u</div></summary></details>\n",                 limits->maxComputeWorkGroupSize[0]             );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupSize[1]              = <div class='val'>%u</div></summary></details>\n",                 limits->maxComputeWorkGroupSize[1]             );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupSize[2]              = <div class='val'>%u</div></summary></details>\n",                 limits->maxComputeWorkGroupSize[2]             );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>subPixelPrecisionBits                   = <div class='val'>%u</div></summary></details>\n",                 limits->subPixelPrecisionBits                  );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>subTexelPrecisionBits                   = <div class='val'>%u</div></summary></details>\n",                 limits->subTexelPrecisionBits                  );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>mipmapPrecisionBits                     = <div class='val'>%u</div></summary></details>\n",                 limits->mipmapPrecisionBits                    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxDrawIndexedIndexValue                = <div class='val'>%u</div></summary></details>\n",                 limits->maxDrawIndexedIndexValue               );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxDrawIndirectCount                    = <div class='val'>%u</div></summary></details>\n",                 limits->maxDrawIndirectCount                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxSamplerLodBias                       = <div class='val'>%f</div></summary></details>\n",                 limits->maxSamplerLodBias                      );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxSamplerAnisotropy                    = <div class='val'>%f</div></summary></details>\n",                 limits->maxSamplerAnisotropy                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxViewports                            = <div class='val'>%u</div></summary></details>\n",                 limits->maxViewports                           );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxViewportDimensions[0]                = <div class='val'>%u</div></summary></details>\n",                 limits->maxViewportDimensions[0]               );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxViewportDimensions[1]                = <div class='val'>%u</div></summary></details>\n",                 limits->maxViewportDimensions[1]               );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>viewportBoundsRange[0]                  = <div class='val'>%13f</div></summary></details>\n",               limits->viewportBoundsRange[0]                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>viewportBoundsRange[1]                  = <div class='val'>%13f</div></summary></details>\n",               limits->viewportBoundsRange[1]                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>viewportSubPixelBits                    = <div class='val'>%u</div></summary></details>\n",                 limits->viewportSubPixelBits                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>minMemoryMapAlignment                   = <div class='val'>" PRINTF_SIZE_T_SPECIFIER "</div></summary></details>\n", limits->minMemoryMapAlignment         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>minTexelBufferOffsetAlignment           = <div class='val'>0x%" PRIxLEAST64 "</div></summary></details>\n", limits->minTexelBufferOffsetAlignment          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>minUniformBufferOffsetAlignment         = <div class='val'>0x%" PRIxLEAST64 "</div></summary></details>\n", limits->minUniformBufferOffsetAlignment        );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>minStorageBufferOffsetAlignment         = <div class='val'>0x%" PRIxLEAST64 "</div></summary></details>\n", limits->minStorageBufferOffsetAlignment        );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>minTexelOffset                          = <div class='val'>%3d</div></summary></details>\n",                limits->minTexelOffset                         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxTexelOffset                          = <div class='val'>%3d</div></summary></details>\n",                limits->maxTexelOffset                         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>minTexelGatherOffset                    = <div class='val'>%3d</div></summary></details>\n",                limits->minTexelGatherOffset                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxTexelGatherOffset                    = <div class='val'>%3d</div></summary></details>\n",                limits->maxTexelGatherOffset                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>minInterpolationOffset                  = <div class='val'>%9f</div></summary></details>\n",                limits->minInterpolationOffset                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxInterpolationOffset                  = <div class='val'>%9f</div></summary></details>\n",                limits->maxInterpolationOffset                 );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>subPixelInterpolationOffsetBits         = <div class='val'>%u</div></summary></details>\n",                 limits->subPixelInterpolationOffsetBits        );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxFramebufferWidth                     = <div class='val'>%u</div></summary></details>\n",                 limits->maxFramebufferWidth                    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxFramebufferHeight                    = <div class='val'>%u</div></summary></details>\n",                 limits->maxFramebufferHeight                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxFramebufferLayers                    = <div class='val'>%u</div></summary></details>\n",                 limits->maxFramebufferLayers                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>framebufferColorSampleCounts            = <div class='val'>%u</div></summary></details>\n",                 limits->framebufferColorSampleCounts           );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>framebufferDepthSampleCounts            = <div class='val'>%u</div></summary></details>\n",                 limits->framebufferDepthSampleCounts           );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>framebufferStencilSampleCounts          = <div class='val'>%u</div></summary></details>\n",                 limits->framebufferStencilSampleCounts         );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>framebufferNoAttachmentsSampleCounts    = <div class='val'>%u</div></summary></details>\n",                 limits->framebufferNoAttachmentsSampleCounts   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxColorAttachments                     = <div class='val'>%u</div></summary></details>\n",                 limits->maxColorAttachments                    );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sampledImageColorSampleCounts           = <div class='val'>%u</div></summary></details>\n",                 limits->sampledImageColorSampleCounts          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sampledImageDepthSampleCounts           = <div class='val'>%u</div></summary></details>\n",                 limits->sampledImageDepthSampleCounts          );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sampledImageStencilSampleCounts         = <div class='val'>%u</div></summary></details>\n",                 limits->sampledImageStencilSampleCounts        );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>sampledImageIntegerSampleCounts         = <div class='val'>%u</div></summary></details>\n",                 limits->sampledImageIntegerSampleCounts        );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>storageImageSampleCounts                = <div class='val'>%u</div></summary></details>\n",                 limits->storageImageSampleCounts               );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxSampleMaskWords                      = <div class='val'>%u</div></summary></details>\n",                 limits->maxSampleMaskWords                     );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>timestampComputeAndGraphics             = <div class='val'>%u</div></summary></details>\n",                 limits->timestampComputeAndGraphics            );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>timestampPeriod                         = <div class='val'>%f</div></summary></details>\n",                 limits->timestampPeriod                        );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxClipDistances                        = <div class='val'>%u</div></summary></details>\n",                 limits->maxClipDistances                       );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxCullDistances                        = <div class='val'>%u</div></summary></details>\n",                 limits->maxCullDistances                       );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>maxCombinedClipAndCullDistances         = <div class='val'>%u</div></summary></details>\n",                 limits->maxCombinedClipAndCullDistances        );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>discreteQueuePriorities                 = <div class='val'>%u</div></summary></details>\n",                 limits->discreteQueuePriorities                );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>pointSizeRange[0]                       = <div class='val'>%f</div></summary></details>\n",                 limits->pointSizeRange[0]                      );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>pointSizeRange[1]                       = <div class='val'>%f</div></summary></details>\n",                 limits->pointSizeRange[1]                      );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>lineWidthRange[0]                       = <div class='val'>%f</div></summary></details>\n",                 limits->lineWidthRange[0]                      );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>lineWidthRange[1]                       = <div class='val'>%f</div></summary></details>\n",                 limits->lineWidthRange[1]                      );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>pointSizeGranularity                    = <div class='val'>%f</div></summary></details>\n",                 limits->pointSizeGranularity                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>lineWidthGranularity                    = <div class='val'>%f</div></summary></details>\n",                 limits->lineWidthGranularity                   );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>strictLines                             = <div class='val'>%u</div></summary></details>\n",                 limits->strictLines                            );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>standardSampleLocations                 = <div class='val'>%u</div></summary></details>\n",                 limits->standardSampleLocations                );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>optimalBufferCopyOffsetAlignment        = <div class='val'>0x%" PRIxLEAST64 "</div></summary></details>\n", limits->optimalBufferCopyOffsetAlignment       );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>optimalBufferCopyRowPitchAlignment      = <div class='val'>0x%" PRIxLEAST64 "</div></summary></details>\n", limits->optimalBufferCopyRowPitchAlignment     );
-        fprintf(out, "\t\t\t\t\t\t<details><summary>nonCoherentAtomSize                     = <div class='val'>0x%" PRIxLEAST64 "</div></summary></details>\n", limits->nonCoherentAtomSize                    );
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxImageDimension1D                     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxImageDimension1D);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxImageDimension2D                     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxImageDimension2D);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxImageDimension3D                     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxImageDimension3D);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxImageDimensionCube                   = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxImageDimensionCube);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxImageArrayLayers                     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxImageArrayLayers);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxTexelBufferElements                  = <div class='val'>0x%" PRIxLEAST32
+                "</div></summary></details>\n",
+                limits->maxTexelBufferElements);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxUniformBufferRange                   = <div class='val'>0x%" PRIxLEAST32
+                "</div></summary></details>\n",
+                limits->maxUniformBufferRange);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxStorageBufferRange                   = <div class='val'>0x%" PRIxLEAST32
+                "</div></summary></details>\n",
+                limits->maxStorageBufferRange);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxPushConstantsSize                    = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxPushConstantsSize);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxMemoryAllocationCount                = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxMemoryAllocationCount);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxSamplerAllocationCount               = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxSamplerAllocationCount);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>bufferImageGranularity                  = <div class='val'>0x%" PRIxLEAST64
+                "</div></summary></details>\n",
+                limits->bufferImageGranularity);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sparseAddressSpaceSize                  = <div class='val'>0x%" PRIxLEAST64
+                "</div></summary></details>\n",
+                limits->sparseAddressSpaceSize);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxBoundDescriptorSets                  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxBoundDescriptorSets);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorSamplers           = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxPerStageDescriptorSamplers);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorUniformBuffers     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxPerStageDescriptorUniformBuffers);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorStorageBuffers     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxPerStageDescriptorStorageBuffers);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorSampledImages      = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxPerStageDescriptorSampledImages);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorStorageImages      = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxPerStageDescriptorStorageImages);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxPerStageDescriptorInputAttachments   = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxPerStageDescriptorInputAttachments);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxPerStageResources                    = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxPerStageResources);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxDescriptorSetSamplers                = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxDescriptorSetSamplers);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxDescriptorSetUniformBuffers          = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxDescriptorSetUniformBuffers);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxDescriptorSetUniformBuffersDynamic   = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxDescriptorSetUniformBuffersDynamic);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxDescriptorSetStorageBuffers          = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxDescriptorSetStorageBuffers);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxDescriptorSetStorageBuffersDynamic   = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxDescriptorSetStorageBuffersDynamic);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxDescriptorSetSampledImages           = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxDescriptorSetSampledImages);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxDescriptorSetStorageImages           = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxDescriptorSetStorageImages);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxDescriptorSetInputAttachments        = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxDescriptorSetInputAttachments);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxVertexInputAttributes                = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxVertexInputAttributes);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxVertexInputBindings                  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxVertexInputBindings);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxVertexInputAttributeOffset           = <div class='val'>0x%" PRIxLEAST32
+                "</div></summary></details>\n",
+                limits->maxVertexInputAttributeOffset);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxVertexInputBindingStride             = <div class='val'>0x%" PRIxLEAST32
+                "</div></summary></details>\n",
+                limits->maxVertexInputBindingStride);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxVertexOutputComponents               = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxVertexOutputComponents);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxTessellationGenerationLevel          = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxTessellationGenerationLevel);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxTessellationPatchSize                        = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxTessellationPatchSize);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxTessellationControlPerVertexInputComponents  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxTessellationControlPerVertexInputComponents);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxTessellationControlPerVertexOutputComponents = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxTessellationControlPerVertexOutputComponents);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxTessellationControlPerPatchOutputComponents  = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxTessellationControlPerPatchOutputComponents);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxTessellationControlTotalOutputComponents     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxTessellationControlTotalOutputComponents);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxTessellationEvaluationInputComponents        = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxTessellationEvaluationInputComponents);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxTessellationEvaluationOutputComponents       = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxTessellationEvaluationOutputComponents);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxGeometryShaderInvocations            = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxGeometryShaderInvocations);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxGeometryInputComponents              = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxGeometryInputComponents);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxGeometryOutputComponents             = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxGeometryOutputComponents);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxGeometryOutputVertices               = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxGeometryOutputVertices);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxGeometryTotalOutputComponents        = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxGeometryTotalOutputComponents);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxFragmentInputComponents              = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxFragmentInputComponents);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxFragmentOutputAttachments            = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxFragmentOutputAttachments);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxFragmentDualSrcAttachments           = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxFragmentDualSrcAttachments);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxFragmentCombinedOutputResources      = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxFragmentCombinedOutputResources);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxComputeSharedMemorySize              = <div class='val'>0x%" PRIxLEAST32
+                "</div></summary></details>\n",
+                limits->maxComputeSharedMemorySize);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupCount[0]             = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxComputeWorkGroupCount[0]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupCount[1]             = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxComputeWorkGroupCount[1]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupCount[2]             = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxComputeWorkGroupCount[2]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupInvocations          = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxComputeWorkGroupInvocations);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupSize[0]              = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxComputeWorkGroupSize[0]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupSize[1]              = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxComputeWorkGroupSize[1]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxComputeWorkGroupSize[2]              = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxComputeWorkGroupSize[2]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>subPixelPrecisionBits                   = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->subPixelPrecisionBits);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>subTexelPrecisionBits                   = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->subTexelPrecisionBits);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>mipmapPrecisionBits                     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->mipmapPrecisionBits);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxDrawIndexedIndexValue                = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxDrawIndexedIndexValue);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxDrawIndirectCount                    = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxDrawIndirectCount);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxSamplerLodBias                       = <div "
+                "class='val'>%f</div></summary></details>\n",
+                limits->maxSamplerLodBias);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxSamplerAnisotropy                    = <div "
+                "class='val'>%f</div></summary></details>\n",
+                limits->maxSamplerAnisotropy);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxViewports                            = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxViewports);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxViewportDimensions[0]                = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxViewportDimensions[0]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxViewportDimensions[1]                = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxViewportDimensions[1]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>viewportBoundsRange[0]                  = <div "
+                "class='val'>%13f</div></summary></details>\n",
+                limits->viewportBoundsRange[0]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>viewportBoundsRange[1]                  = <div "
+                "class='val'>%13f</div></summary></details>\n",
+                limits->viewportBoundsRange[1]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>viewportSubPixelBits                    = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->viewportSubPixelBits);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>minMemoryMapAlignment                   = <div class='val'>" PRINTF_SIZE_T_SPECIFIER
+                "</div></summary></details>\n",
+                limits->minMemoryMapAlignment);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>minTexelBufferOffsetAlignment           = <div class='val'>0x%" PRIxLEAST64
+                "</div></summary></details>\n",
+                limits->minTexelBufferOffsetAlignment);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>minUniformBufferOffsetAlignment         = <div class='val'>0x%" PRIxLEAST64
+                "</div></summary></details>\n",
+                limits->minUniformBufferOffsetAlignment);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>minStorageBufferOffsetAlignment         = <div class='val'>0x%" PRIxLEAST64
+                "</div></summary></details>\n",
+                limits->minStorageBufferOffsetAlignment);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>minTexelOffset                          = <div "
+                "class='val'>%3d</div></summary></details>\n",
+                limits->minTexelOffset);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxTexelOffset                          = <div "
+                "class='val'>%3d</div></summary></details>\n",
+                limits->maxTexelOffset);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>minTexelGatherOffset                    = <div "
+                "class='val'>%3d</div></summary></details>\n",
+                limits->minTexelGatherOffset);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxTexelGatherOffset                    = <div "
+                "class='val'>%3d</div></summary></details>\n",
+                limits->maxTexelGatherOffset);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>minInterpolationOffset                  = <div "
+                "class='val'>%9f</div></summary></details>\n",
+                limits->minInterpolationOffset);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxInterpolationOffset                  = <div "
+                "class='val'>%9f</div></summary></details>\n",
+                limits->maxInterpolationOffset);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>subPixelInterpolationOffsetBits         = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->subPixelInterpolationOffsetBits);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxFramebufferWidth                     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxFramebufferWidth);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxFramebufferHeight                    = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxFramebufferHeight);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxFramebufferLayers                    = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxFramebufferLayers);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>framebufferColorSampleCounts            = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->framebufferColorSampleCounts);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>framebufferDepthSampleCounts            = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->framebufferDepthSampleCounts);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>framebufferStencilSampleCounts          = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->framebufferStencilSampleCounts);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>framebufferNoAttachmentsSampleCounts    = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->framebufferNoAttachmentsSampleCounts);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxColorAttachments                     = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxColorAttachments);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sampledImageColorSampleCounts           = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->sampledImageColorSampleCounts);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sampledImageDepthSampleCounts           = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->sampledImageDepthSampleCounts);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sampledImageStencilSampleCounts         = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->sampledImageStencilSampleCounts);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>sampledImageIntegerSampleCounts         = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->sampledImageIntegerSampleCounts);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>storageImageSampleCounts                = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->storageImageSampleCounts);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxSampleMaskWords                      = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxSampleMaskWords);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>timestampComputeAndGraphics             = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->timestampComputeAndGraphics);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>timestampPeriod                         = <div "
+                "class='val'>%f</div></summary></details>\n",
+                limits->timestampPeriod);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxClipDistances                        = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxClipDistances);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxCullDistances                        = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxCullDistances);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>maxCombinedClipAndCullDistances         = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->maxCombinedClipAndCullDistances);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>discreteQueuePriorities                 = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->discreteQueuePriorities);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>pointSizeRange[0]                       = <div "
+                "class='val'>%f</div></summary></details>\n",
+                limits->pointSizeRange[0]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>pointSizeRange[1]                       = <div "
+                "class='val'>%f</div></summary></details>\n",
+                limits->pointSizeRange[1]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>lineWidthRange[0]                       = <div "
+                "class='val'>%f</div></summary></details>\n",
+                limits->lineWidthRange[0]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>lineWidthRange[1]                       = <div "
+                "class='val'>%f</div></summary></details>\n",
+                limits->lineWidthRange[1]);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>pointSizeGranularity                    = <div "
+                "class='val'>%f</div></summary></details>\n",
+                limits->pointSizeGranularity);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>lineWidthGranularity                    = <div "
+                "class='val'>%f</div></summary></details>\n",
+                limits->lineWidthGranularity);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>strictLines                             = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->strictLines);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>standardSampleLocations                 = <div "
+                "class='val'>%u</div></summary></details>\n",
+                limits->standardSampleLocations);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>optimalBufferCopyOffsetAlignment        = <div class='val'>0x%" PRIxLEAST64
+                "</div></summary></details>\n",
+                limits->optimalBufferCopyOffsetAlignment);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>optimalBufferCopyRowPitchAlignment      = <div class='val'>0x%" PRIxLEAST64
+                "</div></summary></details>\n",
+                limits->optimalBufferCopyRowPitchAlignment);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>nonCoherentAtomSize                     = <div class='val'>0x%" PRIxLEAST64
+                "</div></summary></details>\n",
+                limits->nonCoherentAtomSize);
         fprintf(out, "\t\t\t\t\t</details>\n");
     } else if (human_readable_output) {
         printf("\tVkPhysicalDeviceLimits:\n");
         printf("\t-----------------------\n");
-        printf("\t\tmaxImageDimension1D                     = %u\n",                 limits->maxImageDimension1D                    );
-        printf("\t\tmaxImageDimension2D                     = %u\n",                 limits->maxImageDimension2D                    );
-        printf("\t\tmaxImageDimension3D                     = %u\n",                 limits->maxImageDimension3D                    );
-        printf("\t\tmaxImageDimensionCube                   = %u\n",                 limits->maxImageDimensionCube                  );
-        printf("\t\tmaxImageArrayLayers                     = %u\n",                 limits->maxImageArrayLayers                    );
-        printf("\t\tmaxTexelBufferElements                  = 0x%" PRIxLEAST32 "\n", limits->maxTexelBufferElements                 );
-        printf("\t\tmaxUniformBufferRange                   = 0x%" PRIxLEAST32 "\n", limits->maxUniformBufferRange                  );
-        printf("\t\tmaxStorageBufferRange                   = 0x%" PRIxLEAST32 "\n", limits->maxStorageBufferRange                  );
-        printf("\t\tmaxPushConstantsSize                    = %u\n",                 limits->maxPushConstantsSize                   );
-        printf("\t\tmaxMemoryAllocationCount                = %u\n",                 limits->maxMemoryAllocationCount               );
-        printf("\t\tmaxSamplerAllocationCount               = %u\n",                 limits->maxSamplerAllocationCount              );
-        printf("\t\tbufferImageGranularity                  = 0x%" PRIxLEAST64 "\n", limits->bufferImageGranularity                 );
-        printf("\t\tsparseAddressSpaceSize                  = 0x%" PRIxLEAST64 "\n", limits->sparseAddressSpaceSize                 );
-        printf("\t\tmaxBoundDescriptorSets                  = %u\n",                 limits->maxBoundDescriptorSets                 );
-        printf("\t\tmaxPerStageDescriptorSamplers           = %u\n",                 limits->maxPerStageDescriptorSamplers          );
-        printf("\t\tmaxPerStageDescriptorUniformBuffers     = %u\n",                 limits->maxPerStageDescriptorUniformBuffers    );
-        printf("\t\tmaxPerStageDescriptorStorageBuffers     = %u\n",                 limits->maxPerStageDescriptorStorageBuffers    );
-        printf("\t\tmaxPerStageDescriptorSampledImages      = %u\n",                 limits->maxPerStageDescriptorSampledImages     );
-        printf("\t\tmaxPerStageDescriptorStorageImages      = %u\n",                 limits->maxPerStageDescriptorStorageImages     );
-        printf("\t\tmaxPerStageDescriptorInputAttachments   = %u\n",                 limits->maxPerStageDescriptorInputAttachments  );
-        printf("\t\tmaxPerStageResources                    = %u\n",                 limits->maxPerStageResources                   );
-        printf("\t\tmaxDescriptorSetSamplers                = %u\n",                 limits->maxDescriptorSetSamplers               );
-        printf("\t\tmaxDescriptorSetUniformBuffers          = %u\n",                 limits->maxDescriptorSetUniformBuffers         );
-        printf("\t\tmaxDescriptorSetUniformBuffersDynamic   = %u\n",                 limits->maxDescriptorSetUniformBuffersDynamic  );
-        printf("\t\tmaxDescriptorSetStorageBuffers          = %u\n",                 limits->maxDescriptorSetStorageBuffers         );
-        printf("\t\tmaxDescriptorSetStorageBuffersDynamic   = %u\n",                 limits->maxDescriptorSetStorageBuffersDynamic  );
-        printf("\t\tmaxDescriptorSetSampledImages           = %u\n",                 limits->maxDescriptorSetSampledImages          );
-        printf("\t\tmaxDescriptorSetStorageImages           = %u\n",                 limits->maxDescriptorSetStorageImages          );
-        printf("\t\tmaxDescriptorSetInputAttachments        = %u\n",                 limits->maxDescriptorSetInputAttachments       );
-        printf("\t\tmaxVertexInputAttributes                = %u\n",                 limits->maxVertexInputAttributes               );
-        printf("\t\tmaxVertexInputBindings                  = %u\n",                 limits->maxVertexInputBindings                 );
-        printf("\t\tmaxVertexInputAttributeOffset           = 0x%" PRIxLEAST32 "\n", limits->maxVertexInputAttributeOffset          );
-        printf("\t\tmaxVertexInputBindingStride             = 0x%" PRIxLEAST32 "\n", limits->maxVertexInputBindingStride            );
-        printf("\t\tmaxVertexOutputComponents               = %u\n",                 limits->maxVertexOutputComponents              );
-        printf("\t\tmaxTessellationGenerationLevel          = %u\n",                 limits->maxTessellationGenerationLevel         );
-        printf("\t\tmaxTessellationPatchSize                        = %u\n",                 limits->maxTessellationPatchSize                       );
-        printf("\t\tmaxTessellationControlPerVertexInputComponents  = %u\n",                 limits->maxTessellationControlPerVertexInputComponents );
-        printf("\t\tmaxTessellationControlPerVertexOutputComponents = %u\n",                 limits->maxTessellationControlPerVertexOutputComponents);
-        printf("\t\tmaxTessellationControlPerPatchOutputComponents  = %u\n",                 limits->maxTessellationControlPerPatchOutputComponents );
-        printf("\t\tmaxTessellationControlTotalOutputComponents     = %u\n",                 limits->maxTessellationControlTotalOutputComponents    );
-        printf("\t\tmaxTessellationEvaluationInputComponents        = %u\n",                 limits->maxTessellationEvaluationInputComponents       );
-        printf("\t\tmaxTessellationEvaluationOutputComponents       = %u\n",                 limits->maxTessellationEvaluationOutputComponents      );
-        printf("\t\tmaxGeometryShaderInvocations            = %u\n",                 limits->maxGeometryShaderInvocations           );
-        printf("\t\tmaxGeometryInputComponents              = %u\n",                 limits->maxGeometryInputComponents             );
-        printf("\t\tmaxGeometryOutputComponents             = %u\n",                 limits->maxGeometryOutputComponents            );
-        printf("\t\tmaxGeometryOutputVertices               = %u\n",                 limits->maxGeometryOutputVertices              );
-        printf("\t\tmaxGeometryTotalOutputComponents        = %u\n",                 limits->maxGeometryTotalOutputComponents       );
-        printf("\t\tmaxFragmentInputComponents              = %u\n",                 limits->maxFragmentInputComponents             );
-        printf("\t\tmaxFragmentOutputAttachments            = %u\n",                 limits->maxFragmentOutputAttachments           );
-        printf("\t\tmaxFragmentDualSrcAttachments           = %u\n",                 limits->maxFragmentDualSrcAttachments          );
-        printf("\t\tmaxFragmentCombinedOutputResources      = %u\n",                 limits->maxFragmentCombinedOutputResources     );
-        printf("\t\tmaxComputeSharedMemorySize              = 0x%" PRIxLEAST32 "\n", limits->maxComputeSharedMemorySize             );
-        printf("\t\tmaxComputeWorkGroupCount[0]             = %u\n",                 limits->maxComputeWorkGroupCount[0]            );
-        printf("\t\tmaxComputeWorkGroupCount[1]             = %u\n",                 limits->maxComputeWorkGroupCount[1]            );
-        printf("\t\tmaxComputeWorkGroupCount[2]             = %u\n",                 limits->maxComputeWorkGroupCount[2]            );
-        printf("\t\tmaxComputeWorkGroupInvocations          = %u\n",                 limits->maxComputeWorkGroupInvocations         );
-        printf("\t\tmaxComputeWorkGroupSize[0]              = %u\n",                 limits->maxComputeWorkGroupSize[0]             );
-        printf("\t\tmaxComputeWorkGroupSize[1]              = %u\n",                 limits->maxComputeWorkGroupSize[1]             );
-        printf("\t\tmaxComputeWorkGroupSize[2]              = %u\n",                 limits->maxComputeWorkGroupSize[2]             );
-        printf("\t\tsubPixelPrecisionBits                   = %u\n",                 limits->subPixelPrecisionBits                  );
-        printf("\t\tsubTexelPrecisionBits                   = %u\n",                 limits->subTexelPrecisionBits                  );
-        printf("\t\tmipmapPrecisionBits                     = %u\n",                 limits->mipmapPrecisionBits                    );
-        printf("\t\tmaxDrawIndexedIndexValue                = %u\n",                 limits->maxDrawIndexedIndexValue               );
-        printf("\t\tmaxDrawIndirectCount                    = %u\n",                 limits->maxDrawIndirectCount                   );
-        printf("\t\tmaxSamplerLodBias                       = %f\n",                 limits->maxSamplerLodBias                      );
-        printf("\t\tmaxSamplerAnisotropy                    = %f\n",                 limits->maxSamplerAnisotropy                   );
-        printf("\t\tmaxViewports                            = %u\n",                 limits->maxViewports                           );
-        printf("\t\tmaxViewportDimensions[0]                = %u\n",                 limits->maxViewportDimensions[0]               );
-        printf("\t\tmaxViewportDimensions[1]                = %u\n",                 limits->maxViewportDimensions[1]               );
-        printf("\t\tviewportBoundsRange[0]                  = %13f\n",               limits->viewportBoundsRange[0]                 );
-        printf("\t\tviewportBoundsRange[1]                  = %13f\n",               limits->viewportBoundsRange[1]                 );
-        printf("\t\tviewportSubPixelBits                    = %u\n",                 limits->viewportSubPixelBits                   );
-        printf("\t\tminMemoryMapAlignment                   = " PRINTF_SIZE_T_SPECIFIER "\n", limits->minMemoryMapAlignment         );
-        printf("\t\tminTexelBufferOffsetAlignment           = 0x%" PRIxLEAST64 "\n", limits->minTexelBufferOffsetAlignment          );
-        printf("\t\tminUniformBufferOffsetAlignment         = 0x%" PRIxLEAST64 "\n", limits->minUniformBufferOffsetAlignment        );
-        printf("\t\tminStorageBufferOffsetAlignment         = 0x%" PRIxLEAST64 "\n", limits->minStorageBufferOffsetAlignment        );
-        printf("\t\tminTexelOffset                          = %3d\n",                limits->minTexelOffset                         );
-        printf("\t\tmaxTexelOffset                          = %3d\n",                limits->maxTexelOffset                         );
-        printf("\t\tminTexelGatherOffset                    = %3d\n",                limits->minTexelGatherOffset                   );
-        printf("\t\tmaxTexelGatherOffset                    = %3d\n",                limits->maxTexelGatherOffset                   );
-        printf("\t\tminInterpolationOffset                  = %9f\n",                limits->minInterpolationOffset                 );
-        printf("\t\tmaxInterpolationOffset                  = %9f\n",                limits->maxInterpolationOffset                 );
-        printf("\t\tsubPixelInterpolationOffsetBits         = %u\n",                 limits->subPixelInterpolationOffsetBits        );
-        printf("\t\tmaxFramebufferWidth                     = %u\n",                 limits->maxFramebufferWidth                    );
-        printf("\t\tmaxFramebufferHeight                    = %u\n",                 limits->maxFramebufferHeight                   );
-        printf("\t\tmaxFramebufferLayers                    = %u\n",                 limits->maxFramebufferLayers                   );
-        printf("\t\tframebufferColorSampleCounts            = %u\n",                 limits->framebufferColorSampleCounts           );
-        printf("\t\tframebufferDepthSampleCounts            = %u\n",                 limits->framebufferDepthSampleCounts           );
-        printf("\t\tframebufferStencilSampleCounts          = %u\n",                 limits->framebufferStencilSampleCounts         );
-        printf("\t\tframebufferNoAttachmentsSampleCounts    = %u\n",                 limits->framebufferNoAttachmentsSampleCounts   );
-        printf("\t\tmaxColorAttachments                     = %u\n",                 limits->maxColorAttachments                    );
-        printf("\t\tsampledImageColorSampleCounts           = %u\n",                 limits->sampledImageColorSampleCounts          );
-        printf("\t\tsampledImageDepthSampleCounts           = %u\n",                 limits->sampledImageDepthSampleCounts          );
-        printf("\t\tsampledImageStencilSampleCounts         = %u\n",                 limits->sampledImageStencilSampleCounts        );
-        printf("\t\tsampledImageIntegerSampleCounts         = %u\n",                 limits->sampledImageIntegerSampleCounts        );
-        printf("\t\tstorageImageSampleCounts                = %u\n",                 limits->storageImageSampleCounts               );
-        printf("\t\tmaxSampleMaskWords                      = %u\n",                 limits->maxSampleMaskWords                     );
-        printf("\t\ttimestampComputeAndGraphics             = %u\n",                 limits->timestampComputeAndGraphics            );
-        printf("\t\ttimestampPeriod                         = %f\n",                 limits->timestampPeriod                        );
-        printf("\t\tmaxClipDistances                        = %u\n",                 limits->maxClipDistances                       );
-        printf("\t\tmaxCullDistances                        = %u\n",                 limits->maxCullDistances                       );
-        printf("\t\tmaxCombinedClipAndCullDistances         = %u\n",                 limits->maxCombinedClipAndCullDistances        );
-        printf("\t\tdiscreteQueuePriorities                 = %u\n",                 limits->discreteQueuePriorities                );
-        printf("\t\tpointSizeRange[0]                       = %f\n",                 limits->pointSizeRange[0]                      );
-        printf("\t\tpointSizeRange[1]                       = %f\n",                 limits->pointSizeRange[1]                      );
-        printf("\t\tlineWidthRange[0]                       = %f\n",                 limits->lineWidthRange[0]                      );
-        printf("\t\tlineWidthRange[1]                       = %f\n",                 limits->lineWidthRange[1]                      );
-        printf("\t\tpointSizeGranularity                    = %f\n",                 limits->pointSizeGranularity                   );
-        printf("\t\tlineWidthGranularity                    = %f\n",                 limits->lineWidthGranularity                   );
-        printf("\t\tstrictLines                             = %u\n",                 limits->strictLines                            );
-        printf("\t\tstandardSampleLocations                 = %u\n",                 limits->standardSampleLocations                );
-        printf("\t\toptimalBufferCopyOffsetAlignment        = 0x%" PRIxLEAST64 "\n", limits->optimalBufferCopyOffsetAlignment       );
-        printf("\t\toptimalBufferCopyRowPitchAlignment      = 0x%" PRIxLEAST64 "\n", limits->optimalBufferCopyRowPitchAlignment     );
-        printf("\t\tnonCoherentAtomSize                     = 0x%" PRIxLEAST64 "\n", limits->nonCoherentAtomSize                    );
+        printf("\t\tmaxImageDimension1D                     = %u\n", limits->maxImageDimension1D);
+        printf("\t\tmaxImageDimension2D                     = %u\n", limits->maxImageDimension2D);
+        printf("\t\tmaxImageDimension3D                     = %u\n", limits->maxImageDimension3D);
+        printf("\t\tmaxImageDimensionCube                   = %u\n", limits->maxImageDimensionCube);
+        printf("\t\tmaxImageArrayLayers                     = %u\n", limits->maxImageArrayLayers);
+        printf("\t\tmaxTexelBufferElements                  = 0x%" PRIxLEAST32 "\n", limits->maxTexelBufferElements);
+        printf("\t\tmaxUniformBufferRange                   = 0x%" PRIxLEAST32 "\n", limits->maxUniformBufferRange);
+        printf("\t\tmaxStorageBufferRange                   = 0x%" PRIxLEAST32 "\n", limits->maxStorageBufferRange);
+        printf("\t\tmaxPushConstantsSize                    = %u\n", limits->maxPushConstantsSize);
+        printf("\t\tmaxMemoryAllocationCount                = %u\n", limits->maxMemoryAllocationCount);
+        printf("\t\tmaxSamplerAllocationCount               = %u\n", limits->maxSamplerAllocationCount);
+        printf("\t\tbufferImageGranularity                  = 0x%" PRIxLEAST64 "\n", limits->bufferImageGranularity);
+        printf("\t\tsparseAddressSpaceSize                  = 0x%" PRIxLEAST64 "\n", limits->sparseAddressSpaceSize);
+        printf("\t\tmaxBoundDescriptorSets                  = %u\n", limits->maxBoundDescriptorSets);
+        printf("\t\tmaxPerStageDescriptorSamplers           = %u\n", limits->maxPerStageDescriptorSamplers);
+        printf("\t\tmaxPerStageDescriptorUniformBuffers     = %u\n", limits->maxPerStageDescriptorUniformBuffers);
+        printf("\t\tmaxPerStageDescriptorStorageBuffers     = %u\n", limits->maxPerStageDescriptorStorageBuffers);
+        printf("\t\tmaxPerStageDescriptorSampledImages      = %u\n", limits->maxPerStageDescriptorSampledImages);
+        printf("\t\tmaxPerStageDescriptorStorageImages      = %u\n", limits->maxPerStageDescriptorStorageImages);
+        printf("\t\tmaxPerStageDescriptorInputAttachments   = %u\n", limits->maxPerStageDescriptorInputAttachments);
+        printf("\t\tmaxPerStageResources                    = %u\n", limits->maxPerStageResources);
+        printf("\t\tmaxDescriptorSetSamplers                = %u\n", limits->maxDescriptorSetSamplers);
+        printf("\t\tmaxDescriptorSetUniformBuffers          = %u\n", limits->maxDescriptorSetUniformBuffers);
+        printf("\t\tmaxDescriptorSetUniformBuffersDynamic   = %u\n", limits->maxDescriptorSetUniformBuffersDynamic);
+        printf("\t\tmaxDescriptorSetStorageBuffers          = %u\n", limits->maxDescriptorSetStorageBuffers);
+        printf("\t\tmaxDescriptorSetStorageBuffersDynamic   = %u\n", limits->maxDescriptorSetStorageBuffersDynamic);
+        printf("\t\tmaxDescriptorSetSampledImages           = %u\n", limits->maxDescriptorSetSampledImages);
+        printf("\t\tmaxDescriptorSetStorageImages           = %u\n", limits->maxDescriptorSetStorageImages);
+        printf("\t\tmaxDescriptorSetInputAttachments        = %u\n", limits->maxDescriptorSetInputAttachments);
+        printf("\t\tmaxVertexInputAttributes                = %u\n", limits->maxVertexInputAttributes);
+        printf("\t\tmaxVertexInputBindings                  = %u\n", limits->maxVertexInputBindings);
+        printf("\t\tmaxVertexInputAttributeOffset           = 0x%" PRIxLEAST32 "\n", limits->maxVertexInputAttributeOffset);
+        printf("\t\tmaxVertexInputBindingStride             = 0x%" PRIxLEAST32 "\n", limits->maxVertexInputBindingStride);
+        printf("\t\tmaxVertexOutputComponents               = %u\n", limits->maxVertexOutputComponents);
+        printf("\t\tmaxTessellationGenerationLevel          = %u\n", limits->maxTessellationGenerationLevel);
+        printf("\t\tmaxTessellationPatchSize                        = %u\n", limits->maxTessellationPatchSize);
+        printf("\t\tmaxTessellationControlPerVertexInputComponents  = %u\n",
+               limits->maxTessellationControlPerVertexInputComponents);
+        printf("\t\tmaxTessellationControlPerVertexOutputComponents = %u\n",
+               limits->maxTessellationControlPerVertexOutputComponents);
+        printf("\t\tmaxTessellationControlPerPatchOutputComponents  = %u\n",
+               limits->maxTessellationControlPerPatchOutputComponents);
+        printf("\t\tmaxTessellationControlTotalOutputComponents     = %u\n", limits->maxTessellationControlTotalOutputComponents);
+        printf("\t\tmaxTessellationEvaluationInputComponents        = %u\n", limits->maxTessellationEvaluationInputComponents);
+        printf("\t\tmaxTessellationEvaluationOutputComponents       = %u\n", limits->maxTessellationEvaluationOutputComponents);
+        printf("\t\tmaxGeometryShaderInvocations            = %u\n", limits->maxGeometryShaderInvocations);
+        printf("\t\tmaxGeometryInputComponents              = %u\n", limits->maxGeometryInputComponents);
+        printf("\t\tmaxGeometryOutputComponents             = %u\n", limits->maxGeometryOutputComponents);
+        printf("\t\tmaxGeometryOutputVertices               = %u\n", limits->maxGeometryOutputVertices);
+        printf("\t\tmaxGeometryTotalOutputComponents        = %u\n", limits->maxGeometryTotalOutputComponents);
+        printf("\t\tmaxFragmentInputComponents              = %u\n", limits->maxFragmentInputComponents);
+        printf("\t\tmaxFragmentOutputAttachments            = %u\n", limits->maxFragmentOutputAttachments);
+        printf("\t\tmaxFragmentDualSrcAttachments           = %u\n", limits->maxFragmentDualSrcAttachments);
+        printf("\t\tmaxFragmentCombinedOutputResources      = %u\n", limits->maxFragmentCombinedOutputResources);
+        printf("\t\tmaxComputeSharedMemorySize              = 0x%" PRIxLEAST32 "\n", limits->maxComputeSharedMemorySize);
+        printf("\t\tmaxComputeWorkGroupCount[0]             = %u\n", limits->maxComputeWorkGroupCount[0]);
+        printf("\t\tmaxComputeWorkGroupCount[1]             = %u\n", limits->maxComputeWorkGroupCount[1]);
+        printf("\t\tmaxComputeWorkGroupCount[2]             = %u\n", limits->maxComputeWorkGroupCount[2]);
+        printf("\t\tmaxComputeWorkGroupInvocations          = %u\n", limits->maxComputeWorkGroupInvocations);
+        printf("\t\tmaxComputeWorkGroupSize[0]              = %u\n", limits->maxComputeWorkGroupSize[0]);
+        printf("\t\tmaxComputeWorkGroupSize[1]              = %u\n", limits->maxComputeWorkGroupSize[1]);
+        printf("\t\tmaxComputeWorkGroupSize[2]              = %u\n", limits->maxComputeWorkGroupSize[2]);
+        printf("\t\tsubPixelPrecisionBits                   = %u\n", limits->subPixelPrecisionBits);
+        printf("\t\tsubTexelPrecisionBits                   = %u\n", limits->subTexelPrecisionBits);
+        printf("\t\tmipmapPrecisionBits                     = %u\n", limits->mipmapPrecisionBits);
+        printf("\t\tmaxDrawIndexedIndexValue                = %u\n", limits->maxDrawIndexedIndexValue);
+        printf("\t\tmaxDrawIndirectCount                    = %u\n", limits->maxDrawIndirectCount);
+        printf("\t\tmaxSamplerLodBias                       = %f\n", limits->maxSamplerLodBias);
+        printf("\t\tmaxSamplerAnisotropy                    = %f\n", limits->maxSamplerAnisotropy);
+        printf("\t\tmaxViewports                            = %u\n", limits->maxViewports);
+        printf("\t\tmaxViewportDimensions[0]                = %u\n", limits->maxViewportDimensions[0]);
+        printf("\t\tmaxViewportDimensions[1]                = %u\n", limits->maxViewportDimensions[1]);
+        printf("\t\tviewportBoundsRange[0]                  = %13f\n", limits->viewportBoundsRange[0]);
+        printf("\t\tviewportBoundsRange[1]                  = %13f\n", limits->viewportBoundsRange[1]);
+        printf("\t\tviewportSubPixelBits                    = %u\n", limits->viewportSubPixelBits);
+        printf("\t\tminMemoryMapAlignment                   = " PRINTF_SIZE_T_SPECIFIER "\n", limits->minMemoryMapAlignment);
+        printf("\t\tminTexelBufferOffsetAlignment           = 0x%" PRIxLEAST64 "\n", limits->minTexelBufferOffsetAlignment);
+        printf("\t\tminUniformBufferOffsetAlignment         = 0x%" PRIxLEAST64 "\n", limits->minUniformBufferOffsetAlignment);
+        printf("\t\tminStorageBufferOffsetAlignment         = 0x%" PRIxLEAST64 "\n", limits->minStorageBufferOffsetAlignment);
+        printf("\t\tminTexelOffset                          = %3d\n", limits->minTexelOffset);
+        printf("\t\tmaxTexelOffset                          = %3d\n", limits->maxTexelOffset);
+        printf("\t\tminTexelGatherOffset                    = %3d\n", limits->minTexelGatherOffset);
+        printf("\t\tmaxTexelGatherOffset                    = %3d\n", limits->maxTexelGatherOffset);
+        printf("\t\tminInterpolationOffset                  = %9f\n", limits->minInterpolationOffset);
+        printf("\t\tmaxInterpolationOffset                  = %9f\n", limits->maxInterpolationOffset);
+        printf("\t\tsubPixelInterpolationOffsetBits         = %u\n", limits->subPixelInterpolationOffsetBits);
+        printf("\t\tmaxFramebufferWidth                     = %u\n", limits->maxFramebufferWidth);
+        printf("\t\tmaxFramebufferHeight                    = %u\n", limits->maxFramebufferHeight);
+        printf("\t\tmaxFramebufferLayers                    = %u\n", limits->maxFramebufferLayers);
+        printf("\t\tframebufferColorSampleCounts            = %u\n", limits->framebufferColorSampleCounts);
+        printf("\t\tframebufferDepthSampleCounts            = %u\n", limits->framebufferDepthSampleCounts);
+        printf("\t\tframebufferStencilSampleCounts          = %u\n", limits->framebufferStencilSampleCounts);
+        printf("\t\tframebufferNoAttachmentsSampleCounts    = %u\n", limits->framebufferNoAttachmentsSampleCounts);
+        printf("\t\tmaxColorAttachments                     = %u\n", limits->maxColorAttachments);
+        printf("\t\tsampledImageColorSampleCounts           = %u\n", limits->sampledImageColorSampleCounts);
+        printf("\t\tsampledImageDepthSampleCounts           = %u\n", limits->sampledImageDepthSampleCounts);
+        printf("\t\tsampledImageStencilSampleCounts         = %u\n", limits->sampledImageStencilSampleCounts);
+        printf("\t\tsampledImageIntegerSampleCounts         = %u\n", limits->sampledImageIntegerSampleCounts);
+        printf("\t\tstorageImageSampleCounts                = %u\n", limits->storageImageSampleCounts);
+        printf("\t\tmaxSampleMaskWords                      = %u\n", limits->maxSampleMaskWords);
+        printf("\t\ttimestampComputeAndGraphics             = %u\n", limits->timestampComputeAndGraphics);
+        printf("\t\ttimestampPeriod                         = %f\n", limits->timestampPeriod);
+        printf("\t\tmaxClipDistances                        = %u\n", limits->maxClipDistances);
+        printf("\t\tmaxCullDistances                        = %u\n", limits->maxCullDistances);
+        printf("\t\tmaxCombinedClipAndCullDistances         = %u\n", limits->maxCombinedClipAndCullDistances);
+        printf("\t\tdiscreteQueuePriorities                 = %u\n", limits->discreteQueuePriorities);
+        printf("\t\tpointSizeRange[0]                       = %f\n", limits->pointSizeRange[0]);
+        printf("\t\tpointSizeRange[1]                       = %f\n", limits->pointSizeRange[1]);
+        printf("\t\tlineWidthRange[0]                       = %f\n", limits->lineWidthRange[0]);
+        printf("\t\tlineWidthRange[1]                       = %f\n", limits->lineWidthRange[1]);
+        printf("\t\tpointSizeGranularity                    = %f\n", limits->pointSizeGranularity);
+        printf("\t\tlineWidthGranularity                    = %f\n", limits->lineWidthGranularity);
+        printf("\t\tstrictLines                             = %u\n", limits->strictLines);
+        printf("\t\tstandardSampleLocations                 = %u\n", limits->standardSampleLocations);
+        printf("\t\toptimalBufferCopyOffsetAlignment        = 0x%" PRIxLEAST64 "\n", limits->optimalBufferCopyOffsetAlignment);
+        printf("\t\toptimalBufferCopyRowPitchAlignment      = 0x%" PRIxLEAST64 "\n", limits->optimalBufferCopyRowPitchAlignment);
+        printf("\t\tnonCoherentAtomSize                     = 0x%" PRIxLEAST64 "\n", limits->nonCoherentAtomSize);
     }
     if (json_output) {
         printf(",\n");
         printf("\t\t\"limits\": {\n");
-        printf("\t\t\t\"maxImageDimension1D\": %u,\n",                                    limits->maxImageDimension1D);
-        printf("\t\t\t\"maxImageDimension2D\": %u,\n",                                    limits->maxImageDimension2D);
-        printf("\t\t\t\"maxImageDimension3D\": %u,\n",                                    limits->maxImageDimension3D);
-        printf("\t\t\t\"maxImageDimensionCube\": %u,\n",                                  limits->maxImageDimensionCube);
-        printf("\t\t\t\"maxImageArrayLayers\": %u,\n",                                    limits->maxImageArrayLayers);
-        printf("\t\t\t\"maxTexelBufferElements\": %u,\n",                                 limits->maxTexelBufferElements);
-        printf("\t\t\t\"maxUniformBufferRange\": %u,\n",                                  limits->maxUniformBufferRange);
-        printf("\t\t\t\"maxStorageBufferRange\": %u,\n",                                  limits->maxStorageBufferRange);
-        printf("\t\t\t\"maxPushConstantsSize\": %u,\n",                                   limits->maxPushConstantsSize);
-        printf("\t\t\t\"maxMemoryAllocationCount\": %u,\n",                               limits->maxMemoryAllocationCount);
-        printf("\t\t\t\"maxSamplerAllocationCount\": %u,\n",                              limits->maxSamplerAllocationCount);
-        printf("\t\t\t\"bufferImageGranularity\": %llu,\n",                               (unsigned long long)limits->bufferImageGranularity);
-        printf("\t\t\t\"sparseAddressSpaceSize\": %llu,\n",                               (unsigned long long)limits->sparseAddressSpaceSize);
-        printf("\t\t\t\"maxBoundDescriptorSets\": %u,\n",                                 limits->maxBoundDescriptorSets);
-        printf("\t\t\t\"maxPerStageDescriptorSamplers\": %u,\n",                          limits->maxPerStageDescriptorSamplers);
-        printf("\t\t\t\"maxPerStageDescriptorUniformBuffers\": %u,\n",                    limits->maxPerStageDescriptorUniformBuffers);
-        printf("\t\t\t\"maxPerStageDescriptorStorageBuffers\": %u,\n",                    limits->maxPerStageDescriptorStorageBuffers);
-        printf("\t\t\t\"maxPerStageDescriptorSampledImages\": %u,\n",                     limits->maxPerStageDescriptorSampledImages);
-        printf("\t\t\t\"maxPerStageDescriptorStorageImages\": %u,\n",                     limits->maxPerStageDescriptorStorageImages);
-        printf("\t\t\t\"maxPerStageDescriptorInputAttachments\": %u,\n",                  limits->maxPerStageDescriptorInputAttachments);
-        printf("\t\t\t\"maxPerStageResources\": %u,\n",                                   limits->maxPerStageResources);
-        printf("\t\t\t\"maxDescriptorSetSamplers\": %u,\n",                               limits->maxDescriptorSetSamplers);
-        printf("\t\t\t\"maxDescriptorSetUniformBuffers\": %u,\n",                         limits->maxDescriptorSetUniformBuffers);
-        printf("\t\t\t\"maxDescriptorSetUniformBuffersDynamic\": %u,\n",                  limits->maxDescriptorSetUniformBuffersDynamic);
-        printf("\t\t\t\"maxDescriptorSetStorageBuffers\": %u,\n",                         limits->maxDescriptorSetStorageBuffers);
-        printf("\t\t\t\"maxDescriptorSetStorageBuffersDynamic\": %u,\n",                  limits->maxDescriptorSetStorageBuffersDynamic);
-        printf("\t\t\t\"maxDescriptorSetSampledImages\": %u,\n",                          limits->maxDescriptorSetSampledImages);
-        printf("\t\t\t\"maxDescriptorSetStorageImages\": %u,\n",                          limits->maxDescriptorSetStorageImages);
-        printf("\t\t\t\"maxDescriptorSetInputAttachments\": %u,\n",                       limits->maxDescriptorSetInputAttachments);
-        printf("\t\t\t\"maxVertexInputAttributes\": %u,\n",                               limits->maxVertexInputAttributes);
-        printf("\t\t\t\"maxVertexInputBindings\": %u,\n",                                 limits->maxVertexInputBindings);
-        printf("\t\t\t\"maxVertexInputAttributeOffset\": %u,\n",                          limits->maxVertexInputAttributeOffset);
-        printf("\t\t\t\"maxVertexInputBindingStride\": %u,\n",                            limits->maxVertexInputBindingStride);
-        printf("\t\t\t\"maxVertexOutputComponents\": %u,\n",                              limits->maxVertexOutputComponents);
-        printf("\t\t\t\"maxTessellationGenerationLevel\": %u,\n",                         limits->maxTessellationGenerationLevel);
-        printf("\t\t\t\"maxTessellationPatchSize\": %u,\n",                               limits->maxTessellationPatchSize);
-        printf("\t\t\t\"maxTessellationControlPerVertexInputComponents\": %u,\n",         limits->maxTessellationControlPerVertexInputComponents);
-        printf("\t\t\t\"maxTessellationControlPerVertexOutputComponents\": %u,\n",        limits->maxTessellationControlPerVertexOutputComponents);
-        printf("\t\t\t\"maxTessellationControlPerPatchOutputComponents\": %u,\n",         limits->maxTessellationControlPerPatchOutputComponents);
-        printf("\t\t\t\"maxTessellationControlTotalOutputComponents\": %u,\n",            limits->maxTessellationControlTotalOutputComponents);
-        printf("\t\t\t\"maxTessellationEvaluationInputComponents\": %u,\n",               limits->maxTessellationEvaluationInputComponents);
-        printf("\t\t\t\"maxTessellationEvaluationOutputComponents\": %u,\n",              limits->maxTessellationEvaluationOutputComponents);
-        printf("\t\t\t\"maxGeometryShaderInvocations\": %u,\n",                           limits->maxGeometryShaderInvocations);
-        printf("\t\t\t\"maxGeometryInputComponents\": %u,\n",                             limits->maxGeometryInputComponents);
-        printf("\t\t\t\"maxGeometryOutputComponents\": %u,\n",                            limits->maxGeometryOutputComponents);
-        printf("\t\t\t\"maxGeometryOutputVertices\": %u,\n",                              limits->maxGeometryOutputVertices);
-        printf("\t\t\t\"maxGeometryTotalOutputComponents\": %u,\n",                       limits->maxGeometryTotalOutputComponents);
-        printf("\t\t\t\"maxFragmentInputComponents\": %u,\n",                             limits->maxFragmentInputComponents);
-        printf("\t\t\t\"maxFragmentOutputAttachments\": %u,\n",                           limits->maxFragmentOutputAttachments);
-        printf("\t\t\t\"maxFragmentDualSrcAttachments\": %u,\n",                          limits->maxFragmentDualSrcAttachments);
-        printf("\t\t\t\"maxFragmentCombinedOutputResources\": %u,\n",                     limits->maxFragmentCombinedOutputResources);
-        printf("\t\t\t\"maxComputeSharedMemorySize\": %u,\n",                             limits->maxComputeSharedMemorySize);
+        printf("\t\t\t\"maxImageDimension1D\": %u,\n", limits->maxImageDimension1D);
+        printf("\t\t\t\"maxImageDimension2D\": %u,\n", limits->maxImageDimension2D);
+        printf("\t\t\t\"maxImageDimension3D\": %u,\n", limits->maxImageDimension3D);
+        printf("\t\t\t\"maxImageDimensionCube\": %u,\n", limits->maxImageDimensionCube);
+        printf("\t\t\t\"maxImageArrayLayers\": %u,\n", limits->maxImageArrayLayers);
+        printf("\t\t\t\"maxTexelBufferElements\": %u,\n", limits->maxTexelBufferElements);
+        printf("\t\t\t\"maxUniformBufferRange\": %u,\n", limits->maxUniformBufferRange);
+        printf("\t\t\t\"maxStorageBufferRange\": %u,\n", limits->maxStorageBufferRange);
+        printf("\t\t\t\"maxPushConstantsSize\": %u,\n", limits->maxPushConstantsSize);
+        printf("\t\t\t\"maxMemoryAllocationCount\": %u,\n", limits->maxMemoryAllocationCount);
+        printf("\t\t\t\"maxSamplerAllocationCount\": %u,\n", limits->maxSamplerAllocationCount);
+        printf("\t\t\t\"bufferImageGranularity\": %llu,\n", (unsigned long long)limits->bufferImageGranularity);
+        printf("\t\t\t\"sparseAddressSpaceSize\": %llu,\n", (unsigned long long)limits->sparseAddressSpaceSize);
+        printf("\t\t\t\"maxBoundDescriptorSets\": %u,\n", limits->maxBoundDescriptorSets);
+        printf("\t\t\t\"maxPerStageDescriptorSamplers\": %u,\n", limits->maxPerStageDescriptorSamplers);
+        printf("\t\t\t\"maxPerStageDescriptorUniformBuffers\": %u,\n", limits->maxPerStageDescriptorUniformBuffers);
+        printf("\t\t\t\"maxPerStageDescriptorStorageBuffers\": %u,\n", limits->maxPerStageDescriptorStorageBuffers);
+        printf("\t\t\t\"maxPerStageDescriptorSampledImages\": %u,\n", limits->maxPerStageDescriptorSampledImages);
+        printf("\t\t\t\"maxPerStageDescriptorStorageImages\": %u,\n", limits->maxPerStageDescriptorStorageImages);
+        printf("\t\t\t\"maxPerStageDescriptorInputAttachments\": %u,\n", limits->maxPerStageDescriptorInputAttachments);
+        printf("\t\t\t\"maxPerStageResources\": %u,\n", limits->maxPerStageResources);
+        printf("\t\t\t\"maxDescriptorSetSamplers\": %u,\n", limits->maxDescriptorSetSamplers);
+        printf("\t\t\t\"maxDescriptorSetUniformBuffers\": %u,\n", limits->maxDescriptorSetUniformBuffers);
+        printf("\t\t\t\"maxDescriptorSetUniformBuffersDynamic\": %u,\n", limits->maxDescriptorSetUniformBuffersDynamic);
+        printf("\t\t\t\"maxDescriptorSetStorageBuffers\": %u,\n", limits->maxDescriptorSetStorageBuffers);
+        printf("\t\t\t\"maxDescriptorSetStorageBuffersDynamic\": %u,\n", limits->maxDescriptorSetStorageBuffersDynamic);
+        printf("\t\t\t\"maxDescriptorSetSampledImages\": %u,\n", limits->maxDescriptorSetSampledImages);
+        printf("\t\t\t\"maxDescriptorSetStorageImages\": %u,\n", limits->maxDescriptorSetStorageImages);
+        printf("\t\t\t\"maxDescriptorSetInputAttachments\": %u,\n", limits->maxDescriptorSetInputAttachments);
+        printf("\t\t\t\"maxVertexInputAttributes\": %u,\n", limits->maxVertexInputAttributes);
+        printf("\t\t\t\"maxVertexInputBindings\": %u,\n", limits->maxVertexInputBindings);
+        printf("\t\t\t\"maxVertexInputAttributeOffset\": %u,\n", limits->maxVertexInputAttributeOffset);
+        printf("\t\t\t\"maxVertexInputBindingStride\": %u,\n", limits->maxVertexInputBindingStride);
+        printf("\t\t\t\"maxVertexOutputComponents\": %u,\n", limits->maxVertexOutputComponents);
+        printf("\t\t\t\"maxTessellationGenerationLevel\": %u,\n", limits->maxTessellationGenerationLevel);
+        printf("\t\t\t\"maxTessellationPatchSize\": %u,\n", limits->maxTessellationPatchSize);
+        printf("\t\t\t\"maxTessellationControlPerVertexInputComponents\": %u,\n",
+               limits->maxTessellationControlPerVertexInputComponents);
+        printf("\t\t\t\"maxTessellationControlPerVertexOutputComponents\": %u,\n",
+               limits->maxTessellationControlPerVertexOutputComponents);
+        printf("\t\t\t\"maxTessellationControlPerPatchOutputComponents\": %u,\n",
+               limits->maxTessellationControlPerPatchOutputComponents);
+        printf("\t\t\t\"maxTessellationControlTotalOutputComponents\": %u,\n", limits->maxTessellationControlTotalOutputComponents);
+        printf("\t\t\t\"maxTessellationEvaluationInputComponents\": %u,\n", limits->maxTessellationEvaluationInputComponents);
+        printf("\t\t\t\"maxTessellationEvaluationOutputComponents\": %u,\n", limits->maxTessellationEvaluationOutputComponents);
+        printf("\t\t\t\"maxGeometryShaderInvocations\": %u,\n", limits->maxGeometryShaderInvocations);
+        printf("\t\t\t\"maxGeometryInputComponents\": %u,\n", limits->maxGeometryInputComponents);
+        printf("\t\t\t\"maxGeometryOutputComponents\": %u,\n", limits->maxGeometryOutputComponents);
+        printf("\t\t\t\"maxGeometryOutputVertices\": %u,\n", limits->maxGeometryOutputVertices);
+        printf("\t\t\t\"maxGeometryTotalOutputComponents\": %u,\n", limits->maxGeometryTotalOutputComponents);
+        printf("\t\t\t\"maxFragmentInputComponents\": %u,\n", limits->maxFragmentInputComponents);
+        printf("\t\t\t\"maxFragmentOutputAttachments\": %u,\n", limits->maxFragmentOutputAttachments);
+        printf("\t\t\t\"maxFragmentDualSrcAttachments\": %u,\n", limits->maxFragmentDualSrcAttachments);
+        printf("\t\t\t\"maxFragmentCombinedOutputResources\": %u,\n", limits->maxFragmentCombinedOutputResources);
+        printf("\t\t\t\"maxComputeSharedMemorySize\": %u,\n", limits->maxComputeSharedMemorySize);
         printf("\t\t\t\"maxComputeWorkGroupCount\": [\n");
-        printf("\t\t\t\t%u,\n",                                                           limits->maxComputeWorkGroupCount[0]);
-        printf("\t\t\t\t%u,\n",                                                           limits->maxComputeWorkGroupCount[1]);
-        printf("\t\t\t\t%u\n",                                                            limits->maxComputeWorkGroupCount[2]);
+        printf("\t\t\t\t%u,\n", limits->maxComputeWorkGroupCount[0]);
+        printf("\t\t\t\t%u,\n", limits->maxComputeWorkGroupCount[1]);
+        printf("\t\t\t\t%u\n", limits->maxComputeWorkGroupCount[2]);
         printf("\t\t\t],\n");
-        printf("\t\t\t\"maxComputeWorkGroupInvocations\": %u,\n",                         limits->maxComputeWorkGroupInvocations);
+        printf("\t\t\t\"maxComputeWorkGroupInvocations\": %u,\n", limits->maxComputeWorkGroupInvocations);
         printf("\t\t\t\"maxComputeWorkGroupSize\": [\n");
-        printf("\t\t\t\t%u,\n",                                                           limits->maxComputeWorkGroupSize[0]);
-        printf("\t\t\t\t%u,\n",                                                           limits->maxComputeWorkGroupSize[1]);
-        printf("\t\t\t\t%u\n",                                                            limits->maxComputeWorkGroupSize[2]);
+        printf("\t\t\t\t%u,\n", limits->maxComputeWorkGroupSize[0]);
+        printf("\t\t\t\t%u,\n", limits->maxComputeWorkGroupSize[1]);
+        printf("\t\t\t\t%u\n", limits->maxComputeWorkGroupSize[2]);
         printf("\t\t\t],\n");
-        printf("\t\t\t\"subPixelPrecisionBits\": %u,\n",                                  limits->subPixelPrecisionBits);
-        printf("\t\t\t\"subTexelPrecisionBits\": %u,\n",                                  limits->subTexelPrecisionBits);
-        printf("\t\t\t\"mipmapPrecisionBits\": %u,\n",                                    limits->mipmapPrecisionBits);
-        printf("\t\t\t\"maxDrawIndexedIndexValue\": %u,\n",                               limits->maxDrawIndexedIndexValue);
-        printf("\t\t\t\"maxDrawIndirectCount\": %u,\n",                                   limits->maxDrawIndirectCount);
-        printf("\t\t\t\"maxSamplerLodBias\": %g,\n",                                      limits->maxSamplerLodBias);
-        printf("\t\t\t\"maxSamplerAnisotropy\": %g,\n",                                   limits->maxSamplerAnisotropy);
-        printf("\t\t\t\"maxViewports\": %u,\n",                                           limits->maxViewports);
+        printf("\t\t\t\"subPixelPrecisionBits\": %u,\n", limits->subPixelPrecisionBits);
+        printf("\t\t\t\"subTexelPrecisionBits\": %u,\n", limits->subTexelPrecisionBits);
+        printf("\t\t\t\"mipmapPrecisionBits\": %u,\n", limits->mipmapPrecisionBits);
+        printf("\t\t\t\"maxDrawIndexedIndexValue\": %u,\n", limits->maxDrawIndexedIndexValue);
+        printf("\t\t\t\"maxDrawIndirectCount\": %u,\n", limits->maxDrawIndirectCount);
+        printf("\t\t\t\"maxSamplerLodBias\": %g,\n", limits->maxSamplerLodBias);
+        printf("\t\t\t\"maxSamplerAnisotropy\": %g,\n", limits->maxSamplerAnisotropy);
+        printf("\t\t\t\"maxViewports\": %u,\n", limits->maxViewports);
         printf("\t\t\t\"maxViewportDimensions\": [\n");
-        printf("\t\t\t\t%u,\n",                                                           limits->maxViewportDimensions[0]);
-        printf("\t\t\t\t%u\n",                                                            limits->maxViewportDimensions[1]);
+        printf("\t\t\t\t%u,\n", limits->maxViewportDimensions[0]);
+        printf("\t\t\t\t%u\n", limits->maxViewportDimensions[1]);
         printf("\t\t\t],\n");
         printf("\t\t\t\"viewportBoundsRange\": [\n");
-        printf("\t\t\t\t%g,\n",                                                           limits->viewportBoundsRange[0]);
-        printf("\t\t\t\t%g\n",                                                            limits->viewportBoundsRange[1]);
+        printf("\t\t\t\t%g,\n", limits->viewportBoundsRange[0]);
+        printf("\t\t\t\t%g\n", limits->viewportBoundsRange[1]);
         printf("\t\t\t],\n");
-        printf("\t\t\t\"viewportSubPixelBits\": %u,\n",                                   limits->viewportSubPixelBits);
-        printf("\t\t\t\"minMemoryMapAlignment\": " PRINTF_SIZE_T_SPECIFIER ",\n",         limits->minMemoryMapAlignment);
-        printf("\t\t\t\"minTexelBufferOffsetAlignment\": %llu,\n",                        (unsigned long long)limits->minTexelBufferOffsetAlignment);
-        printf("\t\t\t\"minUniformBufferOffsetAlignment\": %llu,\n",                      (unsigned long long)limits->minUniformBufferOffsetAlignment);
-        printf("\t\t\t\"minStorageBufferOffsetAlignment\": %llu,\n",                      (unsigned long long)limits->minStorageBufferOffsetAlignment);
-        printf("\t\t\t\"minTexelOffset\": %d,\n",                                         limits->minTexelOffset);
-        printf("\t\t\t\"maxTexelOffset\": %u,\n",                                         limits->maxTexelOffset);
-        printf("\t\t\t\"minTexelGatherOffset\": %d,\n",                                   limits->minTexelGatherOffset);
-        printf("\t\t\t\"maxTexelGatherOffset\": %u,\n",                                   limits->maxTexelGatherOffset);
-        printf("\t\t\t\"minInterpolationOffset\": %g,\n",                                 limits->minInterpolationOffset);
-        printf("\t\t\t\"maxInterpolationOffset\": %g,\n",                                 limits->maxInterpolationOffset);
-        printf("\t\t\t\"subPixelInterpolationOffsetBits\": %u,\n",                        limits->subPixelInterpolationOffsetBits);
-        printf("\t\t\t\"maxFramebufferWidth\": %u,\n",                                    limits->maxFramebufferWidth);
-        printf("\t\t\t\"maxFramebufferHeight\": %u,\n",                                   limits->maxFramebufferHeight);
-        printf("\t\t\t\"maxFramebufferLayers\": %u,\n",                                   limits->maxFramebufferLayers);
-        printf("\t\t\t\"framebufferColorSampleCounts\": %u,\n",                           limits->framebufferColorSampleCounts);
-        printf("\t\t\t\"framebufferDepthSampleCounts\": %u,\n",                           limits->framebufferDepthSampleCounts);
-        printf("\t\t\t\"framebufferStencilSampleCounts\": %u,\n",                         limits->framebufferStencilSampleCounts);
-        printf("\t\t\t\"framebufferNoAttachmentsSampleCounts\": %u,\n",                   limits->framebufferNoAttachmentsSampleCounts);
-        printf("\t\t\t\"maxColorAttachments\": %u,\n",                                    limits->maxColorAttachments);
-        printf("\t\t\t\"sampledImageColorSampleCounts\": %u,\n",                          limits->sampledImageColorSampleCounts);
-        printf("\t\t\t\"sampledImageIntegerSampleCounts\": %u,\n",                        limits->sampledImageIntegerSampleCounts);
-        printf("\t\t\t\"sampledImageDepthSampleCounts\": %u,\n",                          limits->sampledImageDepthSampleCounts);
-        printf("\t\t\t\"sampledImageStencilSampleCounts\": %u,\n",                        limits->sampledImageStencilSampleCounts);
-        printf("\t\t\t\"storageImageSampleCounts\": %u,\n",                               limits->storageImageSampleCounts);
-        printf("\t\t\t\"maxSampleMaskWords\": %u,\n",                                     limits->maxSampleMaskWords);
-        printf("\t\t\t\"timestampComputeAndGraphics\": %u,\n",                            limits->timestampComputeAndGraphics);
-        printf("\t\t\t\"timestampPeriod\": %g,\n",                                        limits->timestampPeriod);
-        printf("\t\t\t\"maxClipDistances\": %u,\n",                                       limits->maxClipDistances);
-        printf("\t\t\t\"maxCullDistances\": %u,\n",                                       limits->maxCullDistances);
-        printf("\t\t\t\"maxCombinedClipAndCullDistances\": %u,\n",                        limits->maxCombinedClipAndCullDistances);
-        printf("\t\t\t\"discreteQueuePriorities\": %u,\n",                                limits->discreteQueuePriorities);
+        printf("\t\t\t\"viewportSubPixelBits\": %u,\n", limits->viewportSubPixelBits);
+        printf("\t\t\t\"minMemoryMapAlignment\": " PRINTF_SIZE_T_SPECIFIER ",\n", limits->minMemoryMapAlignment);
+        printf("\t\t\t\"minTexelBufferOffsetAlignment\": %llu,\n", (unsigned long long)limits->minTexelBufferOffsetAlignment);
+        printf("\t\t\t\"minUniformBufferOffsetAlignment\": %llu,\n", (unsigned long long)limits->minUniformBufferOffsetAlignment);
+        printf("\t\t\t\"minStorageBufferOffsetAlignment\": %llu,\n", (unsigned long long)limits->minStorageBufferOffsetAlignment);
+        printf("\t\t\t\"minTexelOffset\": %d,\n", limits->minTexelOffset);
+        printf("\t\t\t\"maxTexelOffset\": %u,\n", limits->maxTexelOffset);
+        printf("\t\t\t\"minTexelGatherOffset\": %d,\n", limits->minTexelGatherOffset);
+        printf("\t\t\t\"maxTexelGatherOffset\": %u,\n", limits->maxTexelGatherOffset);
+        printf("\t\t\t\"minInterpolationOffset\": %g,\n", limits->minInterpolationOffset);
+        printf("\t\t\t\"maxInterpolationOffset\": %g,\n", limits->maxInterpolationOffset);
+        printf("\t\t\t\"subPixelInterpolationOffsetBits\": %u,\n", limits->subPixelInterpolationOffsetBits);
+        printf("\t\t\t\"maxFramebufferWidth\": %u,\n", limits->maxFramebufferWidth);
+        printf("\t\t\t\"maxFramebufferHeight\": %u,\n", limits->maxFramebufferHeight);
+        printf("\t\t\t\"maxFramebufferLayers\": %u,\n", limits->maxFramebufferLayers);
+        printf("\t\t\t\"framebufferColorSampleCounts\": %u,\n", limits->framebufferColorSampleCounts);
+        printf("\t\t\t\"framebufferDepthSampleCounts\": %u,\n", limits->framebufferDepthSampleCounts);
+        printf("\t\t\t\"framebufferStencilSampleCounts\": %u,\n", limits->framebufferStencilSampleCounts);
+        printf("\t\t\t\"framebufferNoAttachmentsSampleCounts\": %u,\n", limits->framebufferNoAttachmentsSampleCounts);
+        printf("\t\t\t\"maxColorAttachments\": %u,\n", limits->maxColorAttachments);
+        printf("\t\t\t\"sampledImageColorSampleCounts\": %u,\n", limits->sampledImageColorSampleCounts);
+        printf("\t\t\t\"sampledImageIntegerSampleCounts\": %u,\n", limits->sampledImageIntegerSampleCounts);
+        printf("\t\t\t\"sampledImageDepthSampleCounts\": %u,\n", limits->sampledImageDepthSampleCounts);
+        printf("\t\t\t\"sampledImageStencilSampleCounts\": %u,\n", limits->sampledImageStencilSampleCounts);
+        printf("\t\t\t\"storageImageSampleCounts\": %u,\n", limits->storageImageSampleCounts);
+        printf("\t\t\t\"maxSampleMaskWords\": %u,\n", limits->maxSampleMaskWords);
+        printf("\t\t\t\"timestampComputeAndGraphics\": %u,\n", limits->timestampComputeAndGraphics);
+        printf("\t\t\t\"timestampPeriod\": %g,\n", limits->timestampPeriod);
+        printf("\t\t\t\"maxClipDistances\": %u,\n", limits->maxClipDistances);
+        printf("\t\t\t\"maxCullDistances\": %u,\n", limits->maxCullDistances);
+        printf("\t\t\t\"maxCombinedClipAndCullDistances\": %u,\n", limits->maxCombinedClipAndCullDistances);
+        printf("\t\t\t\"discreteQueuePriorities\": %u,\n", limits->discreteQueuePriorities);
         printf("\t\t\t\"pointSizeRange\": [\n");
-        printf("\t\t\t\t%g,\n",                                                           limits->pointSizeRange[0]);
-        printf("\t\t\t\t%g\n",                                                            limits->pointSizeRange[1]);
+        printf("\t\t\t\t%g,\n", limits->pointSizeRange[0]);
+        printf("\t\t\t\t%g\n", limits->pointSizeRange[1]);
         printf("\t\t\t],\n");
         printf("\t\t\t\"lineWidthRange\": [\n");
-        printf("\t\t\t\t%g,\n",                                                           limits->lineWidthRange[0]);
-        printf("\t\t\t\t%g\n",                                                            limits->lineWidthRange[1]);
+        printf("\t\t\t\t%g,\n", limits->lineWidthRange[0]);
+        printf("\t\t\t\t%g\n", limits->lineWidthRange[1]);
         printf("\t\t\t],\n");
-        printf("\t\t\t\"pointSizeGranularity\": %g,\n",                                   limits->pointSizeGranularity);
-        printf("\t\t\t\"lineWidthGranularity\": %g,\n",                                   limits->lineWidthGranularity);
-        printf("\t\t\t\"strictLines\": %u,\n",                                            limits->strictLines);
-        printf("\t\t\t\"standardSampleLocations\": %u,\n",                                limits->standardSampleLocations);
-        printf("\t\t\t\"optimalBufferCopyOffsetAlignment\": %llu,\n",                     (unsigned long long)limits->optimalBufferCopyOffsetAlignment);
-        printf("\t\t\t\"optimalBufferCopyRowPitchAlignment\": %llu,\n",                   (unsigned long long)limits->optimalBufferCopyRowPitchAlignment);
-        printf("\t\t\t\"nonCoherentAtomSize\": %llu\n",                                   (unsigned long long)limits->nonCoherentAtomSize);
+        printf("\t\t\t\"pointSizeGranularity\": %g,\n", limits->pointSizeGranularity);
+        printf("\t\t\t\"lineWidthGranularity\": %g,\n", limits->lineWidthGranularity);
+        printf("\t\t\t\"strictLines\": %u,\n", limits->strictLines);
+        printf("\t\t\t\"standardSampleLocations\": %u,\n", limits->standardSampleLocations);
+        printf("\t\t\t\"optimalBufferCopyOffsetAlignment\": %llu,\n", (unsigned long long)limits->optimalBufferCopyOffsetAlignment);
+        printf("\t\t\t\"optimalBufferCopyRowPitchAlignment\": %llu,\n",
+               (unsigned long long)limits->optimalBufferCopyRowPitchAlignment);
+        printf("\t\t\t\"nonCoherentAtomSize\": %llu\n", (unsigned long long)limits->nonCoherentAtomSize);
         printf("\t\t}");
     }
 }
 
 static void AppGpuDumpProps(const struct AppGpu *gpu, FILE *out) {
-     VkPhysicalDeviceProperties props;
+    VkPhysicalDeviceProperties props;
 
     if (CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
-        gpu->inst->inst_extensions_count)) {
+                              gpu->inst->inst_extensions_count)) {
         const VkPhysicalDeviceProperties *props2_const = &gpu->props2.properties;
         props = *props2_const;
     } else {
@@ -2972,11 +3816,20 @@ static void AppGpuDumpProps(const struct AppGpu *gpu, FILE *out) {
 
     if (html_output) {
         fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceProperties</summary>\n");
-        fprintf(out, "\t\t\t\t\t\t<details><summary>apiVersion = <div class='val'>0x%" PRIxLEAST32 "</div>  (<div class='val'>%d.%d.%d</div>)</summary></details>\n", apiVersion, major, minor, patch);
-        fprintf(out, "\t\t\t\t\t\t<details><summary>driverVersion = <div class='val'>%u</div> (<div class='val'>0x%" PRIxLEAST32 "</div>)</summary></details>\n", props.driverVersion, props.driverVersion);
-        fprintf(out, "\t\t\t\t\t\t<details><summary>vendorID = <div class='val'>0x%04x</div></summary></details>\n", props.vendorID);
-        fprintf(out, "\t\t\t\t\t\t<details><summary>deviceID = <div class='val'>0x%04x</div></summary></details>\n", props.deviceID);
-        fprintf(out, "\t\t\t\t\t\t<details><summary>deviceType = %s</summary></details>\n", VkPhysicalDeviceTypeString(props.deviceType));
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>apiVersion = <div class='val'>0x%" PRIxLEAST32
+                "</div>  (<div class='val'>%d.%d.%d</div>)</summary></details>\n",
+                apiVersion, major, minor, patch);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>driverVersion = <div class='val'>%u</div> (<div class='val'>0x%" PRIxLEAST32
+                "</div>)</summary></details>\n",
+                props.driverVersion, props.driverVersion);
+        fprintf(out, "\t\t\t\t\t\t<details><summary>vendorID = <div class='val'>0x%04x</div></summary></details>\n",
+                props.vendorID);
+        fprintf(out, "\t\t\t\t\t\t<details><summary>deviceID = <div class='val'>0x%04x</div></summary></details>\n",
+                props.deviceID);
+        fprintf(out, "\t\t\t\t\t\t<details><summary>deviceType = %s</summary></details>\n",
+                VkPhysicalDeviceTypeString(props.deviceType));
         fprintf(out, "\t\t\t\t\t\t<details><summary>deviceName = %s</summary></details>\n", props.deviceName);
         fprintf(out, "\t\t\t\t\t</details>\n");
     } else if (human_readable_output) {
@@ -3010,13 +3863,15 @@ static void AppGpuDumpProps(const struct AppGpu *gpu, FILE *out) {
         printf("\t\t]");
     }
 
-    if (CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, gpu->inst->inst_extensions, gpu->inst->inst_extensions_count)) {
+    if (CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
+                              gpu->inst->inst_extensions_count)) {
         AppDumpLimits(&gpu->props2.properties.limits, out);
     } else {
         AppDumpLimits(&gpu->props.limits, out);
     }
 
-    if (CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, gpu->inst->inst_extensions, gpu->inst->inst_extensions_count)) {
+    if (CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
+                              gpu->inst->inst_extensions_count)) {
         AppDumpSparseProps(&gpu->props2.properties.sparseProperties, out);
     } else {
         AppDumpSparseProps(&gpu->props.sparseProperties, out);
@@ -3027,213 +3882,252 @@ static void AppGpuDumpProps(const struct AppGpu *gpu, FILE *out) {
     }
 
     if (CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
-        gpu->inst->inst_extensions_count)) {
+                              gpu->inst->inst_extensions_count)) {
         void *place = gpu->props2.pNext;
         while (place) {
-            struct VkStructureHeader *structure = (struct VkStructureHeader*) place;
-            if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT *blend_op_adv_props = (VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT*)structure;
+            struct VkStructureHeader *structure = (struct VkStructureHeader *)place;
+            if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT &&
+                CheckPhysicalDeviceExtensionIncluded(VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME, gpu->device_extensions,
+                                                     gpu->device_extension_count)) {
+                VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT *blend_op_adv_props =
+                    (VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceBlendOperationAdvancedProperties</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>advancedBlendMaxColorAttachments                = <div class='val'>%u</div></summary></details>\n", blend_op_adv_props->advancedBlendMaxColorAttachments     );
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>advancedBlendIndependentBlend                   = <div class='val'>%u</div></summary></details>\n", blend_op_adv_props->advancedBlendIndependentBlend        );
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>advancedBlendNonPremultipliedSrcColor           = <div class='val'>%u</div></summary></details>\n", blend_op_adv_props->advancedBlendNonPremultipliedSrcColor);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>advancedBlendNonPremultipliedDstColor           = <div class='val'>%u</div></summary></details>\n", blend_op_adv_props->advancedBlendNonPremultipliedDstColor);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>advancedBlendCorrelatedOverlap                  = <div class='val'>%u</div></summary></details>\n", blend_op_adv_props->advancedBlendCorrelatedOverlap       );
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>advancedBlendAllOperations                      = <div class='val'>%u</div></summary></details>\n", blend_op_adv_props->advancedBlendAllOperations           );
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>advancedBlendMaxColorAttachments                = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            blend_op_adv_props->advancedBlendMaxColorAttachments);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>advancedBlendIndependentBlend                   = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            blend_op_adv_props->advancedBlendIndependentBlend);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>advancedBlendNonPremultipliedSrcColor           = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            blend_op_adv_props->advancedBlendNonPremultipliedSrcColor);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>advancedBlendNonPremultipliedDstColor           = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            blend_op_adv_props->advancedBlendNonPremultipliedDstColor);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>advancedBlendCorrelatedOverlap                  = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            blend_op_adv_props->advancedBlendCorrelatedOverlap);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>advancedBlendAllOperations                      = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            blend_op_adv_props->advancedBlendAllOperations);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceBlendOperationAdvancedProperties:\n");
                     printf("=================================================\n");
-                    printf("\tadvancedBlendMaxColorAttachments               = %u\n", blend_op_adv_props->advancedBlendMaxColorAttachments     );
-                    printf("\tadvancedBlendIndependentBlend                  = %u\n", blend_op_adv_props->advancedBlendIndependentBlend        );
-                    printf("\tadvancedBlendNonPremultipliedSrcColor          = %u\n", blend_op_adv_props->advancedBlendNonPremultipliedSrcColor);
-                    printf("\tadvancedBlendNonPremultipliedDstColor          = %u\n", blend_op_adv_props->advancedBlendNonPremultipliedDstColor);
-                    printf("\tadvancedBlendCorrelatedOverlap                 = %u\n", blend_op_adv_props->advancedBlendCorrelatedOverlap       );
-                    printf("\tadvancedBlendAllOperations                     = %u\n", blend_op_adv_props->advancedBlendAllOperations           );
+                    printf("\tadvancedBlendMaxColorAttachments               = %u\n",
+                           blend_op_adv_props->advancedBlendMaxColorAttachments);
+                    printf("\tadvancedBlendIndependentBlend                  = %u\n",
+                           blend_op_adv_props->advancedBlendIndependentBlend);
+                    printf("\tadvancedBlendNonPremultipliedSrcColor          = %u\n",
+                           blend_op_adv_props->advancedBlendNonPremultipliedSrcColor);
+                    printf("\tadvancedBlendNonPremultipliedDstColor          = %u\n",
+                           blend_op_adv_props->advancedBlendNonPremultipliedDstColor);
+                    printf("\tadvancedBlendCorrelatedOverlap                 = %u\n",
+                           blend_op_adv_props->advancedBlendCorrelatedOverlap);
+                    printf("\tadvancedBlendAllOperations                     = %u\n",
+                           blend_op_adv_props->advancedBlendAllOperations);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_MAINTENANCE2_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDevicePointClippingPropertiesKHR *pt_clip_props = (VkPhysicalDevicePointClippingPropertiesKHR*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES_KHR &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_KHR_MAINTENANCE2_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDevicePointClippingPropertiesKHR *pt_clip_props = (VkPhysicalDevicePointClippingPropertiesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDevicePointClippingProperties</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>pointClippingBehavior               = <div class='val'>%u</div></summary></details>\n", pt_clip_props->pointClippingBehavior);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>pointClippingBehavior               = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            pt_clip_props->pointClippingBehavior);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDevicePointClippingProperties:\n");
                     printf("========================================\n");
                     printf("\tpointClippingBehavior               = %u\n", pt_clip_props->pointClippingBehavior);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDevicePushDescriptorPropertiesKHR *push_desc_props = (VkPhysicalDevicePushDescriptorPropertiesKHR*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDevicePushDescriptorPropertiesKHR *push_desc_props =
+                    (VkPhysicalDevicePushDescriptorPropertiesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDevicePushDescriptorProperties</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxPushDescriptors                = <div class='val'>%u</div></summary></details>\n", push_desc_props->maxPushDescriptors);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>maxPushDescriptors                = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            push_desc_props->maxPushDescriptors);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDevicePushDescriptorProperties:\n");
                     printf("=========================================\n");
                     printf("\tmaxPushDescriptors               = %u\n", push_desc_props->maxPushDescriptors);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceDiscardRectanglePropertiesEXT *discard_rect_props = (VkPhysicalDeviceDiscardRectanglePropertiesEXT*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceDiscardRectanglePropertiesEXT *discard_rect_props =
+                    (VkPhysicalDeviceDiscardRectanglePropertiesEXT *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceDiscardRectangleProperties</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxDiscardRectangles               = <div class='val'>%u</div></summary></details>\n", discard_rect_props->maxDiscardRectangles);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>maxDiscardRectangles               = <div "
+                            "class='val'>%u</div></summary></details>\n",
+                            discard_rect_props->maxDiscardRectangles);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceDiscardRectangleProperties:\n");
                     printf("===========================================\n");
                     printf("\tmaxDiscardRectangles               = %u\n", discard_rect_props->maxDiscardRectangles);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_MULTIVIEW_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceMultiviewPropertiesKHR *multiview_props = (VkPhysicalDeviceMultiviewPropertiesKHR*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES_KHR &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_KHR_MULTIVIEW_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceMultiviewPropertiesKHR *multiview_props = (VkPhysicalDeviceMultiviewPropertiesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceMultiviewProperties</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxMultiviewViewCount     = <div class='val'>%u</div></summary></details>\n", multiview_props->maxMultiviewViewCount    );
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxMultiviewInstanceIndex = <div class='val'>%u</div></summary></details>\n", multiview_props->maxMultiviewInstanceIndex);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>maxMultiviewViewCount     = <div class='val'>%u</div></summary></details>\n",
+                        multiview_props->maxMultiviewViewCount);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>maxMultiviewInstanceIndex = <div class='val'>%u</div></summary></details>\n",
+                        multiview_props->maxMultiviewInstanceIndex);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceMultiviewProperties:\n");
                     printf("====================================\n");
-                    printf("\tmaxMultiviewViewCount     = %u\n", multiview_props->maxMultiviewViewCount    );
+                    printf("\tmaxMultiviewViewCount     = %u\n", multiview_props->maxMultiviewViewCount);
                     printf("\tmaxMultiviewInstanceIndex = %u\n", multiview_props->maxMultiviewInstanceIndex);
                 }
             } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES_KHR) {
-                VkPhysicalDeviceMaintenance3PropertiesKHR *maintenance3_props = (VkPhysicalDeviceMaintenance3PropertiesKHR*)structure;
+                VkPhysicalDeviceMaintenance3PropertiesKHR *maintenance3_props =
+                    (VkPhysicalDeviceMaintenance3PropertiesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceMaintenance3Properties</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxPerSetDescriptors    = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", maintenance3_props->maxPerSetDescriptors);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxMemoryAllocationSize = <div class='val'>%" PRIuLEAST64 "</div></summary></details>\n", maintenance3_props->maxMemoryAllocationSize);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>maxPerSetDescriptors    = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            maintenance3_props->maxPerSetDescriptors);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>maxMemoryAllocationSize = <div class='val'>%" PRIuLEAST64
+                            "</div></summary></details>\n",
+                            maintenance3_props->maxMemoryAllocationSize);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceMaintenance3Properties:\n");
                     printf("=======================================\n");
-                    printf("\tmaxPerSetDescriptors    = %" PRIuLEAST32 "\n", maintenance3_props->maxPerSetDescriptors   );
+                    printf("\tmaxPerSetDescriptors    = %" PRIuLEAST32 "\n", maintenance3_props->maxPerSetDescriptors);
                     printf("\tmaxMemoryAllocationSize = %" PRIuLEAST64 "\n", maintenance3_props->maxMemoryAllocationSize);
                 }
             } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES_KHR) {
-                const VkPhysicalDeviceIDPropertiesKHR *id_props = (VkPhysicalDeviceIDPropertiesKHR*)structure;
+                const VkPhysicalDeviceIDPropertiesKHR *id_props = (VkPhysicalDeviceIDPropertiesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\t\t\t\t\t<details><summary>VkPhysicalDeviceIDProperties</summary>\n");
                     // Visual Studio 2013's printf does not support the "hh"
                     // length modifier so cast the operands and use field width
                     // "2" to fake it.
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>deviceUUID      = <div class='val'>%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x</div></summary></details>\n",
-                        (uint32_t)id_props->deviceUUID[0],
-                        (uint32_t)id_props->deviceUUID[1],
-                        (uint32_t)id_props->deviceUUID[2],
-                        (uint32_t)id_props->deviceUUID[3],
-                        (uint32_t)id_props->deviceUUID[4],
-                        (uint32_t)id_props->deviceUUID[5],
-                        (uint32_t)id_props->deviceUUID[6],
-                        (uint32_t)id_props->deviceUUID[7],
-                        (uint32_t)id_props->deviceUUID[8],
-                        (uint32_t)id_props->deviceUUID[9],
-                        (uint32_t)id_props->deviceUUID[10],
-                        (uint32_t)id_props->deviceUUID[11],
-                        (uint32_t)id_props->deviceUUID[12],
-                        (uint32_t)id_props->deviceUUID[13],
-                        (uint32_t)id_props->deviceUUID[14],
-                        (uint32_t)id_props->deviceUUID[15]);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>driverUUID      = <div class='val'>%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x</div></summary></details>\n",
-                        (uint32_t)id_props->driverUUID[0],
-                        (uint32_t)id_props->driverUUID[1],
-                        (uint32_t)id_props->driverUUID[2],
-                        (uint32_t)id_props->driverUUID[3],
-                        (uint32_t)id_props->driverUUID[4],
-                        (uint32_t)id_props->driverUUID[5],
-                        (uint32_t)id_props->driverUUID[6],
-                        (uint32_t)id_props->driverUUID[7],
-                        (uint32_t)id_props->driverUUID[8],
-                        (uint32_t)id_props->driverUUID[9],
-                        (uint32_t)id_props->driverUUID[10],
-                        (uint32_t)id_props->driverUUID[11],
-                        (uint32_t)id_props->driverUUID[12],
-                        (uint32_t)id_props->driverUUID[13],
-                        (uint32_t)id_props->driverUUID[14],
-                        (uint32_t)id_props->driverUUID[15]);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>deviceUUID      = <div "
+                            "class='val'>%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x</div></summary></"
+                            "details>\n",
+                            (uint32_t)id_props->deviceUUID[0], (uint32_t)id_props->deviceUUID[1], (uint32_t)id_props->deviceUUID[2],
+                            (uint32_t)id_props->deviceUUID[3], (uint32_t)id_props->deviceUUID[4], (uint32_t)id_props->deviceUUID[5],
+                            (uint32_t)id_props->deviceUUID[6], (uint32_t)id_props->deviceUUID[7], (uint32_t)id_props->deviceUUID[8],
+                            (uint32_t)id_props->deviceUUID[9], (uint32_t)id_props->deviceUUID[10],
+                            (uint32_t)id_props->deviceUUID[11], (uint32_t)id_props->deviceUUID[12],
+                            (uint32_t)id_props->deviceUUID[13], (uint32_t)id_props->deviceUUID[14],
+                            (uint32_t)id_props->deviceUUID[15]);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>driverUUID      = <div "
+                            "class='val'>%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x</div></summary></"
+                            "details>\n",
+                            (uint32_t)id_props->driverUUID[0], (uint32_t)id_props->driverUUID[1], (uint32_t)id_props->driverUUID[2],
+                            (uint32_t)id_props->driverUUID[3], (uint32_t)id_props->driverUUID[4], (uint32_t)id_props->driverUUID[5],
+                            (uint32_t)id_props->driverUUID[6], (uint32_t)id_props->driverUUID[7], (uint32_t)id_props->driverUUID[8],
+                            (uint32_t)id_props->driverUUID[9], (uint32_t)id_props->driverUUID[10],
+                            (uint32_t)id_props->driverUUID[11], (uint32_t)id_props->driverUUID[12],
+                            (uint32_t)id_props->driverUUID[13], (uint32_t)id_props->driverUUID[14],
+                            (uint32_t)id_props->driverUUID[15]);
                     fprintf(out, "\t\t\t\t\t\t<details><summary>deviceLUIDValid = <div class='val'>%s</div></summary></details>\n",
-                        id_props->deviceLUIDValid ? "true" : "false");
+                            id_props->deviceLUIDValid ? "true" : "false");
                     if (id_props->deviceLUIDValid) {
-                        fprintf(out, "\t\t\t\t\t\t<details><summary>deviceLUID      = <div class='val'>%02x%02x%02x%02x-%02x%02x%02x%02x</div></summary></details>\n",
-                            (uint32_t)id_props->deviceLUID[0],
-                            (uint32_t)id_props->deviceLUID[1],
-                            (uint32_t)id_props->deviceLUID[2],
-                            (uint32_t)id_props->deviceLUID[3],
-                            (uint32_t)id_props->deviceLUID[4],
-                            (uint32_t)id_props->deviceLUID[5],
-                            (uint32_t)id_props->deviceLUID[6],
-                            (uint32_t)id_props->deviceLUID[7]);
-                        fprintf(out, "\t\t\t\t\t\t<details><summary>deviceNodeMask  = <div class='val'>0x%08x</div></summary></details>\n",
+                        fprintf(out,
+                                "\t\t\t\t\t\t<details><summary>deviceLUID      = <div "
+                                "class='val'>%02x%02x%02x%02x-%02x%02x%02x%02x</div></summary></details>\n",
+                                (uint32_t)id_props->deviceLUID[0], (uint32_t)id_props->deviceLUID[1],
+                                (uint32_t)id_props->deviceLUID[2], (uint32_t)id_props->deviceLUID[3],
+                                (uint32_t)id_props->deviceLUID[4], (uint32_t)id_props->deviceLUID[5],
+                                (uint32_t)id_props->deviceLUID[6], (uint32_t)id_props->deviceLUID[7]);
+                        fprintf(
+                            out,
+                            "\t\t\t\t\t\t<details><summary>deviceNodeMask  = <div class='val'>0x%08x</div></summary></details>\n",
                             id_props->deviceNodeMask);
                     }
                     fprintf(out, "\t\t\t\t\t</details>\n");
-                }
-                else if (human_readable_output) {
+                } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceIDProperties:\n");
                     printf("=========================================\n");
                     printf("\tdeviceUUID      = %02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x\n",
-                        (uint32_t)id_props->deviceUUID[0],
-                        (uint32_t)id_props->deviceUUID[1],
-                        (uint32_t)id_props->deviceUUID[2],
-                        (uint32_t)id_props->deviceUUID[3],
-                        (uint32_t)id_props->deviceUUID[4],
-                        (uint32_t)id_props->deviceUUID[5],
-                        (uint32_t)id_props->deviceUUID[6],
-                        (uint32_t)id_props->deviceUUID[7],
-                        (uint32_t)id_props->deviceUUID[8],
-                        (uint32_t)id_props->deviceUUID[9],
-                        (uint32_t)id_props->deviceUUID[10],
-                        (uint32_t)id_props->deviceUUID[11],
-                        (uint32_t)id_props->deviceUUID[12],
-                        (uint32_t)id_props->deviceUUID[13],
-                        (uint32_t)id_props->deviceUUID[14],
-                        (uint32_t)id_props->deviceUUID[15]);
+                           (uint32_t)id_props->deviceUUID[0], (uint32_t)id_props->deviceUUID[1], (uint32_t)id_props->deviceUUID[2],
+                           (uint32_t)id_props->deviceUUID[3], (uint32_t)id_props->deviceUUID[4], (uint32_t)id_props->deviceUUID[5],
+                           (uint32_t)id_props->deviceUUID[6], (uint32_t)id_props->deviceUUID[7], (uint32_t)id_props->deviceUUID[8],
+                           (uint32_t)id_props->deviceUUID[9], (uint32_t)id_props->deviceUUID[10],
+                           (uint32_t)id_props->deviceUUID[11], (uint32_t)id_props->deviceUUID[12],
+                           (uint32_t)id_props->deviceUUID[13], (uint32_t)id_props->deviceUUID[14],
+                           (uint32_t)id_props->deviceUUID[15]);
                     printf("\tdriverUUID      = %02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x\n",
-                        (uint32_t)id_props->driverUUID[0],
-                        (uint32_t)id_props->driverUUID[1],
-                        (uint32_t)id_props->driverUUID[2],
-                        (uint32_t)id_props->driverUUID[3],
-                        (uint32_t)id_props->driverUUID[4],
-                        (uint32_t)id_props->driverUUID[5],
-                        (uint32_t)id_props->driverUUID[6],
-                        (uint32_t)id_props->driverUUID[7],
-                        (uint32_t)id_props->driverUUID[8],
-                        (uint32_t)id_props->driverUUID[9],
-                        (uint32_t)id_props->driverUUID[10],
-                        (uint32_t)id_props->driverUUID[11],
-                        (uint32_t)id_props->driverUUID[12],
-                        (uint32_t)id_props->driverUUID[13],
-                        (uint32_t)id_props->driverUUID[14],
-                        (uint32_t)id_props->driverUUID[15]);
-                    printf("\tdeviceLUIDValid = %s\n",
-                        id_props->deviceLUIDValid ? "true" : "false");
+                           (uint32_t)id_props->driverUUID[0], (uint32_t)id_props->driverUUID[1], (uint32_t)id_props->driverUUID[2],
+                           (uint32_t)id_props->driverUUID[3], (uint32_t)id_props->driverUUID[4], (uint32_t)id_props->driverUUID[5],
+                           (uint32_t)id_props->driverUUID[6], (uint32_t)id_props->driverUUID[7], (uint32_t)id_props->driverUUID[8],
+                           (uint32_t)id_props->driverUUID[9], (uint32_t)id_props->driverUUID[10],
+                           (uint32_t)id_props->driverUUID[11], (uint32_t)id_props->driverUUID[12],
+                           (uint32_t)id_props->driverUUID[13], (uint32_t)id_props->driverUUID[14],
+                           (uint32_t)id_props->driverUUID[15]);
+                    printf("\tdeviceLUIDValid = %s\n", id_props->deviceLUIDValid ? "true" : "false");
                     if (id_props->deviceLUIDValid) {
-                        printf("\tdeviceLUID      = %02x%02x%02x%02x-%02x%02x%02x%02x\n",
-                            (uint32_t)id_props->deviceLUID[0],
-                            (uint32_t)id_props->deviceLUID[1],
-                            (uint32_t)id_props->deviceLUID[2],
-                            (uint32_t)id_props->deviceLUID[3],
-                            (uint32_t)id_props->deviceLUID[4],
-                            (uint32_t)id_props->deviceLUID[5],
-                            (uint32_t)id_props->deviceLUID[6],
-                            (uint32_t)id_props->deviceLUID[7]);
-                        printf("\tdeviceNodeMask  = 0x%08x\n",
-                            id_props->deviceNodeMask);
+                        printf("\tdeviceLUID      = %02x%02x%02x%02x-%02x%02x%02x%02x\n", (uint32_t)id_props->deviceLUID[0],
+                               (uint32_t)id_props->deviceLUID[1], (uint32_t)id_props->deviceLUID[2],
+                               (uint32_t)id_props->deviceLUID[3], (uint32_t)id_props->deviceLUID[4],
+                               (uint32_t)id_props->deviceLUID[5], (uint32_t)id_props->deviceLUID[6],
+                               (uint32_t)id_props->deviceLUID[7]);
+                        printf("\tdeviceNodeMask  = 0x%08x\n", id_props->deviceNodeMask);
                     }
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceDriverPropertiesKHR *driver_props = (VkPhysicalDeviceDriverPropertiesKHR*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceDriverPropertiesKHR *driver_props = (VkPhysicalDeviceDriverPropertiesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceDriverProperties</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>driverID   = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", driver_props->driverID);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>driverID   = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            driver_props->driverID);
                     fprintf(out, "\t\t\t\t\t\t<details><summary>driverName = %s</summary></details>\n", driver_props->driverName);
                     fprintf(out, "\t\t\t\t\t\t<details><summary>driverInfo = %s</summary></details>\n", driver_props->driverInfo);
                     fprintf(out, "\t\t\t\t\t\t<details><summary>conformanceVersion:</summary></details>\n");
-                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>major    = <div class='val'>%" PRIuLEAST8 "</div></summary></details>\n", driver_props->conformanceVersion.major);
-                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>minor    = <div class='val'>%" PRIuLEAST8 "</div></summary></details>\n", driver_props->conformanceVersion.minor);
-                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>subminor = <div class='val'>%" PRIuLEAST8 "</div></summary></details>\n", driver_props->conformanceVersion.subminor);
-                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>patch    = <div class='val'>%" PRIuLEAST8 "</div></summary></details>\n", driver_props->conformanceVersion.patch);
+                    fprintf(out,
+                            "\t\t\t\t\t\t\t<details><summary>major    = <div class='val'>%" PRIuLEAST8
+                            "</div></summary></details>\n",
+                            driver_props->conformanceVersion.major);
+                    fprintf(out,
+                            "\t\t\t\t\t\t\t<details><summary>minor    = <div class='val'>%" PRIuLEAST8
+                            "</div></summary></details>\n",
+                            driver_props->conformanceVersion.minor);
+                    fprintf(out,
+                            "\t\t\t\t\t\t\t<details><summary>subminor = <div class='val'>%" PRIuLEAST8
+                            "</div></summary></details>\n",
+                            driver_props->conformanceVersion.subminor);
+                    fprintf(out,
+                            "\t\t\t\t\t\t\t<details><summary>patch    = <div class='val'>%" PRIuLEAST8
+                            "</div></summary></details>\n",
+                            driver_props->conformanceVersion.patch);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceDriverProperties:\n");
@@ -3247,57 +4141,141 @@ static void AppGpuDumpProps(const struct AppGpu *gpu, FILE *out) {
                     printf("\t\tsubminor = %" PRIuLEAST8 "\n", driver_props->conformanceVersion.subminor);
                     printf("\t\tpatch    = %" PRIuLEAST8 "\n", driver_props->conformanceVersion.patch);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR && CheckPhysicalDeviceExtensionIncluded(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceFloatControlsPropertiesKHR *float_control_props = (VkPhysicalDeviceFloatControlsPropertiesKHR*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceFloatControlsPropertiesKHR *float_control_props =
+                    (VkPhysicalDeviceFloatControlsPropertiesKHR *)structure;
                 if (html_output) {
                     fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceFloatControlsProperties</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>separateDenormSettings       = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->separateDenormSettings);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>separateRoundingModeSettings = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->separateRoundingModeSettings);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderSignedZeroInfNanPreserveFloat16 = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderSignedZeroInfNanPreserveFloat16);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderSignedZeroInfNanPreserveFloat32 = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderSignedZeroInfNanPreserveFloat32);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderSignedZeroInfNanPreserveFloat64 = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderSignedZeroInfNanPreserveFloat64);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderDenormPreserveFloat16           = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderDenormPreserveFloat16);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderDenormPreserveFloat32           = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderDenormPreserveFloat32);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderDenormPreserveFloat64           = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderDenormPreserveFloat64);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderDenormFlushToZeroFloat16        = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderDenormFlushToZeroFloat16);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderDenormFlushToZeroFloat32        = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderDenormFlushToZeroFloat32);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderDenormFlushToZeroFloat64        = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderDenormFlushToZeroFloat64);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTEFloat16          = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderRoundingModeRTEFloat16);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTEFloat32          = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderRoundingModeRTEFloat32);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTEFloat64          = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderRoundingModeRTEFloat64);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTZFloat16          = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderRoundingModeRTZFloat16);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTZFloat32          = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderRoundingModeRTZFloat32);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTZFloat64          = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", float_control_props->shaderRoundingModeRTZFloat64);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>separateDenormSettings       = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->separateDenormSettings);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>separateRoundingModeSettings = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->separateRoundingModeSettings);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderSignedZeroInfNanPreserveFloat16 = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderSignedZeroInfNanPreserveFloat16);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderSignedZeroInfNanPreserveFloat32 = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderSignedZeroInfNanPreserveFloat32);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderSignedZeroInfNanPreserveFloat64 = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderSignedZeroInfNanPreserveFloat64);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderDenormPreserveFloat16           = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderDenormPreserveFloat16);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderDenormPreserveFloat32           = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderDenormPreserveFloat32);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderDenormPreserveFloat64           = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderDenormPreserveFloat64);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderDenormFlushToZeroFloat16        = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderDenormFlushToZeroFloat16);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderDenormFlushToZeroFloat32        = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderDenormFlushToZeroFloat32);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderDenormFlushToZeroFloat64        = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderDenormFlushToZeroFloat64);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTEFloat16          = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderRoundingModeRTEFloat16);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTEFloat32          = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderRoundingModeRTEFloat32);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTEFloat64          = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderRoundingModeRTEFloat64);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTZFloat16          = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderRoundingModeRTZFloat16);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTZFloat32          = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderRoundingModeRTZFloat32);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>shaderRoundingModeRTZFloat64          = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            float_control_props->shaderRoundingModeRTZFloat64);
                     fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceFloatControlsProperties:\n");
                     printf("========================================\n");
                     printf("\tseparateDenormSettings       = %" PRIuLEAST32 "\n", float_control_props->separateDenormSettings);
-                    printf("\tseparateRoundingModeSettings = %" PRIuLEAST32 "\n", float_control_props->separateRoundingModeSettings);
-                    printf("\tshaderSignedZeroInfNanPreserveFloat16 = %" PRIuLEAST32 "\n", float_control_props->shaderSignedZeroInfNanPreserveFloat16);
-                    printf("\tshaderSignedZeroInfNanPreserveFloat32 = %" PRIuLEAST32 "\n", float_control_props->shaderSignedZeroInfNanPreserveFloat32);
-                    printf("\tshaderSignedZeroInfNanPreserveFloat64 = %" PRIuLEAST32 "\n", float_control_props->shaderSignedZeroInfNanPreserveFloat64);
-                    printf("\tshaderDenormPreserveFloat16          = %" PRIuLEAST32 "\n", float_control_props->shaderDenormPreserveFloat16);
-                    printf("\tshaderDenormPreserveFloat32           = %" PRIuLEAST32 "\n", float_control_props->shaderDenormPreserveFloat32);
-                    printf("\tshaderDenormPreserveFloat64           = %" PRIuLEAST32 "\n", float_control_props->shaderDenormPreserveFloat64);
-                    printf("\tshaderDenormFlushToZeroFloat16        = %" PRIuLEAST32 "\n", float_control_props->shaderDenormFlushToZeroFloat16);
-                    printf("\tshaderDenormFlushToZeroFloat32        = %" PRIuLEAST32 "\n", float_control_props->shaderDenormFlushToZeroFloat32);
-                    printf("\tshaderDenormFlushToZeroFloat64        = %" PRIuLEAST32 "\n", float_control_props->shaderDenormFlushToZeroFloat64);
-                    printf("\tshaderRoundingModeRTEFloat16          = %" PRIuLEAST32 "\n", float_control_props->shaderRoundingModeRTEFloat16);
-                    printf("\tshaderRoundingModeRTEFloat32          = %" PRIuLEAST32 "\n", float_control_props->shaderRoundingModeRTEFloat32);
-                    printf("\tshaderRoundingModeRTEFloat64         = %" PRIuLEAST32 "\n", float_control_props->shaderRoundingModeRTEFloat64);
-                    printf("\tshaderRoundingModeRTZFloat16          = %" PRIuLEAST32 "\n", float_control_props->shaderRoundingModeRTZFloat16);
-                    printf("\tshaderRoundingModeRTZFloat32          = %" PRIuLEAST32 "\n", float_control_props->shaderRoundingModeRTZFloat32);
-                    printf("\tshaderRoundingModeRTZFloat64          = %" PRIuLEAST32 "\n", float_control_props->shaderRoundingModeRTZFloat64);
+                    printf("\tseparateRoundingModeSettings = %" PRIuLEAST32 "\n",
+                           float_control_props->separateRoundingModeSettings);
+                    printf("\tshaderSignedZeroInfNanPreserveFloat16 = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderSignedZeroInfNanPreserveFloat16);
+                    printf("\tshaderSignedZeroInfNanPreserveFloat32 = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderSignedZeroInfNanPreserveFloat32);
+                    printf("\tshaderSignedZeroInfNanPreserveFloat64 = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderSignedZeroInfNanPreserveFloat64);
+                    printf("\tshaderDenormPreserveFloat16          = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderDenormPreserveFloat16);
+                    printf("\tshaderDenormPreserveFloat32           = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderDenormPreserveFloat32);
+                    printf("\tshaderDenormPreserveFloat64           = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderDenormPreserveFloat64);
+                    printf("\tshaderDenormFlushToZeroFloat16        = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderDenormFlushToZeroFloat16);
+                    printf("\tshaderDenormFlushToZeroFloat32        = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderDenormFlushToZeroFloat32);
+                    printf("\tshaderDenormFlushToZeroFloat64        = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderDenormFlushToZeroFloat64);
+                    printf("\tshaderRoundingModeRTEFloat16          = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderRoundingModeRTEFloat16);
+                    printf("\tshaderRoundingModeRTEFloat32          = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderRoundingModeRTEFloat32);
+                    printf("\tshaderRoundingModeRTEFloat64         = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderRoundingModeRTEFloat64);
+                    printf("\tshaderRoundingModeRTZFloat16          = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderRoundingModeRTZFloat16);
+                    printf("\tshaderRoundingModeRTZFloat32          = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderRoundingModeRTZFloat32);
+                    printf("\tshaderRoundingModeRTZFloat64          = %" PRIuLEAST32 "\n",
+                           float_control_props->shaderRoundingModeRTZFloat64);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDevicePCIBusInfoPropertiesEXT *pci_bus_properties = (VkPhysicalDevicePCIBusInfoPropertiesEXT*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDevicePCIBusInfoPropertiesEXT *pci_bus_properties = (VkPhysicalDevicePCIBusInfoPropertiesEXT *)structure;
                 if (html_output) {
                     fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDevicePCIBusInfoProperties</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>pciDomain   = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", pci_bus_properties->pciDomain);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>pciBus      = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", pci_bus_properties->pciBus);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>pciDevice   = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", pci_bus_properties->pciDevice);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>pciFunction = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", pci_bus_properties->pciFunction);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>pciDomain   = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            pci_bus_properties->pciDomain);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>pciBus      = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            pci_bus_properties->pciBus);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>pciDevice   = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            pci_bus_properties->pciDevice);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>pciFunction = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            pci_bus_properties->pciFunction);
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDevicePCIBusInfoProperties\n");
                     printf("====================================\n");
@@ -3306,45 +4284,114 @@ static void AppGpuDumpProps(const struct AppGpu *gpu, FILE *out) {
                     printf("\tpciDevice   = %" PRIuLEAST32 "\n", pci_bus_properties->pciDevice);
                     printf("\tpciFunction = %" PRIuLEAST32 "\n", pci_bus_properties->pciFunction);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceTransformFeedbackPropertiesEXT *transform_feedback_properties = (VkPhysicalDeviceTransformFeedbackPropertiesEXT*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceTransformFeedbackPropertiesEXT *transform_feedback_properties =
+                    (VkPhysicalDeviceTransformFeedbackPropertiesEXT *)structure;
                 if (html_output) {
                     fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceTransformFeedbackProperties</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackStreams                = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackStreams);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBuffers                = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackBuffers);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBufferSize             = <div class='val'>%" PRIuLEAST64 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackBufferSize);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackStreamDataSize         = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackStreamDataSize);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBufferDataSize         = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackBufferDataSize);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBufferDataStride       = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->maxTransformFeedbackBufferDataStride);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>transformFeedbackQueries                   = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->transformFeedbackQueries);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>transformFeedbackStreamsLinesTriangles     = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->transformFeedbackStreamsLinesTriangles);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>transformFeedbackRasterizationStreamSelect = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->transformFeedbackRasterizationStreamSelect);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>transformFeedbackDraw                      = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", transform_feedback_properties->transformFeedbackDraw);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>maxTransformFeedbackStreams                = <div class='val'>%" PRIuLEAST32
+                        "</div></summary></details>\n",
+                        transform_feedback_properties->maxTransformFeedbackStreams);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBuffers                = <div class='val'>%" PRIuLEAST32
+                        "</div></summary></details>\n",
+                        transform_feedback_properties->maxTransformFeedbackBuffers);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBufferSize             = <div class='val'>%" PRIuLEAST64
+                        "</div></summary></details>\n",
+                        transform_feedback_properties->maxTransformFeedbackBufferSize);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>maxTransformFeedbackStreamDataSize         = <div class='val'>%" PRIuLEAST32
+                        "</div></summary></details>\n",
+                        transform_feedback_properties->maxTransformFeedbackStreamDataSize);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBufferDataSize         = <div class='val'>%" PRIuLEAST32
+                        "</div></summary></details>\n",
+                        transform_feedback_properties->maxTransformFeedbackBufferDataSize);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>maxTransformFeedbackBufferDataStride       = <div class='val'>%" PRIuLEAST32
+                        "</div></summary></details>\n",
+                        transform_feedback_properties->maxTransformFeedbackBufferDataStride);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>transformFeedbackQueries                   = <div class='val'>%" PRIuLEAST32
+                        "</div></summary></details>\n",
+                        transform_feedback_properties->transformFeedbackQueries);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>transformFeedbackStreamsLinesTriangles     = <div class='val'>%" PRIuLEAST32
+                        "</div></summary></details>\n",
+                        transform_feedback_properties->transformFeedbackStreamsLinesTriangles);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>transformFeedbackRasterizationStreamSelect = <div class='val'>%" PRIuLEAST32
+                        "</div></summary></details>\n",
+                        transform_feedback_properties->transformFeedbackRasterizationStreamSelect);
+                    fprintf(
+                        out,
+                        "\t\t\t\t\t\t<details><summary>transformFeedbackDraw                      = <div class='val'>%" PRIuLEAST32
+                        "</div></summary></details>\n",
+                        transform_feedback_properties->transformFeedbackDraw);
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceTransformFeedbackProperties\n");
                     printf("===========================================\n");
-                    printf("\tmaxTransformFeedbackStreams                = %" PRIuLEAST32 "\n", transform_feedback_properties->maxTransformFeedbackStreams);
-                    printf("\tmaxTransformFeedbackBuffers                = %" PRIuLEAST32 "\n", transform_feedback_properties->maxTransformFeedbackBuffers);
-                    printf("\tmaxTransformFeedbackBufferSize             = %" PRIuLEAST64 "\n", transform_feedback_properties->maxTransformFeedbackBufferSize);
-                    printf("\tmaxTransformFeedbackStreamDataSize         = %" PRIuLEAST32 "\n", transform_feedback_properties->maxTransformFeedbackStreamDataSize);
-                    printf("\tmaxTransformFeedbackBufferDataSize         = %" PRIuLEAST32 "\n", transform_feedback_properties->maxTransformFeedbackBufferDataSize);
-                    printf("\tmaxTransformFeedbackBufferDataStride       = %" PRIuLEAST32 "\n", transform_feedback_properties->maxTransformFeedbackBufferDataStride);
-                    printf("\ttransformFeedbackQueries                   = %" PRIuLEAST32 "\n", transform_feedback_properties->transformFeedbackQueries);
-                    printf("\ttransformFeedbackStreamsLinesTriangles     = %" PRIuLEAST32 "\n", transform_feedback_properties->transformFeedbackStreamsLinesTriangles);
-                    printf("\ttransformFeedbackRasterizationStreamSelect = %" PRIuLEAST32 "\n", transform_feedback_properties->transformFeedbackRasterizationStreamSelect);
-                    printf("\ttransformFeedbackDraw                      = %" PRIuLEAST32 "\n", transform_feedback_properties->transformFeedbackDraw);
+                    printf("\tmaxTransformFeedbackStreams                = %" PRIuLEAST32 "\n",
+                           transform_feedback_properties->maxTransformFeedbackStreams);
+                    printf("\tmaxTransformFeedbackBuffers                = %" PRIuLEAST32 "\n",
+                           transform_feedback_properties->maxTransformFeedbackBuffers);
+                    printf("\tmaxTransformFeedbackBufferSize             = %" PRIuLEAST64 "\n",
+                           transform_feedback_properties->maxTransformFeedbackBufferSize);
+                    printf("\tmaxTransformFeedbackStreamDataSize         = %" PRIuLEAST32 "\n",
+                           transform_feedback_properties->maxTransformFeedbackStreamDataSize);
+                    printf("\tmaxTransformFeedbackBufferDataSize         = %" PRIuLEAST32 "\n",
+                           transform_feedback_properties->maxTransformFeedbackBufferDataSize);
+                    printf("\tmaxTransformFeedbackBufferDataStride       = %" PRIuLEAST32 "\n",
+                           transform_feedback_properties->maxTransformFeedbackBufferDataStride);
+                    printf("\ttransformFeedbackQueries                   = %" PRIuLEAST32 "\n",
+                           transform_feedback_properties->transformFeedbackQueries);
+                    printf("\ttransformFeedbackStreamsLinesTriangles     = %" PRIuLEAST32 "\n",
+                           transform_feedback_properties->transformFeedbackStreamsLinesTriangles);
+                    printf("\ttransformFeedbackRasterizationStreamSelect = %" PRIuLEAST32 "\n",
+                           transform_feedback_properties->transformFeedbackRasterizationStreamSelect);
+                    printf("\ttransformFeedbackDraw                      = %" PRIuLEAST32 "\n",
+                           transform_feedback_properties->transformFeedbackDraw);
                 }
-            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT && CheckPhysicalDeviceExtensionIncluded(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME, gpu->device_extensions, gpu->device_extension_count)) {
-                VkPhysicalDeviceFragmentDensityMapPropertiesEXT *fragment_density_map_properties = (VkPhysicalDeviceFragmentDensityMapPropertiesEXT*)structure;
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceFragmentDensityMapPropertiesEXT *fragment_density_map_properties =
+                    (VkPhysicalDeviceFragmentDensityMapPropertiesEXT *)structure;
                 if (html_output) {
                     fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceFragmentDensityMapProperties</summary>\n");
                     fprintf(out, "\t\t\t\t\t\t<details><summary>minFragmentDensityTexelSize</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_properties->minFragmentDensityTexelSize.width);
-                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_properties->minFragmentDensityTexelSize.height);
+                    fprintf(out,
+                            "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n",
+                            fragment_density_map_properties->minFragmentDensityTexelSize.width);
+                    fprintf(out,
+                            "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            fragment_density_map_properties->minFragmentDensityTexelSize.height);
                     fprintf(out, "\t\t\t\t\t\t<details><summary>maxFragmentDensityTexelSize</summary>\n");
-                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_properties->maxFragmentDensityTexelSize.width);
-                    fprintf(out, "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_properties->maxFragmentDensityTexelSize.height);
-                    fprintf(out, "\t\t\t\t\t\t<details><summary>fragmentDensityInvocations = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n", fragment_density_map_properties->fragmentDensityInvocations);
+                    fprintf(out,
+                            "\t\t\t\t\t\t\t<details><summary>width = <div class='val'>%" PRIuLEAST32 "</div></summary></details>\n",
+                            fragment_density_map_properties->maxFragmentDensityTexelSize.width);
+                    fprintf(out,
+                            "\t\t\t\t\t\t\t<details><summary>height = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            fragment_density_map_properties->maxFragmentDensityTexelSize.height);
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>fragmentDensityInvocations = <div class='val'>%" PRIuLEAST32
+                            "</div></summary></details>\n",
+                            fragment_density_map_properties->fragmentDensityInvocations);
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceFragmentDensityMapProperties\n");
                     printf("============================================\n");
@@ -3354,7 +4401,8 @@ static void AppGpuDumpProps(const struct AppGpu *gpu, FILE *out) {
                     printf("\tmaxFragmentDensityTexelSize\n");
                     printf("\t\twidth = %" PRIuLEAST32 "\n", fragment_density_map_properties->maxFragmentDensityTexelSize.width);
                     printf("\t\theight = %" PRIuLEAST32 "\n", fragment_density_map_properties->maxFragmentDensityTexelSize.height);
-                    printf("\tfragmentDensityInvocations = %" PRIuLEAST32 "\n", fragment_density_map_properties->fragmentDensityInvocations);
+                    printf("\tfragmentDensityInvocations = %" PRIuLEAST32 "\n",
+                           fragment_density_map_properties->fragmentDensityInvocations);
                 }
             }
             place = structure->pNext;
@@ -3458,7 +4506,7 @@ static void AppGpuDumpQueueProps(const struct AppGpu *gpu, uint32_t id, FILE *ou
     VkQueueFamilyProperties props;
 
     if (CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
-        gpu->inst->inst_extensions_count)) {
+                              gpu->inst->inst_extensions_count)) {
         const VkQueueFamilyProperties *props2_const = &gpu->queue_props2[id].queueFamilyProperties;
         props = *props2_const;
     } else {
@@ -3469,7 +4517,7 @@ static void AppGpuDumpQueueProps(const struct AppGpu *gpu, uint32_t id, FILE *ou
     VkBool32 supports_present = VK_FALSE;
     if (gpu->inst->surface) {
         VkResult err = vkGetPhysicalDeviceSurfaceSupportKHR(gpu->obj, id, gpu->inst->surface, &supports_present);
-        if( err ) ERR_EXIT(err);
+        if (err) ERR_EXIT(err);
     }
 
     if (html_output) {
@@ -3501,10 +4549,15 @@ static void AppGpuDumpQueueProps(const struct AppGpu *gpu, uint32_t id, FILE *ou
 
     if (html_output) {
         fprintf(out, "</summary></details>\n");
-        fprintf(out, "\t\t\t\t\t\t<details><summary>queueCount         = <div class='val'>%u</div></summary></details>\n", props.queueCount);
-        fprintf(out, "\t\t\t\t\t\t<details><summary>timestampValidBits = <div class='val'>%u</div></summary></details>\n", props.timestampValidBits);
-        fprintf(out, "\t\t\t\t\t\t<details><summary>minImageTransferGranularity = (<div class='val'>%d</div>, <div class='val'>%d</div>, <div class='val'>%d</div>)</summary></details>\n",
-                props.minImageTransferGranularity.width, props.minImageTransferGranularity.height, props.minImageTransferGranularity.depth);
+        fprintf(out, "\t\t\t\t\t\t<details><summary>queueCount         = <div class='val'>%u</div></summary></details>\n",
+                props.queueCount);
+        fprintf(out, "\t\t\t\t\t\t<details><summary>timestampValidBits = <div class='val'>%u</div></summary></details>\n",
+                props.timestampValidBits);
+        fprintf(out,
+                "\t\t\t\t\t\t<details><summary>minImageTransferGranularity = (<div class='val'>%d</div>, <div "
+                "class='val'>%d</div>, <div class='val'>%d</div>)</summary></details>\n",
+                props.minImageTransferGranularity.width, props.minImageTransferGranularity.height,
+                props.minImageTransferGranularity.depth);
         fprintf(out, "\t\t\t\t\t\t<details><summary>present support    = <div class='val'>%s</div></summary></details>\n",
                 supports_present ? "true" : "false");
         fprintf(out, "\t\t\t\t\t</details>\n");
@@ -3561,7 +4614,7 @@ static void AppGpuDumpMemoryProps(const struct AppGpu *gpu, FILE *out) {
     VkPhysicalDeviceMemoryProperties props;
 
     if (CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, gpu->inst->inst_extensions,
-        gpu->inst->inst_extensions_count)) {
+                              gpu->inst->inst_extensions_count)) {
         const VkPhysicalDeviceMemoryProperties *props2_const = &gpu->memory_props2.memoryProperties;
         props = *props2_const;
     } else {
@@ -3591,7 +4644,9 @@ static void AppGpuDumpMemoryProps(const struct AppGpu *gpu, FILE *out) {
 
         if (html_output) {
             fprintf(out, "\t\t\t\t\t\t\t<details><summary>memoryHeaps[<div class='val'>%u</div>]</summary>\n", i);
-            fprintf(out, "\t\t\t\t\t\t\t\t<details><summary>size = <div class='val'>" PRINTF_SIZE_T_SPECIFIER "</div> (<div class='val'>0x%" PRIxLEAST64 "</div>) (<div class='val'>%s</div>)</summary></details>\n",
+            fprintf(out,
+                    "\t\t\t\t\t\t\t\t<details><summary>size = <div class='val'>" PRINTF_SIZE_T_SPECIFIER
+                    "</div> (<div class='val'>0x%" PRIxLEAST64 "</div>) (<div class='val'>%s</div>)</summary></details>\n",
                     (size_t)memSize, memSize, mem_size_human_readable);
         } else if (human_readable_output) {
             printf("\tmemoryHeaps[%u] :\n", i);
@@ -3604,7 +4659,8 @@ static void AppGpuDumpMemoryProps(const struct AppGpu *gpu, FILE *out) {
         if (html_output) {
             fprintf(out, "\t\t\t\t\t\t\t\t<details open><summary>flags</summary>\n");
             fprintf(out, "\t\t\t\t\t\t\t\t\t<details><summary>");
-            fprintf(out, (heap_flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) ? "<div class='type'>VK_MEMORY_HEAP_DEVICE_LOCAL_BIT</div>" : "None");
+            fprintf(out, (heap_flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) ? "<div class='type'>VK_MEMORY_HEAP_DEVICE_LOCAL_BIT</div>"
+                                                                        : "None");
             fprintf(out, "</summary></details>\n");
             fprintf(out, "\t\t\t\t\t\t\t\t</details>\n");
             fprintf(out, "\t\t\t\t\t\t\t</details>\n");
@@ -3651,8 +4707,11 @@ static void AppGpuDumpMemoryProps(const struct AppGpu *gpu, FILE *out) {
     for (uint32_t i = 0; i < props.memoryTypeCount; ++i) {
         if (html_output) {
             fprintf(out, "\t\t\t\t\t\t\t<details><summary>memoryTypes[<div class='val'>%u</div>]</summary>\n", i);
-            fprintf(out, "\t\t\t\t\t\t\t\t<details><summary>heapIndex = <div class='val'>%u</div></summary></details>\n", props.memoryTypes[i].heapIndex);
-            fprintf(out, "\t\t\t\t\t\t\t\t<details open><summary>propertyFlags = <div class='val'>0x%" PRIxLEAST32 "</div></summary>", props.memoryTypes[i].propertyFlags);
+            fprintf(out, "\t\t\t\t\t\t\t\t<details><summary>heapIndex = <div class='val'>%u</div></summary></details>\n",
+                    props.memoryTypes[i].heapIndex);
+            fprintf(out,
+                    "\t\t\t\t\t\t\t\t<details open><summary>propertyFlags = <div class='val'>0x%" PRIxLEAST32 "</div></summary>",
+                    props.memoryTypes[i].propertyFlags);
             if (props.memoryTypes[i].propertyFlags == 0) {
                 fprintf(out, "</details>\n");
             } else {
@@ -3677,18 +4736,33 @@ static void AppGpuDumpMemoryProps(const struct AppGpu *gpu, FILE *out) {
         // Print each named flag to html or std output if it is set
         const VkFlags flags = props.memoryTypes[i].propertyFlags;
         if (html_output) {
-            if (flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)     fprintf(out, "\t\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT</div></summary></details>\n");
-            if (flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)     fprintf(out, "\t\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT</div></summary></details>\n");
-            if (flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)    fprintf(out, "\t\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_MEMORY_PROPERTY_HOST_COHERENT_BIT</div></summary></details>\n");
-            if (flags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT)      fprintf(out, "\t\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_MEMORY_PROPERTY_HOST_CACHED_BIT</div></summary></details>\n");
-            if (flags & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) fprintf(out, "\t\t\t\t\t\t\t\t\t<details><summary><div class='type'>VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT</div></summary></details>\n");
-            if (props.memoryTypes[i].propertyFlags > 0)         fprintf(out, "\t\t\t\t\t\t\t\t</details>\n");
+            if (flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT</div></summary></details>\n");
+            if (flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT</div></summary></details>\n");
+            if (flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_MEMORY_PROPERTY_HOST_COHERENT_BIT</div></summary></details>\n");
+            if (flags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_MEMORY_PROPERTY_HOST_CACHED_BIT</div></summary></details>\n");
+            if (flags & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
+                fprintf(out,
+                        "\t\t\t\t\t\t\t\t\t<details><summary><div "
+                        "class='type'>VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT</div></summary></details>\n");
+            if (props.memoryTypes[i].propertyFlags > 0) fprintf(out, "\t\t\t\t\t\t\t\t</details>\n");
             fprintf(out, "\t\t\t\t\t\t\t</details>\n");
         } else if (human_readable_output) {
-            if (flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)     printf("\t\t\tVK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT\n");
-            if (flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)     printf("\t\t\tVK_MEMORY_PROPERTY_HOST_VISIBLE_BIT\n");
-            if (flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)    printf("\t\t\tVK_MEMORY_PROPERTY_HOST_COHERENT_BIT\n");
-            if (flags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT)      printf("\t\t\tVK_MEMORY_PROPERTY_HOST_CACHED_BIT\n");
+            if (flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) printf("\t\t\tVK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT\n");
+            if (flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) printf("\t\t\tVK_MEMORY_PROPERTY_HOST_VISIBLE_BIT\n");
+            if (flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) printf("\t\t\tVK_MEMORY_PROPERTY_HOST_COHERENT_BIT\n");
+            if (flags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT) printf("\t\t\tVK_MEMORY_PROPERTY_HOST_CACHED_BIT\n");
             if (flags & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) printf("\t\t\tVK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT\n");
         }
     }
@@ -3710,7 +4784,6 @@ static void AppGpuDumpMemoryProps(const struct AppGpu *gpu, FILE *out) {
     fflush(out);
     fflush(stdout);
 }
-// clang-format on
 
 static void AppGpuDump(const struct AppGpu *gpu, FILE *out) {
     if (html_output) {


### PR DESCRIPTION
It doesn't make sense to enforce clang-format rules
and then turn it off for more than half of the file.

Removed `clang-format off` from vulkaninfo.c and ran
clang-format to clean up the code.

closes #124 