### PR TITLE
build: Fix known-good MoltenVK building

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -27,7 +27,7 @@
       "install_dir" : "MoltenVK",
       "commit" : "v1.0.36",
       "custom_build" : [
-        "./fetchDependencies --v-headers-root {0[Vulkan-Headers][repo_dir]} --glslang-root {0[glslang][repo_dir]}",
+        "./fetchDependencies --glslang-root {0[glslang][repo_dir]}",
         "xcodebuild -project MoltenVKPackaging.xcodeproj GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS MVK_CONFIG_LOG_LEVEL=1' -scheme \"MoltenVK Package\" build"
       ],
       "build_step" : "custom",


### PR DESCRIPTION
MoltenVK seems to have trouble building on the
current version of Vulkan-Headers.

Since Vulkan-Headers doesn't take very long to build and
changes often, this fix removes the reuse of the
Vulkan-Headers repo, whose version is provided by Vulkan-Tools
known-good.json, in the MoltenVK build.

It instead uses the version of Vulkan-Headers provided by
the MoltenVK known-good when building MoltenVK.

**Note:** Vulkan-Tools and other required repos are still
built with the version of Vulkan-Headers provided by
Vulkan-Tools known-good.json.