### PR TITLE
vulkaninfo: Support VK_EXT_tooling_info

### DIFF
--- a/scripts/vulkaninfo_generator.py
+++ b/scripts/vulkaninfo_generator.py
@@ -80,8 +80,8 @@ std::string to_hex_str(Printer &p, T i) {
 '''
 
 # used in the .cpp code
-structures_to_gen = ['VkExtent3D', 'VkExtent2D', 'VkPhysicalDeviceLimits', 'VkPhysicalDeviceFeatures',
-                     'VkPhysicalDeviceSparseProperties', 'VkSurfaceCapabilitiesKHR', 'VkSurfaceFormatKHR', 'VkLayerProperties']
+structures_to_gen = ['VkExtent3D', 'VkExtent2D', 'VkPhysicalDeviceLimits', 'VkPhysicalDeviceFeatures', 'VkPhysicalDeviceSparseProperties',
+                     'VkSurfaceCapabilitiesKHR', 'VkSurfaceFormatKHR', 'VkLayerProperties', 'VkPhysicalDeviceToolPropertiesEXT']
 enums_to_gen = ['VkResult', 'VkFormat', 'VkPresentModeKHR',
                 'VkPhysicalDeviceType', 'VkImageTiling']
 flags_to_gen = ['VkSurfaceTransformFlagsKHR', 'VkCompositeAlphaFlagsKHR',

--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -773,6 +773,30 @@ void DumpVkDeviceGroupPresentModeFlagBitsKHR(Printer &p, std::string name, VkDev
     DumpVkDeviceGroupPresentModeFlagsKHR(p, name, value, width);
     p.ObjectEnd();
 }
+void DumpVkToolPurposeFlagsEXT(Printer &p, std::string name, VkToolPurposeFlagBitsEXT value, int width = 0) {
+    if (value == 0) p.PrintElement("None");
+    if (1 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_VALIDATION_BIT_EXT");
+    if (2 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_PROFILING_BIT_EXT");
+    if (4 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_TRACING_BIT_EXT");
+    if (8 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_ADDITIONAL_FEATURES_BIT_EXT");
+    if (16 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_MODIFYING_FEATURES_BIT_EXT");
+    if (32 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_DEBUG_REPORTING_BIT_EXT");
+    if (64 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_DEBUG_MARKERS_BIT_EXT");
+    if (32 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_DEBUG_REPORTING_BIT_EXT");
+    if (64 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_DEBUG_MARKERS_BIT_EXT");
+}
+void DumpVkToolPurposeFlagsEXT(Printer &p, std::string name, VkToolPurposeFlagsEXT value, int width = 0) {
+    if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
+    p.ObjectStart(name);
+    DumpVkToolPurposeFlagsEXT(p, name, static_cast<VkToolPurposeFlagBitsEXT>(value), width);
+    p.ObjectEnd();
+}
+void DumpVkToolPurposeFlagBitsEXT(Printer &p, std::string name, VkToolPurposeFlagBitsEXT value, int width = 0) {
+    if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
+    p.ObjectStart(name);
+    DumpVkToolPurposeFlagsEXT(p, name, value, width);
+    p.ObjectEnd();
+}
 void DumpVkPhysicalDeviceFeatures(Printer &p, std::string name, VkPhysicalDeviceFeatures &obj) {
     p.ObjectStart(name);
     p.PrintKeyBool("robustBufferAccess", static_cast<bool>(obj.robustBufferAccess), 39);
@@ -1616,6 +1640,15 @@ void DumpVkPhysicalDeviceBufferDeviceAddressFeaturesEXT(Printer &p, std::string 
     p.PrintKeyBool("bufferDeviceAddress", static_cast<bool>(obj.bufferDeviceAddress), 32);
     p.PrintKeyBool("bufferDeviceAddressCaptureReplay", static_cast<bool>(obj.bufferDeviceAddressCaptureReplay), 32);
     p.PrintKeyBool("bufferDeviceAddressMultiDevice", static_cast<bool>(obj.bufferDeviceAddressMultiDevice), 32);
+    p.ObjectEnd();
+}
+void DumpVkPhysicalDeviceToolPropertiesEXT(Printer &p, std::string name, VkPhysicalDeviceToolPropertiesEXT &obj) {
+    p.ObjectStart(name);
+    p.PrintKeyString("name", obj.name, 16);
+    p.PrintKeyString("version", obj.version, 16);
+    DumpVkToolPurposeFlagsEXT(p, "purposes", obj.purposes, 16);
+    p.PrintKeyString("description", obj.description, 16);
+    p.PrintKeyString("layer", obj.layer, 16);
     p.ObjectEnd();
 }
 void DumpVkPhysicalDeviceFragmentShaderInterlockFeaturesEXT(Printer &p, std::string name, VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT &obj) {

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -546,6 +546,17 @@ void GpuDumpFormatProperty(Printer &p, VkFormat fmt, VkFormatProperties prop) {
     p.ObjectEnd();
 }
 
+void GpuDumpToolingInfo(Printer &p, AppGpu &gpu) {
+    auto tools = GetToolingInfo(gpu);
+    if (tools.size() > 0) {
+        p.SetSubHeader().ObjectStart("Tooling Info");
+        for (auto tool : tools) {
+            DumpVkPhysicalDeviceToolPropertiesEXT(p, tool.name, tool);
+        }
+        p.ObjectEnd();
+    }
+}
+
 void GpuDevDump(Printer &p, AppGpu &gpu) {
     if (p.Type() == OutputType::json) {
         p.ArrayStart("ArrayOfVkFormatProperties");
@@ -648,6 +659,9 @@ void DumpGpu(Printer &p, AppGpu &gpu, bool show_formats) {
     }
     GpuDumpMemoryProps(p, gpu);
     GpuDumpFeatures(p, gpu);
+
+    if (p.Type() != OutputType::json) GpuDumpToolingInfo(p, gpu);
+
     if (p.Type() != OutputType::text || show_formats) {
         GpuDevDump(p, gpu);
     }

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -296,6 +296,7 @@ struct AppInstance {
     PFN_vkGetPhysicalDeviceMemoryProperties2KHR vkGetPhysicalDeviceMemoryProperties2KHR;
     PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR vkGetPhysicalDeviceSurfaceCapabilities2KHR;
     PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT vkGetPhysicalDeviceSurfaceCapabilities2EXT;
+    PFN_vkGetPhysicalDeviceToolPropertiesEXT vkGetPhysicalDeviceToolPropertiesEXT;
 
     std::vector<SurfaceExtension> surface_extensions;
 
@@ -437,6 +438,7 @@ struct AppInstance {
         LOAD_INSTANCE_VK_CMD(vkGetPhysicalDeviceMemoryProperties2KHR);
         LOAD_INSTANCE_VK_CMD(vkGetPhysicalDeviceSurfaceCapabilities2KHR);
         LOAD_INSTANCE_VK_CMD(vkGetPhysicalDeviceSurfaceCapabilities2EXT);
+        LOAD_INSTANCE_VK_CMD(vkGetPhysicalDeviceToolPropertiesEXT);
 
 #undef LOAD_INSTANCE_VK_CMD
     }
@@ -1435,6 +1437,26 @@ struct AppQueueFamilyProperties {
         }
     }
 };
+
+std::vector<VkPhysicalDeviceToolPropertiesEXT> GetToolingInfo(AppGpu &gpu) {
+    uint32_t count = 0;
+    VkResult err;
+    std::vector<VkPhysicalDeviceToolPropertiesEXT> tool_properties;
+
+    if (gpu.inst.vkGetPhysicalDeviceToolPropertiesEXT == nullptr) return {};
+    do {
+        err = gpu.inst.vkGetPhysicalDeviceToolPropertiesEXT(gpu.phys_device, &count, nullptr);
+        if (err != VK_SUCCESS && err != VK_INCOMPLETE) {
+            return {};
+        }
+        tool_properties.resize(count);
+        err = gpu.inst.vkGetPhysicalDeviceToolPropertiesEXT(gpu.phys_device, &count, tool_properties.data());
+        if (err != VK_SUCCESS && err != VK_INCOMPLETE) {
+            return {};
+        }
+    } while (err == VK_INCOMPLETE);
+    return tool_properties;
+}
 
 // --------- Format Properties ----------//
 


### PR DESCRIPTION
Added support for the VK_EXT_tooling_info extension.

Files modified:
	modified:   scripts/vulkaninfo_generator.py
	modified:   vulkaninfo/generated/vulkaninfo.hpp
	modified:   vulkaninfo/vulkaninfo.cpp
	modified:   vulkaninfo/vulkaninfo.h

Change-Id: I9fc4e239b37fdff9ecdba4bf947a0b5d57d06745