### PR TITLE
Make Mock ICD physical device static

### DIFF
--- a/icd/generated/mock_icd.cpp
+++ b/icd/generated/mock_icd.cpp
@@ -31,7 +31,7 @@ using std::unordered_map;
 // Map device memory handle to any mapped allocations that we'll need to free on unmap
 static unordered_map<VkDeviceMemory, std::vector<void*>> mapped_memory_map;
 
-static VkPhysicalDevice physical_device = nullptr;
+static VkPhysicalDevice physical_device = (VkPhysicalDevice)CreateDispObjHandle();
 static unordered_map<VkDevice, unordered_map<uint32_t, unordered_map<uint32_t, VkQueue>>> queue_map;
 static unordered_map<VkDevice, unordered_map<VkBuffer, VkBufferCreateInfo>> buffer_map;
 
@@ -186,9 +186,6 @@ static VKAPI_ATTR void VKAPI_CALL DestroyInstance(
     const VkAllocationCallbacks*                pAllocator)
 {
 
-    // Destroy physical device
-    DestroyDispObjHandle((void*)physical_device);
-
     DestroyDispObjHandle((void*)instance);
 }
 
@@ -198,9 +195,6 @@ static VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
     VkPhysicalDevice*                           pPhysicalDevices)
 {
     if (pPhysicalDevices) {
-        if (!physical_device) {
-            physical_device = (VkPhysicalDevice)CreateDispObjHandle();
-        }
         *pPhysicalDevices = physical_device;
     } else {
         *pPhysicalDeviceCount = 1;

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -57,7 +57,7 @@ using std::unordered_map;
 // Map device memory handle to any mapped allocations that we'll need to free on unmap
 static unordered_map<VkDeviceMemory, std::vector<void*>> mapped_memory_map;
 
-static VkPhysicalDevice physical_device = nullptr;
+static VkPhysicalDevice physical_device = (VkPhysicalDevice)CreateDispObjHandle();
 static unordered_map<VkDevice, unordered_map<uint32_t, unordered_map<uint32_t, VkQueue>>> queue_map;
 static unordered_map<VkDevice, unordered_map<VkBuffer, VkBufferCreateInfo>> buffer_map;
 
@@ -425,16 +425,10 @@ CUSTOM_C_INTERCEPTS = {
     return VK_SUCCESS;
 ''',
 'vkDestroyInstance': '''
-    // Destroy physical device
-    DestroyDispObjHandle((void*)physical_device);
-
     DestroyDispObjHandle((void*)instance);
 ''',
 'vkEnumeratePhysicalDevices': '''
     if (pPhysicalDevices) {
-        if (!physical_device) {
-            physical_device = (VkPhysicalDevice)CreateDispObjHandle();
-        }
         *pPhysicalDevices = physical_device;
     } else {
         *pPhysicalDeviceCount = 1;


### PR DESCRIPTION
PDev created at EnumPhysDevices time, but destroyed at DestroyInstance-time. This crashes when mixing Create/DestroyInstance calls as EnumPhysDevices is not required to be called.

