### PR TITLE
vulkaninfo: erroneous presentation surfaces

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -902,6 +902,7 @@ void SetupWindowExtensions(AppInstance &inst) {
 class AppSurface {
    public:
     AppInstance &inst;
+	VkPhysicalDevice phys_device;
     SurfaceExtension surface_extension;
 
     std::vector<VkPresentModeKHR> surf_present_modes;
@@ -915,7 +916,7 @@ class AppSurface {
 
     AppSurface(AppInstance &inst, VkPhysicalDevice phys_device, SurfaceExtension surface_extension,
                std::vector<pNextChainBuildingBlockInfo> &sur_extension_pNextChain)
-        : inst(inst), surface_extension(surface_extension) {
+        : inst(inst), phys_device(phys_device), surface_extension(surface_extension) {
         uint32_t present_mode_count = 0;
         VkResult error =
             inst.vkGetPhysicalDeviceSurfacePresentModesKHR(phys_device, surface_extension.surface, &present_mode_count, nullptr);


### PR DESCRIPTION
In the commit to reduce unecessary surfaces being listed where only the surface extension differed, the which gpu the surface was using wasn't considered, creating a matrix of surfaces, when there should of been only 1. This fixes it by making sure to only collate surface extensions if they share a GPU.

Change-Id: Ib0d17a229713b3e4cec6f2885f81c96c5232ee0b