### PR TITLE
vulkaninfo: use gpu version instead of instance

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -349,7 +349,7 @@ void GpuDumpProps(Printer &p, AppGpu &gpu) {
     if (p.Type() != OutputType::json) {
         if (gpu.inst.CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
             void *place = gpu.props2.pNext;
-            chain_iterator_phys_device_props2(p, gpu.inst, gpu, place, gpu.inst.vk_version);
+            chain_iterator_phys_device_props2(p, gpu.inst, gpu, place, gpu.api_version);
         }
     }
     p.AddNewline();
@@ -521,7 +521,7 @@ void GpuDumpFeatures(Printer &p, AppGpu &gpu) {
     if (p.Type() != OutputType::json) {
         if (gpu.inst.CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
             void *place = gpu.features2.pNext;
-            chain_iterator_phys_device_features2(p, gpu, place, gpu.inst.vk_version);
+            chain_iterator_phys_device_features2(p, gpu, place, gpu.api_version);
         }
     }
 }

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -1053,6 +1053,7 @@ struct AppGpu {
     AppInstance &inst;
     uint32_t id;
     VkPhysicalDevice phys_device;
+    VulkanVersion api_version;
 
     VkPhysicalDeviceProperties props;
     VkPhysicalDeviceProperties2KHR props2;
@@ -1083,6 +1084,10 @@ struct AppGpu {
     AppGpu(AppInstance &inst, uint32_t id, VkPhysicalDevice phys_device, pNextChainInfos chainInfos)
         : inst(inst), id(id), phys_device(phys_device) {
         vkGetPhysicalDeviceProperties(phys_device, &props);
+
+        // needs to find the minimum of the instance and device version, and use that to print the device info
+        uint32_t gpu_version = props.apiVersion < inst.instance_version ? props.apiVersion : inst.instance_version;
+        api_version = {VK_VERSION_MAJOR(gpu_version), VK_VERSION_MINOR(gpu_version), VK_VERSION_PATCH(gpu_version)};
 
         if (inst.CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
             props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;


### PR DESCRIPTION
vulkaninfo would previously use the instance version for determining
what capabilities to display. This leads to issues when running a 1.2
loader on a 1.1 or 1.0 driver.

Changes to be committed:
	modified:   vulkaninfo/vulkaninfo.cpp
	modified:   vulkaninfo/vulkaninfo.h

Change-Id: I7f12c10d48f99d429025337b00c677936a040d13