### PR TITLE
Fixed undefined reference to 'clock_gettime' by linking rt library

### DIFF
--- a/cube/CMakeLists.txt
+++ b/cube/CMakeLists.txt
@@ -174,6 +174,13 @@ elseif(NOT WIN32)
                        cube.vert.inc
                        cube.frag.inc)
         target_link_libraries(vkcube Vulkan::Vulkan)
+
+       if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+           find_library(LIBRT rt)
+           if(LIBRT)
+               target_link_libraries(vkcube ${LIBRT})
+           endif()
+        endif()
     endif()
 else()
     if(CMAKE_CL_64)


### PR DESCRIPTION
On CentOS6.8 with a local build of g++ 6.4.0 (the default g++ version on CentOS6.8 is 4.4.7), the build fails with undefined reference to 'clock_gettime'.

Linking vkcube against the rt library fixed the issue.

This patch is similar to https://github.com/KhronosGroup/SPIRV-Tools/pull/2409
