### PR TITLE
test: Update cloud CI to use known_good.json

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,30 +26,13 @@ before_build:
   - "SET PATH=C:\\Python35;C:\\Python35\\Scripts;%PATH%"
   - echo Starting build for %APPVEYOR_REPO_NAME% in %APPVEYOR_BUILD_FOLDER%
   - cmake --version
-  # Build Vulkan-Headers
-  - echo Building Vulkan-Headers for %PLATFORM% %CONFIGURATION%
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - git clone https://github.com/KhronosGroup/Vulkan-Headers.git
-  - cd Vulkan-Headers
-  - mkdir build
-  - cd build
-  - cmake -A %PLATFORM% -DCMAKE_INSTALL_PREFIX=install ..
-  - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
-  # Build Vulkan-Loader
-  - echo Building Vulkan-Loader for %PLATFORM% %CONFIGURATION%
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - git clone https://github.com/KhronosGroup/Vulkan-Loader.git
-  - cd Vulkan-Loader
-  - mkdir build
-  - cd build
-  - cmake -A %PLATFORM% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/build/install -DCMAKE_INSTALL_PREFIX=install ..
-  - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
   # Generate build files using CMake for the build step.
   - echo Generating Vulkan-Tools CMake files for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build
   - cd build
-  - cmake -A %PLATFORM% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/build/install -DVULKAN_LOADER_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Loader/build/install ..
+  - python %APPVEYOR_BUILD_FOLDER%/scripts/update_deps.py --arch=%PLATFORM% --config=%CONFIGURATION% --dir=%APPVEYOR_BUILD_FOLDER%/external
+  - cmake -A %PLATFORM% -C %APPVEYOR_BUILD_FOLDER%/external/helper.cmake ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
 
 platform:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,35 +72,12 @@ script:
   - cmake --version
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
-      # Build Vulkan-Headers
-      cd ${TRAVIS_BUILD_DIR}
-      git clone https://github.com/KhronosGroup/Vulkan-Headers.git
-      cd Vulkan-Headers
-      mkdir build
-      cd build
-      cmake -DCMAKE_INSTALL_PREFIX=install ..
-      make -j $core_count install
-      cd ${TRAVIS_BUILD_DIR}
-    fi
-  - |
-    if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
-      # Build Vulkan-Loader for Vulkan-Tools
-      cd ${TRAVIS_BUILD_DIR}
-      git clone https://github.com/KhronosGroup/Vulkan-Loader.git
-      cd Vulkan-Loader
-      mkdir build
-      cd build
-      cmake -DCMAKE_BUILD_TYPE=Debug -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Headers/build/install -DCMAKE_INSTALL_PREFIX=install ..
-      make -j $core_count install
-      cd ${TRAVIS_BUILD_DIR}
-    fi
-  - |
-    if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Build Vulkan-Tools
       cd ${TRAVIS_BUILD_DIR}
       mkdir build
       cd build
-      cmake -DCMAKE_BUILD_TYPE=Debug -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Headers/build/install -DVULKAN_LOADER_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Loader/build/install ..
+      python ${TRAVIS_BUILD_DIR}/scripts/update_deps.py --config=Debug --dir=${TRAVIS_BUILD_DIR}/external
+      cmake -C${TRAVIS_BUILD_DIR}/external/helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
       make -j $core_count
       cd ${TRAVIS_BUILD_DIR}
     fi


### PR DESCRIPTION
Updates to other repos can cause errors to propagate
from changes that have nothing to do with PRs on
Vulkan-Tools.

This commit changes cloud CI systems to build with
known_good.json in Vulkan-Tools so that issues
affecting other repos do not prevent PRs in Vulkan-Tools
from getting merged.