### PR TITLE
vulkaninfo: dynamically load vulkan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,10 +103,9 @@ script:
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Run vulkaninfo as a test
       cd ${TRAVIS_BUILD_DIR}
-      LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${TRAVIS_BUILD_DIR}/external/Vulkan-Loader/build/install/lib/
       cd build/vulkaninfo
       ldd vulkaninfo
-      VK_ICD_FILENAMES=../icd/VkICD_mock_icd.json ./vulkaninfo
+      LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${TRAVIS_BUILD_DIR}/external/Vulkan-Loader/build/install/lib/ VK_ICD_FILENAMES=../icd/VkICD_mock_icd.json ./vulkaninfo
       cd ${TRAVIS_BUILD_DIR}
     fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,7 @@ script:
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Run vulkaninfo as a test
       cd ${TRAVIS_BUILD_DIR}
+      LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${TRAVIS_BUILD_DIR}/external/Vulkan-Loader/build/install/lib/
       cd build/vulkaninfo
       ldd vulkaninfo
       VK_ICD_FILENAMES=../icd/VkICD_mock_icd.json ./vulkaninfo

--- a/vulkaninfo/CMakeLists.txt
+++ b/vulkaninfo/CMakeLists.txt
@@ -47,6 +47,10 @@ endif()
 target_include_directories(vulkaninfo PRIVATE ${CMAKE_SOURCE_DIR}/vulkaninfo)
 target_include_directories(vulkaninfo PRIVATE ${CMAKE_SOURCE_DIR}/vulkaninfo/generated)
 
+if (NOT WIN32)
+    target_link_libraries(vulkaninfo ${CMAKE_DL_LIBS})
+endif()
+
 if(UNIX AND NOT APPLE) # i.e. Linux
     include(FindPkgConfig)
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
@@ -57,21 +61,21 @@ if(UNIX AND NOT APPLE) # i.e. Linux
         find_package(XCB REQUIRED)
         target_include_directories(vulkaninfo PRIVATE ${XCB_INCLUDE_DIRS})
         target_link_libraries(vulkaninfo ${XCB_LIBRARIES})
-        target_compile_definitions(vulkaninfo PRIVATE -DVK_USE_PLATFORM_XCB_KHR)
+        target_compile_definitions(vulkaninfo PRIVATE -DVK_USE_PLATFORM_XCB_KHR -DVK_NO_PROTOTYPES)
     endif()
 
     if(BUILD_WSI_XLIB_SUPPORT)
         find_package(X11 REQUIRED)
         target_include_directories(vulkaninfo PRIVATE ${X11_INCLUDE_DIR})
         target_link_libraries(vulkaninfo ${X11_LIBRARIES})
-        target_compile_definitions(vulkaninfo PRIVATE -DVK_USE_PLATFORM_XLIB_KHR)
+        target_compile_definitions(vulkaninfo PRIVATE -DVK_USE_PLATFORM_XLIB_KHR -DVK_NO_PROTOTYPES)
     endif()
 
     if(BUILD_WSI_WAYLAND_SUPPORT)
         find_package(Wayland REQUIRED)
         target_include_directories(vulkaninfo PRIVATE ${WAYLAND_CLIENT_INCLUDE_DIR})
         target_link_libraries(vulkaninfo ${WAYLAND_CLIENT_LIBRARIES})
-        target_compile_definitions(vulkaninfo PRIVATE -DVK_USE_PLATFORM_WAYLAND_KHR)
+        target_compile_definitions(vulkaninfo PRIVATE -DVK_USE_PLATFORM_WAYLAND_KHR -DVK_NO_PROTOTYPES)
     endif()
 endif()
 
@@ -80,7 +84,7 @@ if(APPLE)
     target_link_libraries(vulkaninfo ${Vulkan_LIBRARY} "-framework AppKit -framework QuartzCore")
     target_include_directories(vulkaninfo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo ${VulkanHeaders_INCLUDE_DIR})
 else()
-    target_link_libraries(vulkaninfo Vulkan::Vulkan)
+    target_include_directories(vulkaninfo PRIVATE ${VulkanHeaders_INCLUDE_DIR})
 endif()
 
 # Create vulkaninfo application bundle for MacOS
@@ -89,7 +93,7 @@ if(APPLE)
 endif()
 
 if(WIN32)
-    target_compile_definitions(vulkaninfo PUBLIC -DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN -D_CRT_SECURE_NO_WARNINGS)
+    target_compile_definitions(vulkaninfo PUBLIC -DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN -D_CRT_SECURE_NO_WARNINGS -DVK_NO_PROTOTYPES)
     if(NOT MSVC_VERSION LESS 1900)
         # Enable control flow guard
         message(STATUS "Building vulkaninfo with control flow guard")
@@ -120,7 +124,7 @@ if(WIN32)
 
     file(COPY vulkaninfo.vcxproj.user DESTINATION ${CMAKE_BINARY_DIR}/vulkaninfo)
 elseif(APPLE)
-    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK -DVK_USE_PLATFORM_METAL_EXT)
+    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK -DVK_USE_PLATFORM_METAL_EXT -DVK_NO_PROTOTYPES)
 endif()
 
 if(APPLE)

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -261,7 +261,7 @@ void DumpGroups(Printer &p, AppInstance &inst) {
         int group_id = 0;
         for (auto &group : groups) {
             ObjectWrapper obj(p, "Group " + std::to_string(group_id));
-            auto group_props = GetGroupProps(group);
+            auto group_props = GetGroupProps(inst, group);
             {
                 ObjectWrapper obj(p, "Properties");
                 {
@@ -647,7 +647,7 @@ void GpuDevDump(Printer &p, AppGpu &gpu) {
                     VkFormat fmt = static_cast<VkFormat>(fmt_counter);
 
                     VkFormatProperties props;
-                    vkGetPhysicalDeviceFormatProperties(gpu.phys_device, fmt, &props);
+                    gpu.inst.dll.vkGetPhysicalDeviceFormatProperties(gpu.phys_device, fmt, &props);
 
                     GpuDumpFormatProperty(p, fmt, props);
                 }
@@ -667,7 +667,7 @@ void GpuDevDumpJson(Printer &p, AppGpu &gpu) {
                 VkFormat fmt = static_cast<VkFormat>(fmt_counter);
 
                 VkFormatProperties props;
-                vkGetPhysicalDeviceFormatProperties(gpu.phys_device, fmt, &props);
+                gpu.inst.dll.vkGetPhysicalDeviceFormatProperties(gpu.phys_device, fmt, &props);
 
                 // don't print format properties that are unsupported
                 if ((props.linearTilingFeatures || props.optimalTilingFeatures || props.bufferFeatures) == 0) continue;

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -892,9 +892,9 @@ class AppSurface {
     std::vector<VkSurfaceFormatKHR> surf_formats;
     std::vector<VkSurfaceFormat2KHR> surf_formats2;
 
-    VkSurfaceCapabilitiesKHR surface_capabilities;
-    VkSurfaceCapabilities2KHR surface_capabilities2_khr;
-    VkSurfaceCapabilities2EXT surface_capabilities2_ext;
+    VkSurfaceCapabilitiesKHR surface_capabilities{};
+    VkSurfaceCapabilities2KHR surface_capabilities2_khr{};
+    VkSurfaceCapabilities2EXT surface_capabilities2_ext{};
 
     AppSurface(AppInstance &inst, VkPhysicalDevice phys_device, SurfaceExtension surface_extension,
                std::vector<pNextChainBuildingBlockInfo> &sur_extension_pNextChain)


### PR DESCRIPTION
This commit makes it so that vulkaninfo will not statically link to the vulkan
loader dll. This is to satisfy the Microsoft ApiValidator requirements.

Change-Id: Ibac46dd13df9568e9a97ce1ba4e50613902848a1