### PR TITLE
Cube: Add depth buffer per swapchain image

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -1828,14 +1828,14 @@ static void demo_prepare_descriptor_layout(struct demo *demo) {
     err = vkCreateDescriptorSetLayout(demo->device, &descriptor_layout, NULL, &demo->desc_layout);
     assert(!err);
 
-    const VkPipelineLayoutCreateInfo pPipelineLayoutCreateInfo = {
+    const VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = {
         .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
         .pNext = NULL,
         .setLayoutCount = 1,
         .pSetLayouts = &demo->desc_layout,
     };
 
-    err = vkCreatePipelineLayout(demo->device, &pPipelineLayoutCreateInfo, NULL, &demo->pipeline_layout);
+    err = vkCreatePipelineLayout(demo->device, &pipelineLayoutCreateInfo, NULL, &demo->pipeline_layout);
     assert(!err);
 }
 

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -1771,9 +1771,9 @@ void Demo::prepare_descriptor_layout() {
     auto result = device.createDescriptorSetLayout(&descriptor_layout, nullptr, &desc_layout);
     VERIFY(result == vk::Result::eSuccess);
 
-    auto const pPipelineLayoutCreateInfo = vk::PipelineLayoutCreateInfo().setSetLayoutCount(1).setPSetLayouts(&desc_layout);
+    auto const pipelineLayoutCreateInfo = vk::PipelineLayoutCreateInfo().setSetLayoutCount(1).setPSetLayouts(&desc_layout);
 
-    result = device.createPipelineLayout(&pPipelineLayoutCreateInfo, nullptr, &pipeline_layout);
+    result = device.createPipelineLayout(&pipelineLayoutCreateInfo, nullptr, &pipeline_layout);
     VERIFY(result == vk::Result::eSuccess);
 }
 


### PR DESCRIPTION
Addresses #122 by allocating a depth buffer for each swapchain image, removing the need for additional synchronization.  Also fixes a typo.