### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/vulkaninfo/CMakeLists.txt
+++ b/vulkaninfo/CMakeLists.txt
@@ -71,6 +71,13 @@ endif()
 
 if(WIN32)
     target_compile_definitions(vulkaninfo PUBLIC -DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN -D_CRT_SECURE_NO_WARNINGS)
+    if(NOT MSVC_VERSION LESS 1900)
+        # Enable control flow guard
+        message(STATUS "Building vulkaninfo with control flow guard")
+        add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/guard:cf>")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf")
+    endif()
 
     # Use static MSVCRT libraries
     foreach(configuration


### PR DESCRIPTION
Adds Control Flow Guard compiler flag to vulkaninfo

Control Flow Guard (CG) protects against some forms of memory corruption.
See https://docs.microsoft.com/en-us/windows/desktop/secbp/control-flow-guard for details.

This compiler flag enables CFG on vulkaninfo. (CFG is already enabled on the Cube project.)

Enabling CFG is a low-risk, "set and forget" low hanging fruit for security hardening.