### PR TITLE
vulkaninfo: Add '--list-formats' option

### DIFF
--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -94,6 +94,7 @@ static bool html_output = false;
 static bool human_readable_output = true;
 static bool json_output = false;
 static uint32_t selected_gpu = 0;
+static bool list_formats = false;
 
 struct VkStructureHeader {
     VkStructureType sType;
@@ -2522,6 +2523,7 @@ void FormatPropsShortenedDump(const struct AppGpu *gpu) {
 }
 
 static void AppDevDump(const struct AppGpu *gpu, FILE *out) {
+    if (!list_formats && !json_output) return;
     if (html_output) {
         fprintf(out, "\t\t\t\t\t<details><summary>Format Properties</summary>\n");
     } else if (human_readable_output) {
@@ -5534,7 +5536,8 @@ void print_usage(char *argv0) {
     printf("--json=<gpu-number>   For a multi-gpu system, a single gpu can be targetted by\n");
     printf("                      specifying the gpu-number associated with the gpu of \n");
     printf("                      interest. This number can be determined by running\n");
-    printf("                      vulkaninfo without any options specified.\n\n");
+    printf("                      vulkaninfo without any options specified.\n");
+    printf("--list-formats        Print format properties.\n\n");
 }
 
 int main(int argc, char **argv) {
@@ -5553,6 +5556,9 @@ int main(int argc, char **argv) {
             if (strcmp(argv[i], "--html") == 0) {
                 human_readable_output = false;
                 html_output = true;
+                continue;
+            } else if (strcmp(argv[i], "--list-formats") == 0) {
+                list_formats = true;
                 continue;
             } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
                 print_usage(argv[0]);

--- a/vulkaninfo/vulkaninfo.md
+++ b/vulkaninfo/vulkaninfo.md
@@ -42,6 +42,11 @@ vulkaninfo --json
  Use the `--json` option to produce [DevSim-schema](https://schema.khronos.org/vulkan/devsim_1_0_0.json)-compatible JSON output for your device. Additionally, JSON output can be specified with the `-j` option and for multi-GPU systems, a single GPU can be targeted using the `--json=`*`GPU-number`* option where the *`GPU-number`* indicates the GPU of interest (e.g., `--json=0`). To determine the GPU number corresponding to a particular GPU, execute `vulkaninfo` with the `--html` option (or none at all) first; doing so will summarize all GPUs in the system.
  The generated configuration information can be used as input for the [`VK_LAYER_LUNARG_device_simulation`](./device_simulation_layer.html) layer.
 
+```
+vulkaninfo --list-formats
+```
+
+By default, Vulkan Info will not print format properties for your GPU. The `--list-formats` option will turn this feature on.
 
  Use the `--help` or `-h` option to produce a list of all available Vulkan Info options.
 ```
@@ -60,6 +65,7 @@ OPTIONS:
                       specifying the gpu-number associated with the gpu of
                       interest. This number can be determined by running
                       vulkaninfo without any options specified.
+--list-formats        Print format properties.
 ```
 
 ### Windows


### PR DESCRIPTION
This commit makes the following changes:
  - Vulkaninfo no longer prints format properties by default.
  - Adds the `--list-formats` option to turn format listing back on.
  - Adds a description of `--list-formats` to `vulkaninfo.md`