### PR TITLE
format: clang-format updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ a good reason is "This violates the style guide, but it improves type safety."
     * There are `.clang-format` files present in the repository to define clang-format settings
       which are found and used automatically by clang-format.
 	* **clang-format** binaries are available from the LLVM orginization, here: [LLVM](https://clang.llvm.org/). Our CI system (Travis-CI)
-	  currently uses clang-format version 5.0.0 to check that the lines of code you have changed are formatted properly. It is
+	  currently uses clang-format version 7.0.0 to check that the lines of code you have changed are formatted properly. It is
 	  recommended that you use the same version to format your code prior to submission.
     * A sample git workflow may look like:
 

--- a/scripts/check_code_format.sh
+++ b/scripts/check_code_format.sh
@@ -22,6 +22,8 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
+clang-format --version
+
 FILES_TO_CHECK=$(git diff --name-only master | grep -v -E "^include/vulkan" | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
 
 if [ -z "${FILES_TO_CHECK}" ]; then
@@ -37,5 +39,7 @@ if [ -z "${FORMAT_DIFF}" ]; then
 else
   echo -e "${RED}Found formatting errors!${NC}"
   echo "${FORMAT_DIFF}"
+  echo "Be sure you are using the following version of clang-format:"
+  clang-format --version
   exit 1
 fi


### PR DESCRIPTION
Updated `CONTRIBUTING.md` with the Travis version of clang-format:
`5.0.0` -> `7.0.0`

Added output to `.travis.yml` and `check_code_format.sh` too tell the
user the version of clang-format used by Travis CI.