### PR TITLE
[WIP] cube: portability_subset demo (for review only)

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -23,6 +23,7 @@
  * Author: Gwan-gyeong Mun <elongbug@gmail.com>
  * Author: Tony Barbour <tony@LunarG.com>
  * Author: Bill Hollings <bill.hollings@brenwill.com>
+ * Author: Mike Weiblen <mikew@lunarg.com>
  */
 
 #define _GNU_SOURCE
@@ -62,6 +63,12 @@
 #define DEMO_TEXTURE_COUNT 1
 #define APP_SHORT_NAME "vkcube"
 #define APP_LONG_NAME "Vulkan Cube"
+
+#define ENABLE_PORTABILITY_SUBSET 1
+#if ENABLE_PORTABILITY_SUBSET
+//#pragma message("Building cube.c with VK_EXTX_portability_subset v0.2")
+#include "vk_extx_portability_subset.h"
+#endif
 
 // Allow a maximum of two outstanding presentation operations.
 #define FRAME_LAG 2
@@ -269,6 +276,88 @@ static const float g_uv_buffer_data[] = {
     1.0f, 0.0f,
 };
 // clang-format on
+
+#if ENABLE_PORTABILITY_SUBSET
+
+static void testVkPhysicalDevicePortabilitySubsetFeaturesEXTX(VkInstance inst, VkPhysicalDevice physDev) {
+    PFN_vkGetPhysicalDeviceFeatures2KHR pfn_vkGetPhysicalDeviceFeatures2KHR =
+        (PFN_vkGetPhysicalDeviceFeatures2KHR)vkGetInstanceProcAddr(inst, "vkGetPhysicalDeviceFeatures2KHR");
+
+    VkPhysicalDevicePortabilitySubsetFeaturesEXTX pdFeatsPort = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_EXTX,
+        .pNext = VK_NULL_HANDLE,
+        .triangleFans = true,
+        .separateStencilMaskRef = true,
+        .events = true,
+        .standardImageViews = true,
+        .samplerMipLodBias = true};
+
+    VkPhysicalDeviceFeatures2 pdFeats = {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, .pNext = &pdFeatsPort};
+
+    DbgMsg(">>> cube: PRE  VkPhysicalDevicePortabilitySubsetFeaturesEXTX @ %p\n", pfn_vkGetPhysicalDeviceFeatures2KHR);
+    pfn_vkGetPhysicalDeviceFeatures2KHR(physDev, &pdFeats);
+    DbgMsg(">>> cube: POST VkPhysicalDevicePortabilitySubsetFeaturesEXTX\n");
+
+    // Your app does something meaningful with the results in pdFeatsPort here.
+}
+
+static void testVkPhysicalDevicePortabilitySubsetPropertiesEXTX(VkInstance inst, VkPhysicalDevice physDev) {
+    PFN_vkGetPhysicalDeviceProperties2KHR pfn_vkGetPhysicalDeviceProperties2KHR =
+        (PFN_vkGetPhysicalDeviceProperties2KHR)vkGetInstanceProcAddr(inst, "vkGetPhysicalDeviceProperties2KHR");
+
+    VkPhysicalDevicePortabilitySubsetPropertiesEXTX pdPropsPort = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_EXTX,
+        .pNext = VK_NULL_HANDLE,
+        .minVertexInputBindingStrideAlignment = 0};
+
+    VkPhysicalDeviceProperties2 pdProps = {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, .pNext = &pdPropsPort};
+
+    DbgMsg(">>> cube: PRE  VkPhysicalDevicePortabilitySubsetPropertiesEXTX @ %p\n", pfn_vkGetPhysicalDeviceProperties2KHR);
+    pfn_vkGetPhysicalDeviceProperties2KHR(physDev, &pdProps);
+    DbgMsg(">>> cube: POST VkPhysicalDevicePortabilitySubsetPropertiesEXTX\n");
+
+    // Your app does something meaningful with the results in pdPropsPort here.
+}
+
+static VkResult testVkPhysicalDeviceImageViewSupportEXTX(VkInstance inst, VkPhysicalDevice physDev) {
+    PFN_vkGetPhysicalDeviceImageFormatProperties2KHR pfn_vkGetPhysicalDeviceImageFormatProperties2KHR =
+        (PFN_vkGetPhysicalDeviceImageFormatProperties2KHR)vkGetInstanceProcAddr(inst,
+                                                                                "vkGetPhysicalDeviceImageFormatProperties2KHR");
+
+    VkImageFormatProperties2 imgFmtProps = {.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2, .pNext = VK_NULL_HANDLE};
+
+    VkPhysicalDeviceImageViewSupportEXTX imgViewPort = {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_SUPPORT_EXTX,
+                                                        .pNext = VK_NULL_HANDLE,
+                                                        .flags = 0,
+                                                        .viewType = VK_IMAGE_VIEW_TYPE_2D,
+                                                        .format = VK_FORMAT_R8G8B8A8_UNORM,
+                                                        .components =
+                                                            {
+                                                                .r = VK_COMPONENT_SWIZZLE_R,
+                                                                .g = VK_COMPONENT_SWIZZLE_A,
+                                                                .b = VK_COMPONENT_SWIZZLE_IDENTITY,
+                                                                .a = VK_COMPONENT_SWIZZLE_IDENTITY,
+                                                            },
+                                                        .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT};
+
+    VkPhysicalDeviceImageFormatInfo2KHR imgFmtInfo = {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2,
+                                                      .pNext = &imgViewPort,
+                                                      .format = VK_FORMAT_R8G8B8A8_UNORM,
+                                                      .type = VK_IMAGE_TYPE_2D,
+                                                      .tiling = VK_IMAGE_TILING_OPTIMAL,
+                                                      .usage = VK_IMAGE_USAGE_SAMPLED_BIT,
+                                                      .flags = 0};
+
+    DbgMsg(">>> cube: PRE  VkPhysicalDeviceImageViewSupportEXTX @ %p\n", pfn_vkGetPhysicalDeviceImageFormatProperties2KHR);
+    VkResult result = pfn_vkGetPhysicalDeviceImageFormatProperties2KHR(physDev, &imgFmtInfo, &imgFmtProps);
+    DbgMsg(">>> cube: POST VkPhysicalDeviceImageViewSupportEXTX result=%d\n", result);
+
+    // Your app does something meaningful with result here.
+
+    return result;
+}
+
+#endif  // ENABLE_PORTABILITY_SUBSET
 
 void dumpMatrix(const char *note, mat4x4 MVP) {
     int i;
@@ -2954,6 +3043,10 @@ static void demo_init_vk(struct demo *demo) {
     demo->is_minimized = false;
     demo->cmd_pool = VK_NULL_HANDLE;
 
+#if ENABLE_PORTABILITY_SUBSET
+    DbgMsg("\n>>> cube: built with VK_EXTX_portability_subset v0.2\n\n");
+#endif
+
     // Look for validation layers
     VkBool32 validation_found = 0;
     if (demo->validate) {
@@ -2985,6 +3078,10 @@ static void demo_init_vk(struct demo *demo) {
     /* Look for instance extensions */
     VkBool32 surfaceExtFound = 0;
     VkBool32 platformSurfaceExtFound = 0;
+#if ENABLE_PORTABILITY_SUBSET
+    VkBool32 portabilitySubsetExtFound = VK_FALSE;
+    VkBool32 physicalDeviceProperties2ExtFound = VK_FALSE;
+#endif
     memset(demo->extension_names, 0, sizeof(demo->extension_names));
 
     err = vkEnumerateInstanceExtensionProperties(NULL, &instance_extension_count, NULL);
@@ -3045,11 +3142,30 @@ static void demo_init_vk(struct demo *demo) {
                     demo->extension_names[demo->enabled_extension_count++] = VK_EXT_DEBUG_UTILS_EXTENSION_NAME;
                 }
             }
+#if ENABLE_PORTABILITY_SUBSET
+            // If "VK_EXTX_portability_subset" exists, it _must_ be enabled and queried.
+            if (!strcmp(VK_EXTX_PORTABILITY_SUBSET_EXTENSION_NAME, instance_extensions[i].extensionName)) {
+                portabilitySubsetExtFound = VK_TRUE;
+                demo->extension_names[demo->enabled_extension_count++] = VK_EXTX_PORTABILITY_SUBSET_EXTENSION_NAME;
+                DbgMsg(">>> cube: enabling extension \"" VK_EXTX_PORTABILITY_SUBSET_EXTENSION_NAME "\"\n");
+            }
+            // "VK_EXTX_portability_subset" requires "VK_KHR_get_physical_device_properties2"
+            if (!strcmp(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, instance_extensions[i].extensionName)) {
+                physicalDeviceProperties2ExtFound = VK_TRUE;
+                demo->extension_names[demo->enabled_extension_count++] = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME;
+                DbgMsg(">>> cube: enabling extension \"" VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME "\"\n");
+            }
+#endif
             assert(demo->enabled_extension_count < 64);
         }
 
         free(instance_extensions);
     }
+
+#if ENABLE_PORTABILITY_SUBSET
+    DbgMsg(">>> cube: portabilitySubsetExtFound = %s\n", portabilitySubsetExtFound?"TRUE":"FALSE");
+    DbgMsg(">>> cube: physicalDeviceProperties2ExtFound = %s\n", physicalDeviceProperties2ExtFound?"TRUE":"FALSE");
+#endif
 
     if (!surfaceExtFound) {
         ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_SURFACE_EXTENSION_NAME
@@ -3188,6 +3304,12 @@ static void demo_init_vk(struct demo *demo) {
             "Please look at the Getting Started guide for additional information.\n",
             "vkEnumeratePhysicalDevices Failure");
     }
+
+#if ENABLE_PORTABILITY_SUBSET
+    testVkPhysicalDevicePortabilitySubsetFeaturesEXTX(demo->inst, demo->gpu);
+    testVkPhysicalDevicePortabilitySubsetPropertiesEXTX(demo->inst, demo->gpu);
+    testVkPhysicalDeviceImageViewSupportEXTX(demo->inst, demo->gpu);
+#endif
 
     /* Look for device extensions */
     uint32_t device_extension_count = 0;

--- a/cube/vk_extx_portability_subset.h
+++ b/cube/vk_extx_portability_subset.h
@@ -1,0 +1,76 @@
+#ifndef VK_EXTX_PORTABILITY_SUBSET_H_
+#define VK_EXTX_PORTABILITY_SUBSET_H_ 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+/*
+ Please Note:  This extension is currently defined as "EXTX", meaning "multivendor experimental".
+ That means the definition of this extension is in active development, and may break compatibility
+ between point releases (defined as any increment of VK_EXTX_PORTABILITY_SUBSET_SPEC_VERSION).
+ You are free to explore the extension and provide feedback, but it is not recommended to use this
+ extension for shipping applications, particularly applications that require the driver implementing this
+ extension to be linked dynamically and potentially "dropped-in" to the application execution environment.
+ */
+
+#include "vulkan/vulkan.h"
+
+#define VK_EXTX_PORTABILITY_SUBSET_SPEC_VERSION       1
+#define VK_EXTX_PORTABILITY_SUBSET_EXTENSION_NAME     "VK_EXTX_portability_subset"
+
+#define VK_EXTX_PORTABILITY_SUBSET_EXTENSION_ID 164
+// See enum_offset() from https://www.khronos.org/registry/vulkan/specs/1.1/styleguide.html#_assigning_extension_token_values
+#define VK_EXTX_PORTABILITY_SUBSET_STYPE_ID(x) \
+    ((VkStructureType)(1000000000 + 1000 * (VK_EXTX_PORTABILITY_SUBSET_EXTENSION_ID - 1) + x))
+#define VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_EXTX      VK_EXTX_PORTABILITY_SUBSET_STYPE_ID(0)
+#define VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_EXTX    VK_EXTX_PORTABILITY_SUBSET_STYPE_ID(1)
+#define VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_SUPPORT_EXTX               VK_EXTX_PORTABILITY_SUBSET_STYPE_ID(2)
+
+typedef struct VkPhysicalDevicePortabilitySubsetFeaturesEXTX {
+     VkStructureType    sType;
+     void*              pNext;
+     VkBool32           triangleFans;
+     VkBool32           separateStencilMaskRef;
+     VkBool32           events;
+     VkBool32           standardImageViews;
+     VkBool32           samplerMipLodBias;
+} VkPhysicalDevicePortabilitySubsetFeaturesEXTX;
+
+typedef struct VkPhysicalDevicePortabilitySubsetPropertiesEXTX {
+     VkStructureType    sType;
+     void*              pNext;
+     uint32_t           minVertexInputBindingStrideAlignment;
+} VkPhysicalDevicePortabilitySubsetPropertiesEXTX;
+
+typedef struct VkPhysicalDeviceImageViewSupportEXTX {
+     VkStructureType        sType;
+     void*                  pNext;
+     VkImageViewCreateFlags flags;
+     VkImageViewType        viewType;
+     VkFormat               format;
+     VkComponentMapping     components;
+     VkImageAspectFlags     aspectMask;
+} VkPhysicalDeviceImageViewSupportEXTX;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // VK_EXTX_PORTABILITY_SUBSET_H_


### PR DESCRIPTION
DO NOT MERGE, FOR REVIEW ONLY!

Demonstrate using the portability_subset extension using the vkcube example.
This example code does little exception checking, in order to provide
opportunities for the portability validation layer to detect issues.

Also included is a verbatim local copy of vk_extx_portability_subset.h from the v0.2 release.

Change-Id: Ibe631782e92427cb8dc025d98d4bef6ff41092c7