### PR TITLE
vulkaninfo: fix forgotten </details> tag

### DIFF
--- a/vulkaninfo/vulkaninfo.c
+++ b/vulkaninfo/vulkaninfo.c
@@ -4637,6 +4637,8 @@ static void AppGpuDumpProps(const struct AppGpu *gpu, FILE *out) {
                             "\t\t\t\t\t\t<details><summary>pciFunction = <span class='val'>%" PRIuLEAST32
                             "</span></summary></details>\n",
                             pci_bus_properties->pciFunction);
+                    fprintf(out, "\t\t\t\t\t</details>\n");
+
                 } else if (human_readable_output) {
                     printf("\nVkPhysicalDevicePCIBusInfoProperties\n");
                     printf("====================================\n");


### PR DESCRIPTION
Fixes incorrect html output from a forgotten html closing tag.

Change-Id: I3e731dafc0b191dfaa71426a7a88b6ccd28477c2