### PR TITLE
vulkaninfo: use patch version from instance

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -362,7 +362,10 @@ struct AppInstance {
             if (err) ERR_EXIT(err);
         }
 
-        vk_version = {VK_VERSION_MAJOR(instance_version), VK_VERSION_MINOR(instance_version), VK_VERSION_PATCH(VK_HEADER_VERSION)};
+        // fallback to baked header version if loader returns 0 for the patch version
+        uint32_t patch_version = VK_VERSION_PATCH(instance_version);
+        if (patch_version == 0) patch_version = VK_VERSION_PATCH(VK_HEADER_VERSION);
+        vk_version = {VK_VERSION_MAJOR(instance_version), VK_VERSION_MINOR(instance_version), patch_version};
 
         AppGetInstanceExtensions();
 


### PR DESCRIPTION
When the original vkEnumerateInstanceVersion was implemented, the loader always return
0 for the patch. This has since been corrected, but in the mean time vulkaninfo used the
hardcoded VK_HEADER_VERSION to get the patch information. Now vulkaninfo will use the
patch version from the instance, unless it is zero, in which it will then fallback
to VK_HEADER_VERSION's patch.

Changes to be committed:
	modified:   vulkaninfo/vulkaninfo.h

Change-Id: If0a63534253afadccbad50c6256cdef8016222c1