### PR TITLE
vulkaninfo: added more documentation for show-formats

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -668,7 +668,9 @@ void print_usage(const char *argv0) {
     std::cout << "                      specifying the gpu-number associated with the gpu of \n";
     std::cout << "                      interest. This number can be determined by running\n";
     std::cout << "                      vulkaninfo without any options specified.\n";
-    std::cout << "--show-formats        Display the format properties of each physical device.\n\n";
+    std::cout << "--show-formats        Display the format properties of each physical device.\n";
+    std::cout << "                      Note: This option does not affect html or json output;\n";
+    std::cout << "                      they will always print format properties.\n\n";
 }
 
 int main(int argc, char **argv) {

--- a/vulkaninfo/vulkaninfo.md
+++ b/vulkaninfo/vulkaninfo.md
@@ -61,6 +61,9 @@ OPTIONS:
                       interest. This number can be determined by running
                       vulkaninfo without any options specified.
 --show-formats        Display the format properties of each physical device.
+                      Note: This option does not affect html or json output;
+                      they will always print format properties.
+
 ```
 
 ### Windows


### PR DESCRIPTION
The indented behavior was to only show format properties if requested
for text output and always show them for html & json. This commit
modifies the --help output and documentation to better reflect this
behavior.

files modified
 - vulkaninfo/vulkaninfo.cpp
 - vulkaninfo/vulkaninfo.md

Change-Id: I5e35b8af2db74c37dfadf669ffc81e69304fc4e0