### PR TITLE
vulkaninfo: add missing debug report flags

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -344,7 +344,8 @@ struct AppInstance {
         AppGetInstanceExtensions();
 
         const VkDebugReportCallbackCreateInfoEXT dbg_info = {VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT, nullptr,
-                                                             VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT,
+                                                             VK_DEBUG_REPORT_INFORMATION_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT |
+                                                                 VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_DEBUG_BIT_EXT,
                                                              DbgCallback};
 
         const VkApplicationInfo app_info = {


### PR DESCRIPTION
Previously, the debug report extension only reported ERROR and WARNING
messages. This commit add the INFORMATION and DEBUG flags to the
debug report create info struct, to catch more loader messages.

Change-Id: I5332ec6bed5466aaa1263bcee0372c7e22313ead