### PR TITLE
generate_vulkan_layers_json.py: Fix Python 3 compatibility

### DIFF
--- a/build-gn/generate_vulkan_layers_json.py
+++ b/build-gn/generate_vulkan_layers_json.py
@@ -79,7 +79,7 @@ def main():
             data[data_key]['library_path'] = prev_name
 
         target_fname = os.path.join(target_dir, os.path.basename(json_fname))
-        with open(target_fname, 'wb') as outfile:
+        with open(target_fname, 'w') as outfile:
             json.dump(data, outfile)
 
     # Get the Vulkan version from the vulkan_core.h file


### PR DESCRIPTION
json.dump() returns a string. Writing strings to a file opened in binary mode doesn't work. Python 2 doesn't properly distringuish bytes and strings.
Open in non-binary mode, so this code works on both.