### PR TITLE
cube: Revert 1.1.114 SDK workaround for vkcube

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -3704,12 +3704,6 @@ static void demo_init(struct demo *demo, int argc, char **argv) {
     demo->presentMode = VK_PRESENT_MODE_FIFO_KHR;
     demo->frameCount = INT32_MAX;
     
-#if defined(VK_USE_PLATFORM_MACOS_MVK)
-    // MoltenVK may not allow host coherent mapping to linear tiled images
-    // Force the use of a staging buffer to be safe
-    demo->use_staging_buffer = true;
-#endif
-
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--use_staging") == 0) {
             demo->use_staging_buffer = true;

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -909,12 +909,6 @@ void Demo::init(int argc, char **argv) {
     frameCount = UINT32_MAX;
     use_xlib = false;
 
-#if defined(VK_USE_PLATFORM_MACOS_MVK)
-    // MoltenVK may not allow host coherent mapping to linear tiled images
-    // Force the use of a staging buffer to be safe
-    use_staging_buffer = true;
-#endif
-
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--use_staging") == 0) {
             use_staging_buffer = true;


### PR DESCRIPTION
During the release of the 1.1.114 MacOS SDK, a workaround
for vkcube was needed to get it functioning in time for release.

The underlying problem has since been fixed, and this workaround
is not longer necessary.