### PR TITLE
build: Fix LunarXchange Issue 862

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -28,7 +28,7 @@
       "commit" : "v1.0.35",
       "custom_build" : [
         "./fetchDependencies --v-headers-root {0[Vulkan-Headers][repo_dir]} --glslang-root {0[glslang][repo_dir]}",
-        "xcodebuild -project MoltenVKPackaging.xcodeproj GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS MVK_LOGGING_ENABLED=0' -scheme \"MoltenVK Package\" build"
+        "xcodebuild -project MoltenVKPackaging.xcodeproj GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS MVK_CONFIG_LOG_LEVEL=1' -scheme \"MoltenVK Package\" build"
       ],
       "build_step" : "custom",
       "build_platforms" : [


### PR DESCRIPTION
Modified MoltenVK build arguments for MacOS from
`MVK_LOGGING_ENABLED=0` to `MVK_CONFIG_LOG_LEVEL=1`.

This allows users to set the logging information they
want when an application is run using MoltenVK.

By default, only errors are logged.

Fixes [LunarXchange Issue #862](https://vulkan.lunarg.com/issue/view/5d18ef0686da81065fffeb52)