### PR TITLE
vulkaninfo: Add extensions

### DIFF
--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -1094,7 +1094,9 @@ static void AppGpuInit(struct AppGpu *gpu, struct AppInstance *inst, uint32_t id
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT,
              .mem_size = sizeof(VkPhysicalDeviceMemoryPriorityFeaturesEXT)},
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT,
-             .mem_size = sizeof(VkPhysicalDeviceBufferAddressFeaturesEXT)}};
+             .mem_size = sizeof(VkPhysicalDeviceBufferAddressFeaturesEXT)},
+            {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT,
+             .mem_size = sizeof(VkPhysicalDeviceYcbcrImageArraysFeaturesEXT)}};
 
         uint32_t chain_info_len = ARRAY_SIZE(chain_info);
 
@@ -3160,6 +3162,7 @@ static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
                             "\t\t\t\t\t\t<details><summary>memoryPriority = <span class='val'>%" PRIuLEAST32
                             "</span></summary></details>\n",
                             memory_priority_features->memoryPriority);
+                    fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceMemoryPriorityFeatures:\n");
                     printf("======================================\n");
@@ -3184,14 +3187,32 @@ static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
                             "\t\t\t\t\t\t<details><summary>bufferDeviceAddressMultiDevice = <span class='val'>%" PRIuLEAST32
                             "</span></summary></details>\n",
                             buffer_address_features->bufferDeviceAddressMultiDevice);
+                    fprintf(out, "\t\t\t\t\t</details>\n");
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDeviceBufferAddressFeatures:\n");
                     printf("======================================\n");
                     printf("\tbufferDeviceAddress = %" PRIuLEAST32 "\n", buffer_address_features->bufferDeviceAddress);
                     printf("\tbufferDeviceAddressCaptureReplay = %" PRIuLEAST32 "\n",
-                           buffer_address_features->bufferDeviceAddressCaptureReplay);
+                            buffer_address_features->bufferDeviceAddressCaptureReplay);
                     printf("\tbufferDeviceAddressMultiDevice = %" PRIuLEAST32 "\n",
-                           buffer_address_features->bufferDeviceAddressMultiDevice);
+                            buffer_address_features->bufferDeviceAddressMultiDevice);
+                }
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_EXT_YCBCR_IMAGE_ARRAYS_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *ycbcr_image_arrays_features =
+                    (VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *)structure;
+                if (html_output) {
+                    fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceYcbcrImageArraysFeatures</summary>\n");
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>ycbcrImageArrays = <span class='val'>%" PRIuLEAST32
+                            "</span></summary></details>\n",
+                            ycbcr_image_arrays_features->ycbcrImageArrays);
+                    fprintf(out, "\t\t\t\t\t</details>\n");
+                } else if (human_readable_output) {
+                    printf("\nVkPhysicalDeviceYcbcrImageArraysFeatures:\n");
+                    printf("=========================================\n");
+                    printf("\tycbcrImageArrays = %" PRIuLEAST32 "\n", ycbcr_image_arrays_features->ycbcrImageArrays);
                 }
             }
             place = structure->pNext;

--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -1096,7 +1096,9 @@ static void AppGpuInit(struct AppGpu *gpu, struct AppInstance *inst, uint32_t id
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT,
              .mem_size = sizeof(VkPhysicalDeviceBufferAddressFeaturesEXT)},
             {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT,
-             .mem_size = sizeof(VkPhysicalDeviceYcbcrImageArraysFeaturesEXT)}};
+             .mem_size = sizeof(VkPhysicalDeviceYcbcrImageArraysFeaturesEXT)},
+            {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT,
+             .mem_size = sizeof(VkPhysicalDeviceHostQueryResetFeaturesEXT)}};
 
         uint32_t chain_info_len = ARRAY_SIZE(chain_info);
 
@@ -3213,6 +3215,23 @@ static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
                     printf("\nVkPhysicalDeviceYcbcrImageArraysFeatures:\n");
                     printf("=========================================\n");
                     printf("\tycbcrImageArrays = %" PRIuLEAST32 "\n", ycbcr_image_arrays_features->ycbcrImageArrays);
+                }
+            } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT &&
+                       CheckPhysicalDeviceExtensionIncluded(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME, gpu->device_extensions,
+                                                            gpu->device_extension_count)) {
+                VkPhysicalDeviceHostQueryResetFeaturesEXT *host_query_reset_features =
+                    (VkPhysicalDeviceHostQueryResetFeaturesEXT *)structure;
+                if (html_output) {
+                    fprintf(out, "\n\t\t\t\t\t<details><summary>VkPhysicalDeviceHostQueryResetFeatures</summary>\n");
+                    fprintf(out,
+                            "\t\t\t\t\t\t<details><summary>hostQueryReset = <span class='val'>%" PRIuLEAST32
+                            "</span></summary></details>\n",
+                            host_query_reset_features->hostQueryReset);
+                    fprintf(out, "\t\t\t\t\t</details>\n");
+                } else if (human_readable_output) {
+                    printf("\nVkPhysicalDeviceHostQueryResetFeatures:\n");
+                    printf("=======================================\n");
+                    printf("\thostQueryReset = %" PRIuLEAST32 "\n", host_query_reset_features->hostQueryReset);
                 }
             }
             place = structure->pNext;

--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -1991,7 +1991,8 @@ static void AppDumpSurfaceCapabilities(struct AppInstance *inst, struct AppGpu *
             void *place = surface_capabilities2.pNext;
             while (place) {
                 struct VkStructureHeader *work = (struct VkStructureHeader *)place;
-                if (work->sType == VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR && CheckExtensionEnabled(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME, gpu->inst->inst_extensions,
+                if (work->sType == VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR &&
+                    CheckExtensionEnabled(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME, gpu->inst->inst_extensions,
                                           gpu->inst->inst_extensions_count)) {
                     VkSharedPresentSurfaceCapabilitiesKHR *shared_surface_capabilities =
                         (VkSharedPresentSurfaceCapabilitiesKHR *)place;
@@ -2078,10 +2079,10 @@ static void AppDumpSurfaceCapabilities(struct AppInstance *inst, struct AppGpu *
                             printf("\t\tVK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT\n");
                         }
                     }
-                } else if (work->sType == VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR && CheckExtensionEnabled(VK_KHR_SURFACE_PROTECTED_CAPABILITIES_EXTENSION_NAME, gpu->inst->inst_extensions,
-                                          gpu->inst->inst_extensions_count)) {
-                    VkSurfaceProtectedCapabilitiesKHR *protected_surface_capabilities =
-                        (VkSurfaceProtectedCapabilitiesKHR *)place;
+                } else if (work->sType == VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR &&
+                           CheckExtensionEnabled(VK_KHR_SURFACE_PROTECTED_CAPABILITIES_EXTENSION_NAME, gpu->inst->inst_extensions,
+                                                 gpu->inst->inst_extensions_count)) {
+                    VkSurfaceProtectedCapabilitiesKHR *protected_surface_capabilities = (VkSurfaceProtectedCapabilitiesKHR *)place;
                     if (html_output) {
                         fprintf(out, "\t\t\t\t\t\t<details><summary>VkSurfaceProtectedCapabilities</summary>\n");
                         fprintf(out,
@@ -3213,9 +3214,9 @@ static void AppGpuDumpFeatures(const struct AppGpu *gpu, FILE *out) {
                     printf("======================================\n");
                     printf("\tbufferDeviceAddress = %" PRIuLEAST32 "\n", buffer_address_features->bufferDeviceAddress);
                     printf("\tbufferDeviceAddressCaptureReplay = %" PRIuLEAST32 "\n",
-                            buffer_address_features->bufferDeviceAddressCaptureReplay);
+                           buffer_address_features->bufferDeviceAddressCaptureReplay);
                     printf("\tbufferDeviceAddressMultiDevice = %" PRIuLEAST32 "\n",
-                            buffer_address_features->bufferDeviceAddressMultiDevice);
+                           buffer_address_features->bufferDeviceAddressMultiDevice);
                 }
             } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT &&
                        CheckPhysicalDeviceExtensionIncluded(VK_EXT_YCBCR_IMAGE_ARRAYS_EXTENSION_NAME, gpu->device_extensions,


### PR DESCRIPTION
Added the following extensions to vulkaninfo:

- VK_EXT_ycbcr_image_arrays
- VK_EXT_host_query_reset
- VK_KHR_surface_protected_capabilities

With output from the following structs:

- VkPhysicalDeviceYcbcrImageArraysFeaturesEXT
- VkPhysicalDeviceHostQueryResetFeaturesEXT
- VkSurfaceProtectedCapabilitiesKHR