### PR TITLE
vulkaninfo: remove duplicate flags/bitmasks

### DIFF
--- a/scripts/vulkaninfo_generator.py
+++ b/scripts/vulkaninfo_generator.py
@@ -788,6 +788,13 @@ class VulkanBitmask:
             if(support == "disabled"):
                 continue
 
+            duplicate = False
+            for option in self.options:
+                if option.name == childName:
+                    duplicate = True
+            if duplicate:
+                continue
+
             self.options.append(VulkanEnum.Option(
                 childName, childValue, childBitpos, childComment))
 

--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -782,8 +782,6 @@ void DumpVkToolPurposeFlagsEXT(Printer &p, std::string name, VkToolPurposeFlagBi
     if (16 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_MODIFYING_FEATURES_BIT_EXT");
     if (32 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_DEBUG_REPORTING_BIT_EXT");
     if (64 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_DEBUG_MARKERS_BIT_EXT");
-    if (32 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_DEBUG_REPORTING_BIT_EXT");
-    if (64 & value) p.SetAsType().PrintElement("TOOL_PURPOSE_DEBUG_MARKERS_BIT_EXT");
 }
 void DumpVkToolPurposeFlagsEXT(Printer &p, std::string name, VkToolPurposeFlagsEXT value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }


### PR DESCRIPTION
Tooling info added flags for different purposes, however they let the debug utils, debug report
and debug marker extensions use the same bitpos values for the same flags.
The autogen didn't consider this possibly, and would output the flags multiple times.

Changes to be committed:
	modified:   scripts/vulkaninfo_generator.py
	modified:   vulkaninfo/generated/vulkaninfo.hpp

Change-Id: I7c7a648d9051f8ce2876083dfb0d2ddc2eb7ca95