### PR TITLE
vulkaninfo: fix app bundle not finding loader

### DIFF
--- a/vulkaninfo/macOS/vulkaninfo.cmake
+++ b/vulkaninfo/macOS/vulkaninfo.cmake
@@ -25,6 +25,7 @@ add_executable(vulkaninfo-bundle
                vulkaninfo.cpp
                ${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json
                ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo.sh
+               ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo_run.command
                ${CMAKE_CURRENT_SOURCE_DIR}/macOS/Resources/VulkanIcon.icns
                ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo/metal_view.mm
                ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo/metal_view.h)
@@ -38,6 +39,7 @@ target_link_libraries(vulkaninfo-bundle ${Vulkan_LIBRARY} "-framework AppKit -fr
 target_include_directories(vulkaninfo-bundle PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo ${CMAKE_CURRENT_SOURCE_DIR}/generated ${CMAKE_BINARY_DIR}/vulkaninfo ${VulkanHeaders_INCLUDE_DIR})
 add_dependencies(vulkaninfo-bundle MoltenVK_icd-staging-json)
 
+set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo_run.command PROPERTIES MACOSX_PACKAGE_LOCATION "MacOS")
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo.sh PROPERTIES MACOSX_PACKAGE_LOCATION "MacOS")
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/macOS/Resources/VulkanIcon.icns
                             PROPERTIES

--- a/vulkaninfo/macOS/vulkaninfo.sh
+++ b/vulkaninfo/macOS/vulkaninfo.sh
@@ -3,7 +3,8 @@ BASEDIR=`dirname $0`
 
 if [ -d /System/Applications/Utilities/Terminal.app ]
 then
-    open /System/Applications/Utilities/Terminal.app $BASEDIR/vulkaninfo
+    open /System/Applications/Utilities/Terminal.app ./$BASEDIR/vulkaninfo_run.command
 else
-    open /Applications/Utilities/Terminal.app $BASEDIR/vulkaninfo
+    open /Applications/Utilities/Terminal.app ./$BASEDIR/vulkaninfo_run.command
 fi
+

--- a/vulkaninfo/macOS/vulkaninfo_run.command
+++ b/vulkaninfo/macOS/vulkaninfo_run.command
@@ -1,0 +1,4 @@
+#!/bin/bash
+BASEDIR=`dirname $0`
+export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$BASEDIR
+$BASEDIR/vulkaninfo


### PR DESCRIPTION
The change of vulkaninfo to dlopen the loader broke the app bundle.
This commit fixes it by manually setting up DYLD_LIBRARY_PATH before
starting vulkaninfo, ensuring that it can be found.