### PR TITLE
vulkaninfo: Update VkFormat ranges

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -1296,6 +1296,13 @@ struct AppGpu {
                 VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG,
                 VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG,
             },
+            {
+                // ASTC extension, not standardized
+                0,
+                VK_EXT_TEXTURE_COMPRESSION_ASTC_HDR_EXTENSION_NAME,
+                VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT,
+                VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT,
+            },
         };
     }
     ~AppGpu() {

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -1278,10 +1278,9 @@ struct AppGpu {
         supported_format_ranges = {
             {
                 // Standard formats in Vulkan 1.0
-                VK_MAKE_VERSION(1, 0, 0),
-                NULL,
-                VK_FORMAT_BEGIN_RANGE,
-                VK_FORMAT_END_RANGE,
+                VK_MAKE_VERSION(1, 0, 0), NULL,
+                static_cast<VkFormat>(0),   // first core VkFormat
+                static_cast<VkFormat>(184)  // last core VkFormat
             },
             {
                 // YCBCR extension, standard in Vulkan 1.1


### PR DESCRIPTION
The vulkan spec deprecated usage of the BEGIN END and RANGE enum values in
the vulkan headers, thus necessitating a removal of those features in
vulkaninfo. This commit also adds the ASTC_HDR formats which were missing.

Change-Id: I56998cfddd647865e4078351e30e9687d6449fb9