### PR TITLE
cube: Pick non-SRGB surface formats first

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -3412,6 +3412,24 @@ static void demo_create_surface(struct demo *demo) {
     assert(!err);
 }
 
+static VkSurfaceFormatKHR pick_surface_format(const VkSurfaceFormatKHR *surfaceFormats, uint32_t count) {
+    // Prefer non-SRGB formats...
+    for (uint32_t i = 0; i < count; i++) {
+        const VkFormat format = surfaceFormats[i].format;
+
+        if (format == VK_FORMAT_R8G8B8A8_UNORM || format == VK_FORMAT_B8G8R8A8_UNORM ||
+            format == VK_FORMAT_A2B10G10R10_UNORM_PACK32 || format == VK_FORMAT_A2R10G10B10_UNORM_PACK32 ||
+            format == VK_FORMAT_R16G16B16A16_SFLOAT) {
+            return surfaceFormats[i];
+        }
+    }
+
+    printf("Can't find our preferred formats... Falling back to first exposed format. Rendering may be incorrect.\n");
+
+    assert(count >= 1);
+    return surfaceFormats[0];
+}
+
 static void demo_init_vk_swapchain(struct demo *demo) {
     VkResult U_ASSERT_ONLY err;
 
@@ -3489,9 +3507,9 @@ static void demo_init_vk_swapchain(struct demo *demo) {
     VkSurfaceFormatKHR *surfFormats = (VkSurfaceFormatKHR *)malloc(formatCount * sizeof(VkSurfaceFormatKHR));
     err = demo->fpGetPhysicalDeviceSurfaceFormatsKHR(demo->gpu, demo->surface, &formatCount, surfFormats);
     assert(!err);
-    assert(formatCount >= 1);
-    demo->format = surfFormats[0].format;
-    demo->color_space = surfFormats[0].colorSpace;
+    VkSurfaceFormatKHR surfaceFormat = pick_surface_format(surfFormats, formatCount);
+    demo->format = surfaceFormat.format;
+    demo->color_space = surfaceFormat.colorSpace;
     free(surfFormats);
 
     demo->quit = false;

--- a/cube/cube.c
+++ b/cube/cube.c
@@ -3489,15 +3489,8 @@ static void demo_init_vk_swapchain(struct demo *demo) {
     VkSurfaceFormatKHR *surfFormats = (VkSurfaceFormatKHR *)malloc(formatCount * sizeof(VkSurfaceFormatKHR));
     err = demo->fpGetPhysicalDeviceSurfaceFormatsKHR(demo->gpu, demo->surface, &formatCount, surfFormats);
     assert(!err);
-    // If the format list includes just one entry of VK_FORMAT_UNDEFINED,
-    // the surface has no preferred format.  Otherwise, at least one
-    // supported format will be returned.
-    if (formatCount == 1 && surfFormats[0].format == VK_FORMAT_UNDEFINED) {
-        demo->format = VK_FORMAT_B8G8R8A8_UNORM;
-    } else {
-        assert(formatCount >= 1);
-        demo->format = surfFormats[0].format;
-    }
+    assert(formatCount >= 1);
+    demo->format = surfFormats[0].format;
     demo->color_space = surfFormats[0].colorSpace;
     free(surfFormats);
 


### PR DESCRIPTION
Pick some common non-SRGB formats first. Some drivers such as RADV expose SRGB formats first which causes incorrect rendering otherwise.