### PR TITLE
build: Correct Metal platform name

### DIFF
--- a/scripts/common_codegen.py
+++ b/scripts/common_codegen.py
@@ -52,7 +52,7 @@ platform_dict = {
     'fuchsia' : 'VK_USE_PLATFORM_FUCHSIA',
     'ios' : 'VK_USE_PLATFORM_IOS_MVK',
     'macos' : 'VK_USE_PLATFORM_MACOS_MVK',
-    'metal' : 'VK_USE_PLATFORM_METAL',
+    'metal' : 'VK_USE_PLATFORM_METAL_EXT',
     'vi' : 'VK_USE_PLATFORM_VI_NN',
     'wayland' : 'VK_USE_PLATFORM_WAYLAND_KHR',
     'win32' : 'VK_USE_PLATFORM_WIN32_KHR',


### PR DESCRIPTION
In `common_codegen.py` the Metal platform was defined without the "_EXT"
suffix