### PR TITLE
vulkaninfo: exit on invalid gpu selected

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -756,7 +756,8 @@ int main(int argc, char **argv) {
     }
 
     if (selected_gpu >= gpus.size()) {
-        selected_gpu = 0;
+        std::cout << "The selected gpu (" << selected_gpu << ") is not in the valid range of 0 to " << gpus.size() - 1 << ".\n";
+        return 0;
     }
 
     std::vector<std::unique_ptr<Printer>> printers;


### PR DESCRIPTION
Before when using the --json=X flag, if X was out of range it would
default to the first gpu. Now it emits an error and exits.

Changes to be committed:
	modified:   vulkaninfo/vulkaninfo.cpp

Change-Id: I0df1100f7ccc6ca37069f7798f3b620efc9a8bee