### PR TITLE
vulkaninfo: Fix closing immediately on windows

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -747,5 +747,11 @@ int main(int argc, char **argv) {
     }
 #endif
 
+#ifdef _WIN32
+    if (ConsoleIsExclusive()) {
+        Sleep(INFINITE);
+    }
+#endif
+
     return 0;
 }


### PR DESCRIPTION
On windows the console window will immediately close after running
vulkaninfo, this fixes it.

