### PR TITLE
vulkaninfo: return properly on xcb onnection errors

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -503,7 +503,9 @@ static void AppCreateXcbWindow(AppInstance &inst) {
     if (conn_error) {
         fprintf(stderr, "XCB failed to connect to the X server due to error:%d.\n", conn_error);
         fflush(stderr);
+        xcb_disconnect(inst.xcb_connection);
         inst.xcb_connection = nullptr;
+        return;
     }
 
     setup = xcb_get_setup(inst.xcb_connection);


### PR DESCRIPTION
Calling xcb_disconnect on the connection to release memory and
return.

Otherwise on a headless display with no X11 backend the nullptr
for the connection will cause segmentation fault on following
xcb calls when xcb_connection_has_error returns a code.

examples ran on headless displays

DISPLAY=:0 vulkaninfo returns XCB_CONN_ERROR
DISPLAY=foobar vulkaninfo returns XCB_CONN_CLOSED_PARSE_ERR

Signed-off-by: Daniel Charles <daniel.charles@intel.com>