### PR TITLE
cube: Add support for VK_EXT_headless_surface

### DIFF
--- a/cube/CMakeLists.txt
+++ b/cube/CMakeLists.txt
@@ -103,6 +103,8 @@ elseif(UNIX AND NOT APPLE) # i.e. Linux
         add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR)
     elseif(CUBE_WSI_SELECTION STREQUAL "DISPLAY")
         add_definitions(-DVK_USE_PLATFORM_DISPLAY_KHR)
+    elseif(CUBE_WSI_SELECTION STREQUAL "HEADLESS")
+        add_definitions(-DVK_USE_PLATFORM_HEADLESS_EXT)
     else()
         message(FATAL_ERROR "Unrecognized value for CUBE_WSI_SELECTION: ${CUBE_WSI_SELECTION}")
     endif()


### PR DESCRIPTION
Adds HEADLESS as an option for CUBE_WSI_SELECTION
This builds cube using the VK_EXT_headless_surface
extension.

Change-Id: I3ec0d323fce996f15f3f85682a68758b1a213408