### PR TITLE
vulkaninfo: safely handle device groups not supported

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -231,8 +231,15 @@ void DumpPresentableSurfaces(Printer &p, AppInstance &inst, const std::vector<st
 
 void DumpGroups(Printer &p, AppInstance &inst) {
     if (inst.CheckExtensionEnabled(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME)) {
-        p.SetHeader().ObjectStart("Groups");
         auto groups = GetGroups(inst);
+        if (groups.size() == 0) {
+            p.SetHeader().ObjectStart("Groups");
+            p.PrintElement("No Device Groups Found");
+            p.ObjectEnd();
+            p.AddNewline();
+            return;
+        }
+        p.SetHeader().ObjectStart("Groups");
         int group_id = 0;
         for (auto &group : groups) {
             p.ObjectStart("Device Group Properties (Group " + std::to_string(group_id) + ")");

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -998,11 +998,15 @@ std::vector<VkPhysicalDeviceGroupProperties> GetGroups(AppInstance &inst) {
         VkResult err;
         do {
             err = vkEnumeratePhysicalDeviceGroupsKHR(inst.instance, &group_count, NULL);
-            if (err != VK_SUCCESS && err != VK_INCOMPLETE) ERR_EXIT(err);
+            if (err != VK_SUCCESS && err != VK_INCOMPLETE) {
+                return {};
+            }
             groups.resize(group_count);
 
             err = vkEnumeratePhysicalDeviceGroupsKHR(inst.instance, &group_count, groups.data());
-            if (err != VK_SUCCESS && err != VK_INCOMPLETE) ERR_EXIT(err);
+            if (err != VK_SUCCESS && err != VK_INCOMPLETE) {
+                return {};
+            }
         } while (err == VK_INCOMPLETE);
         return groups;
     }


### PR DESCRIPTION
Previously, vulkaninfo would hard crash if device groups failed
the call to vkEnumeratePhysicalDeviceGroupsKHR. If an error happens
now the GetGroups call simply returns an empty vector.

Files Modified:
	vulkaninfo/vulkaninfo.cpp
	vulkaninfo/vulkaninfo.h

Change-Id: I60ed002161523cede53a144be3fad1d4bb0dd1f1