### PR TITLE
cube: Remove redundant memset

### DIFF
--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -2064,7 +2064,6 @@ void Demo::prepare_texture_buffer(const char *filename, texture_object *tex_obj)
     VERIFY(result == vk::Result::eSuccess);
 
     vk::SubresourceLayout layout;
-    memset(&layout, 0, sizeof(layout));
     layout.rowPitch = tex_width * 4;
     auto data = device.mapMemory(tex_obj->mem, 0, tex_obj->mem_alloc.allocationSize);
     VERIFY(data.result == vk::Result::eSuccess);


### PR DESCRIPTION
The C++ Vulkan headers will default initialize objects, not need to memset it.

Change-Id: Icdc5cde13410bc7f0002c2d6d4075e79100fd86d