### PR TITLE
cube: Fix DbgMsg() use of varargs

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -90,9 +90,9 @@ bool in_callback = false;
 void DbgMsg(char *fmt, ...) {
     va_list va;
     va_start(va, fmt);
-    printf(fmt, va);
-    fflush(stdout);
+    vprintf(fmt, va);
     va_end(va);
+    fflush(stdout);
 }
 
 #elif defined __ANDROID__
@@ -125,9 +125,9 @@ void DbgMsg(const char *fmt, ...) {
 void DbgMsg(char *fmt, ...) {
     va_list va;
     va_start(va, fmt);
-    printf(fmt, va);
-    fflush(stdout);
+    vprintf(fmt, va);
     va_end(va);
+    fflush(stdout);
 }
 #endif
 


### PR DESCRIPTION
vprintf (not printf) must be used with va_list.

Also moved flush() outside the va_list's scope.

Change-Id: Ib82b9f7e7ec1f954619c3eadb8dcaeb08abf113a