### PR TITLE
icd: Fix vkGetSwapchainImages behavior reup

### DIFF
--- a/icd/generated/mock_icd.cpp
+++ b/icd/generated/mock_icd.cpp
@@ -21,6 +21,7 @@
 
 #include "mock_icd.h"
 #include <stdlib.h>
+#include <algorithm>
 #include <vector>
 #include "vk_typemap_helper.h"
 namespace vkmock {
@@ -2141,13 +2142,19 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
     uint32_t*                                   pSwapchainImageCount,
     VkImage*                                    pSwapchainImages)
 {
+    constexpr uint32_t icd_image_count = 1;
+
     if (!pSwapchainImages) {
-        *pSwapchainImageCount = 1;
-    } else if (*pSwapchainImageCount > 0) {
-        pSwapchainImages[0] = (VkImage)global_unique_handle++;
-        if (*pSwapchainImageCount != 1) {
-            return VK_INCOMPLETE;
+        *pSwapchainImageCount = icd_image_count;
+    } else {
+        unique_lock_t lock(global_lock);
+        for (uint32_t img_i = 0; img_i < (std::min)(*pSwapchainImageCount, icd_image_count); ++img_i){
+            // For simplicity always returns new handles, which is wrong
+            pSwapchainImages[img_i] = (VkImage)global_unique_handle++;
         }
+
+        if (*pSwapchainImageCount < icd_image_count) return VK_INCOMPLETE;
+        else if (*pSwapchainImageCount > icd_image_count) *pSwapchainImageCount = icd_image_count;
     }
     return VK_SUCCESS;
 }

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -880,13 +880,19 @@ CUSTOM_C_INTERCEPTS = {
     *pLayout = VkSubresourceLayout(); // Default constructor zero values.
 ''',
 'vkGetSwapchainImagesKHR': '''
+    constexpr uint32_t icd_image_count = 1;
+
     if (!pSwapchainImages) {
-        *pSwapchainImageCount = 1;
-    } else if (*pSwapchainImageCount > 0) {
-        pSwapchainImages[0] = (VkImage)global_unique_handle++;
-        if (*pSwapchainImageCount != 1) {
-            return VK_INCOMPLETE;
+        *pSwapchainImageCount = icd_image_count;
+    } else {
+        unique_lock_t lock(global_lock);
+        for (uint32_t img_i = 0; img_i < (std::min)(*pSwapchainImageCount, icd_image_count); ++img_i){
+            // For simplicity always returns new handles, which is wrong
+            pSwapchainImages[img_i] = (VkImage)global_unique_handle++;
         }
+
+        if (*pSwapchainImageCount < icd_image_count) return VK_INCOMPLETE;
+        else if (*pSwapchainImageCount > icd_image_count) *pSwapchainImageCount = icd_image_count;
     }
     return VK_SUCCESS;
 ''',
@@ -1074,6 +1080,7 @@ class MockICDOutputGenerator(OutputGenerator):
         else:
             write('#include "mock_icd.h"', file=self.outFile)
             write('#include <stdlib.h>', file=self.outFile)
+            write('#include <algorithm>', file=self.outFile)
             write('#include <vector>', file=self.outFile)
             write('#include "vk_typemap_helper.h"', file=self.outFile)
 

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -64,6 +64,9 @@ static VkPhysicalDevice physical_device = (VkPhysicalDevice)CreateDispObjHandle(
 static unordered_map<VkDevice, unordered_map<uint32_t, unordered_map<uint32_t, VkQueue>>> queue_map;
 static unordered_map<VkDevice, unordered_map<VkBuffer, VkBufferCreateInfo>> buffer_map;
 
+static constexpr uint32_t icd_swapchain_image_count = 1;
+static std::unordered_map<VkSwapchainKHR, VkImage[icd_swapchain_image_count]> swapchain_image_map;
+
 // TODO: Would like to codegen this but limits aren't in XML
 static VkPhysicalDeviceLimits SetLimits(VkPhysicalDeviceLimits *limits) {
     limits->maxImageDimension1D = 4096;
@@ -876,23 +879,32 @@ CUSTOM_C_INTERCEPTS = {
     mapped_memory_map.erase(memory);
 ''',
 'vkGetImageSubresourceLayout': '''
-    // Need safe values. Callers are computing memory offsets from pLayout, with no return code to flag failure. 
+    // Need safe values. Callers are computing memory offsets from pLayout, with no return code to flag failure.
     *pLayout = VkSubresourceLayout(); // Default constructor zero values.
 ''',
+'vkCreateSwapchainKHR': '''
+    unique_lock_t lock(global_lock);
+    *pSwapchain = (VkSwapchainKHR)global_unique_handle++;
+    for(uint32_t i = 0; i < icd_swapchain_image_count; ++i){
+        swapchain_image_map[*pSwapchain][i] = (VkImage)global_unique_handle++;
+    }
+    return VK_SUCCESS;
+''',
+'vkDestroySwapchainKHR': '''
+    unique_lock_t lock(global_lock);
+    swapchain_image_map.clear();
+''',
 'vkGetSwapchainImagesKHR': '''
-    constexpr uint32_t icd_image_count = 1;
-
     if (!pSwapchainImages) {
-        *pSwapchainImageCount = icd_image_count;
+        *pSwapchainImageCount = icd_swapchain_image_count;
     } else {
         unique_lock_t lock(global_lock);
-        for (uint32_t img_i = 0; img_i < (std::min)(*pSwapchainImageCount, icd_image_count); ++img_i){
-            // For simplicity always returns new handles, which is wrong
-            pSwapchainImages[img_i] = (VkImage)global_unique_handle++;
+        for (uint32_t img_i = 0; img_i < (std::min)(*pSwapchainImageCount, icd_swapchain_image_count); ++img_i){
+            pSwapchainImages[img_i] = swapchain_image_map.at(swapchain)[img_i];
         }
 
-        if (*pSwapchainImageCount < icd_image_count) return VK_INCOMPLETE;
-        else if (*pSwapchainImageCount > icd_image_count) *pSwapchainImageCount = icd_image_count;
+        if (*pSwapchainImageCount < icd_swapchain_image_count) return VK_INCOMPLETE;
+        else if (*pSwapchainImageCount > icd_swapchain_image_count) *pSwapchainImageCount = icd_swapchain_image_count;
     }
     return VK_SUCCESS;
 ''',


### PR DESCRIPTION
Reup of #368 

- add missing lock
- return correct values via return and count
- <s>bump to two images</s>
- make it return the same image handles for the same swapchain
