### PR TITLE
vulkaninfo: Fix lack of display throwing on linux

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -987,7 +987,7 @@ void SetupWindowExtensions(AppInstance &inst) {
     const char *display_var = getenv("DISPLAY");
     if (display_var == nullptr || strlen(display_var) == 0) {
         has_display = false;
-        THROW_ERR("'DISPLAY' environment variable not set... skipping surface info");
+        std::cerr << "'DISPLAY' environment variable not set... skipping surface info\n";
     }
 #endif
 


### PR DESCRIPTION
During the Error Handling refactor, this line was accidentally made throwing when before
it simply reported an issue and kept going.

Change-Id: Ia3b33749ee05037a5df22398ba8b628811fad29b