### PR TITLE
vulkaninfo: Add more descriptive error message

### DIFF
--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -917,6 +917,9 @@ static void AppCreateInstance(struct AppInstance *inst) {
     VkResult err = vkCreateInstance(&inst_info, NULL, &inst->instance);
     if (err == VK_ERROR_INCOMPATIBLE_DRIVER) {
         fprintf(stderr, "Cannot create Vulkan instance.\n");
+        fprintf(stderr,
+                "This problem is often caused by a faulty installation of the Vulkan driver or attempting to use a GPU that does "
+                "not support Vulkan.\n");
         ERR_EXIT(err);
     } else if (err) {
         ERR_EXIT(err);


### PR DESCRIPTION
Issue #207 mentions that one of the main problems users
encounter when troubleshooting is a failure to create a
Vulkan instance, and suggests that a statement be added
to this error message that describes the most common
causes of this problem.

This commit adds this additional statement to the current
error message.

Closes #207 