### PR TITLE
vkcube: fix unknown CMake command error

### DIFF
--- a/cube/CMakeLists.txt
+++ b/cube/CMakeLists.txt
@@ -174,6 +174,7 @@ elseif(NOT WIN32)
                        cube.vert.inc
                        cube.frag.inc)
         target_link_libraries(vkcube Vulkan::Vulkan)
+        include(CheckLibraryExists)
         CHECK_LIBRARY_EXISTS("rt" clock_gettime "" NEED_RT)
         if (NEED_RT)
             target_link_libraries(vkcube rt)


### PR DESCRIPTION
```
CMake Error at cube/CMakeLists.txt:177 (CHECK_LIBRARY_EXISTS):
  Unknown CMake command "CHECK_LIBRARY_EXISTS".
```

I'm running into this error when building with:

```
cmake -DCMAKE_COLOR_MAKEFILE:BOOL=TRUE -DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE -DCMAKE_BUILD_TYPE:STRING=None -DCMAKE_C_FLAGS:STRING=-march=native -O2 -pipe -DCMAKE_CXX_FLAGS:STRING=-march=native -O2 -pipe -DCMAKE_AR:PATH=x86_64-pc-linux-gnu-ar -DCMAKE_RANLIB:PATH=x86_64-pc-linux-gnu-ranlib -DCMAKE_NM:PATH=x86_64-pc-linux-gnu-nm -DCMAKE_C_COMPILER:PATH=x86_64-pc-linux-gnu-cc -DCMAKE_CXX_COMPILER:PATH=x86_64-pc-linux-gnu-c++ -DCMAKE_INSTALL_PREFIX:PATH=/usr/x86_64-pc-linux-gnu -DCMAKE_FIND_ROOT_PATH=/usr/x86_64-pc-linux-gnu -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM:STRING=NEVER -DCMAKE_SYSTEM_PREFIX_PATH:PATH=/usr/x86_64-pc-linux-gnu -DCMAKE_INSTALL_LIBDIR:STRING=lib -DCMAKE_INSTALL_DATAROOTDIR:PATH=/usr/share/ -DBUILD_CUBE:BOOL=TRUE -DBUILD_ICD:BOOL=FALSE -DBUILD_VULKANINFO:BOOL=TRUE -DBUILD_WSI_XCB_SUPPORT:BOOL=FALSE -DBUILD_WSI_XLIB_SUPPORT:BOOL=FALSE -DBUILD_WSI_WAYLAND_SUPPORT:BOOL=TRUE -DGLSLANG_INSTALL_DIR:PATH=/usr/x86_64-pc-linux-gnu -DVulkanRegistry_DIR:PATH=/usr/share/vulkan/registry -DCUBE_WSI_SELECTION:STRING=WAYLAND /var/tmp/paludis/build/sys-apps-vulkan-tools-1.2.131-r1/work/Vulkan-Tools-1.2.131
```

It doesn't happen when building with another WSI target, for example
`-DCUBE_WSI_SELECTION:STRING=XCB`
works fine, while
`-DCUBE_WSI_SELECTION:STRING=WAYLAND`
results in the above error message.