### PR TITLE
Workaround macOS cube issue

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -3688,6 +3688,12 @@ static void demo_init(struct demo *demo, int argc, char **argv) {
     memset(demo, 0, sizeof(*demo));
     demo->presentMode = VK_PRESENT_MODE_FIFO_KHR;
     demo->frameCount = INT32_MAX;
+    
+#if defined(VK_USE_PLATFORM_MACOS_MVK)
+    // MoltenVK may not allow host coherent mapping to linear tiled images
+    // Force the use of a staging buffer to be safe
+    demo->use_staging_buffer = true;
+#endif
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--use_staging") == 0) {

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -899,6 +899,12 @@ void Demo::init(int argc, char **argv) {
     presentMode = vk::PresentModeKHR::eFifo;
     frameCount = UINT32_MAX;
     use_xlib = false;
+    
+#if defined(VK_USE_PLATFORM_MACOS_MVK)
+    // MoltenVK may not allow host coherent mapping to linear tiled images
+    // Force the use of a staging buffer to be safe
+    use_staging_buffer = true;
+#endif
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--use_staging") == 0) {


### PR DESCRIPTION
Latest version of MoltenVK behaves in an apparently non-conformant way
by not allowing some linear images to be mapped to memory with
VK_MEMORY_PROPERTY_HOST_COHERENT_BIT.  This change sidesteps the issue
by forcing the use of staging buffer for loading textures.