### PR TITLE
cmake: Use CMake 3.10.2 for CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,6 +17,7 @@ os:
 environment:
   PYTHON_PATH: "C:/Python35"
   PYTHON_PACKAGE_PATH: "C:/Python35/Scripts"
+  CMAKE_URL: "http://cmake.org/files/v3.10/cmake-3.10.2-win64-x64.zip"
 
 branches:
   only:
@@ -24,14 +25,14 @@ branches:
 
 # Install desired CMake version 3.10.2 before any other building
 install:
-  - choco upgrade cmake --version 3.10.2
-  - set path=C:\Program Files\CMake\bin;%path%
+  - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
+  - 7z x cmake.zip -oC:\cmake > nul
+  - set path=C:\cmake\bin;%path%
   - cmake --version
 
 before_build:
   - "SET PATH=C:\\Python35;C:\\Python35\\Scripts;%PATH%"
   - echo Starting build for %APPVEYOR_REPO_NAME% in %APPVEYOR_BUILD_FOLDER%
-  - cmake --version
   # Generate build files using CMake for the build step.
   - echo Generating Vulkan-Tools CMake files for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,12 @@ branches:
   only:
     - master
 
+# Install desired CMake version 3.10.2 before any other building
+install:
+  - choco upgrade cmake --version 3.10.2
+  - set path=C:\Program Files\CMake\bin;%path%
+  - cmake --version
+
 before_build:
   - "SET PATH=C:\\Python35;C:\\Python35\\Scripts;%PATH%"
   - echo Starting build for %APPVEYOR_REPO_NAME% in %APPVEYOR_BUILD_FOLDER%

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,17 @@ cache: ccache
 
 before_install:
   - set -e
+  - CMAKE_VERSION=3.10.2
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+      echo CMAKE_URL=${CMAKE_URL}
+      mkdir cmake-${CMAKE_VERSION} && travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake-${CMAKE_VERSION}
+      export PATH=${PWD}/cmake-${CMAKE_VERSION}/bin:${PATH}
+    else
+      brew install cmake || brew upgrade cmake
+    fi
+    cmake --version
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]] || [[ "$VULKAN_BUILD_TARGET" == "GN" ]]; then
       # Install the appropriate Linux packages.
@@ -73,7 +84,6 @@ before_install:
 
 script:
   - set -e
-  - cmake --version
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Build Vulkan-Tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,6 @@ script:
 notifications:
   email:
     recipients:
-      - karl@lunarg.com
       - cnorthrop@google.com
       - tobine@google.com
       - chrisforbes@google.com

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -343,7 +343,7 @@ class GoodRepo(object):
     def Checkout(self):
         print('Checking out {n} in {d}'.format(n=self.name, d=self.repo_dir))
         if self._args.do_clean_repo:
-            shutil.rmtree(self.repo_dir)
+            shutil.rmtree(self.repo_dir, ignore_errors=True)
         if not os.path.exists(os.path.join(self.repo_dir, '.git')):
             self.Clone()
         self.Fetch()


### PR DESCRIPTION
These changes ensure that the Travis and AppVeyor
builds use a known version of CMake.