### PR TITLE
Fix GN build

### DIFF
--- a/build-gn/secondary/build_overrides/vulkan_headers.gni
+++ b/build-gn/secondary/build_overrides/vulkan_headers.gni
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+vulkan_use_x11 = true


### PR DESCRIPTION
Vulkan-Headers uses a new build_override include to toggle x11 support