### PR TITLE
cube: Fix vkcubepp.app bundle crashing on MacOS

### DIFF
--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -1894,7 +1894,8 @@ void Demo::prepare_pipeline() {
                                        .setDepthBiasEnable(VK_FALSE)
                                        .setLineWidth(1.0f);
 
-    auto const multisampleInfo = vk::PipelineMultisampleStateCreateInfo();
+    auto const multisampleInfo =
+        vk::PipelineMultisampleStateCreateInfo().setPSampleMask(nullptr).setRasterizationSamples(vk::SampleCountFlagBits::e1);
 
     auto const stencilOp =
         vk::StencilOpState().setFailOp(vk::StencilOp::eKeep).setPassOp(vk::StencilOp::eKeep).setCompareOp(vk::CompareOp::eAlways);

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -25,7 +25,7 @@
       "sub_dir" : "MoltenVK",
       "build_dir" : "MoltenVK",
       "install_dir" : "MoltenVK",
-      "commit" : "v1.0.38",
+      "commit" : "v1.0.40",
       "custom_build" : [
         "./fetchDependencies --glslang-root {0[glslang][repo_dir]}",
         "xcodebuild -project MoltenVKPackaging.xcodeproj GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS MVK_CONFIG_LOG_LEVEL=1' -scheme \"MoltenVK Package\" build"


### PR DESCRIPTION
The vk::PipelineMultisampleStateCreateInfo used to create
vkcubepp's graphics pipeline was not initalizing
rasterizationSamples as expected.

Manually setting rasterizationSamples to `VK_SAMPLE_COUNT_1_BIT`
seems to have fixed the problem.