### PR TITLE
vulkaninfo: fix infinite sleep for non text outputs

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -676,11 +676,7 @@ int main(int argc, char **argv) {
     if (ConsoleIsExclusive()) ConsoleEnlarge();
 #endif
 
-    bool human_readable_output = true;
-    bool html_output = false;
-    bool json_output = false;
     uint32_t selected_gpu = 0;
-    bool show_formats = false;
 
     // Combinations of output: html only, html AND json, json only, human readable only
     for (int i = 1; i < argc; ++i) {
@@ -791,11 +787,7 @@ int main(int argc, char **argv) {
     }
 #endif
 
-#ifdef _WIN32
-    if (ConsoleIsExclusive()) {
-        Sleep(INFINITE);
-    }
-#endif
+    WAIT_FOR_CONSOLE_DESTROY;
 
     return 0;
 }


### PR DESCRIPTION
Previous versions, in win32 would sleep infinitely if a crash occured. 
This commit will first check if its a text output first before sleeping, to preserve 
the error if it is in a console but return immediate if it isn't.

Change-Id: Ib1b43001e970c8c3114e666d96b24dc3c557a579