### PR TITLE
vulkaninfo: make where output goes uniform

### DIFF
--- a/vulkaninfo/vulkaninfo.md
+++ b/vulkaninfo/vulkaninfo.md
@@ -51,12 +51,10 @@ USAGE: ./vulkaninfo [options]
 
 OPTIONS:
 -h, --help            Print this help.
---html                Produce an html version of vulkaninfo output, saved as
-                      "vulkaninfo.html" in the directory in which the command is
-                      run.
--j, --json            Produce a json version of vulkaninfo output to standard
-                      output.
---json=<gpu-number>   For a multi-gpu system, a single gpu can be targetted by
+--html                Produces an html version of vulkaninfo to standard output.
+-j, --json            Produces a json version of vulkaninfo to standard output of
+                      the first gpu in the system conforming to the DevSim schema.
+--json=<gpu-number>   For a multi-gpu system, a single gpu can be targeted by
                       specifying the gpu-number associated with the gpu of
                       interest. This number can be determined by running
                       vulkaninfo without any options specified.


### PR DESCRIPTION
Currently, text and json output are put to standard output while
html is put to vulkaninfo.html. This commit makes it uniform so that
unless specifed, all output types are put to standard out. By using
the `--dest=<filename>` command line argument a user can manually
specify the file name of where to put the output.
In this implementation, the file is appended with the extension
appropriate for the output, so .txt for the default text, .html for
html, and .json for json.

This is a breaking change in that --html will not create a new file,
but this brings the application back in line with user expectations.

files modified
 - vulkaninfo/vulkaninfo.cpp
 - vulkaninfo/vulkaninfo.md

Change-Id: I97004a1743e13f938b4b0210ad8373abc5e57dd3