### PR TITLE
vulkaninfo: Present Surfaces now wont show duplicates

### DIFF
--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -2120,4 +2120,49 @@ void chain_iterator_format_properties2(Printer &p, AppGpu &gpu, void * place) {
         place = structure->pNext;
     }
 }
+bool operator==(const VkExtent2D & a, const VkExtent2D b);
+bool operator==(const VkSurfaceCapabilities2EXT & a, const VkSurfaceCapabilities2EXT b);
+bool operator==(const VkSurfaceCapabilities2KHR & a, const VkSurfaceCapabilities2KHR b);
+bool operator==(const VkSurfaceCapabilitiesKHR & a, const VkSurfaceCapabilitiesKHR b);
+bool operator==(const VkSurfaceFormat2KHR & a, const VkSurfaceFormat2KHR b);
+bool operator==(const VkSurfaceFormatKHR & a, const VkSurfaceFormatKHR b);
+bool operator==(const VkExtent2D & a, const VkExtent2D b) {
+    return a.width == b.width
+        && a.height == b.height;
+}
+bool operator==(const VkSurfaceCapabilities2EXT & a, const VkSurfaceCapabilities2EXT b) {
+    return a.minImageCount == b.minImageCount
+        && a.maxImageCount == b.maxImageCount
+        && a.currentExtent == b.currentExtent
+        && a.minImageExtent == b.minImageExtent
+        && a.maxImageExtent == b.maxImageExtent
+        && a.maxImageArrayLayers == b.maxImageArrayLayers
+        && a.supportedTransforms == b.supportedTransforms
+        && a.currentTransform == b.currentTransform
+        && a.supportedCompositeAlpha == b.supportedCompositeAlpha
+        && a.supportedUsageFlags == b.supportedUsageFlags
+        && a.supportedSurfaceCounters == b.supportedSurfaceCounters;
+}
+bool operator==(const VkSurfaceCapabilities2KHR & a, const VkSurfaceCapabilities2KHR b) {
+    return a.surfaceCapabilities == b.surfaceCapabilities;
+}
+bool operator==(const VkSurfaceCapabilitiesKHR & a, const VkSurfaceCapabilitiesKHR b) {
+    return a.minImageCount == b.minImageCount
+        && a.maxImageCount == b.maxImageCount
+        && a.currentExtent == b.currentExtent
+        && a.minImageExtent == b.minImageExtent
+        && a.maxImageExtent == b.maxImageExtent
+        && a.maxImageArrayLayers == b.maxImageArrayLayers
+        && a.supportedTransforms == b.supportedTransforms
+        && a.currentTransform == b.currentTransform
+        && a.supportedCompositeAlpha == b.supportedCompositeAlpha
+        && a.supportedUsageFlags == b.supportedUsageFlags;
+}
+bool operator==(const VkSurfaceFormat2KHR & a, const VkSurfaceFormat2KHR b) {
+    return a.surfaceFormat == b.surfaceFormat;
+}
+bool operator==(const VkSurfaceFormatKHR & a, const VkSurfaceFormatKHR b) {
+    return a.format == b.format
+        && a.colorSpace == b.colorSpace;
+}
 


### PR DESCRIPTION
If a machine has multiple surface types that work with the
same gpu and have the same properties, vulkainfo will now
list them in a short array instead of duplicating the entire
surfaces information. To do this required being able to compare
vulkan objects, necesitating the autogeneration of comparators
for vulkan structs. This patch also refactors some of the
device creation code to better reflect the actual data
dependencies of the various vulkan objects.

files modified
 - vulkaninfo/vulkaninfo.cpp
 - vulkaninfo/vulkaninfo.h
 - scripts/vulkaninfo_generator.py
 - vulkaninfo/generated/vulkaninfo.hpp

Change-Id: Ifda51eacc3883982a6e2f7f60439827eb355c204