### PR TITLE
vulkaninfo: use generate_source.py for autogen

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,4 +17,4 @@
 # Generated source files will always have LF (unix) line endings on checkout.
 icd/generated/*.cpp text eol=lf
 icd/generated/*.h text eol=lf
-
+vulkaninfo/generated/*.hpp text eol=lf

--- a/scripts/kvt_genvk.py
+++ b/scripts/kvt_genvk.py
@@ -275,6 +275,8 @@ if __name__ == '__main__':
     parser.add_argument('-defaultExtensions', action='store',
                         default='vulkan',
                         help='Specify a single class of extensions to add to targets')
+    parser.add_argument('-directory', action='store',
+                        help='Specify where the built file is place')
     parser.add_argument('-extension', action='append',
                         default=[],
                         help='Specify an extension or extensions to add to targets')

--- a/scripts/vulkaninfo_generator.py
+++ b/scripts/vulkaninfo_generator.py
@@ -80,6 +80,7 @@ std::string to_hex_str(Printer &p, T i) {
     else
         return to_hex_str(i);
 }
+
 '''
 
 
@@ -104,14 +105,12 @@ predefined_types = ['char', 'VkBool32', 'uint32_t', 'uint8_t', 'int32_t',
                     'float', 'uint64_t', 'size_t', 'VkDeviceSize']
 
 # Types that need pNext Chains built. 'extends' is the xml tag used in the structextends member. 'type' can be device, instance, or both
-EXTENSION_CATEGORIES = {'phys_device_props2': {'extends': 'VkPhysicalDeviceProperties2', 'type': 'both'},
-                        'phys_device_mem_props2': {'extends': 'VkPhysicalDeviceMemoryProperties2', 'type': 'device'},
-                        'phys_device_features2': {'extends': 'VkPhysicalDeviceFeatures2,VkDeviceCreateInfo', 'type': 'device'},
-                        'surface_capabilities2': {'extends': 'VkSurfaceCapabilities2KHR', 'type': 'both'},
-                        'format_properties2': {'extends': 'VkFormatProperties2', 'type': 'device'}
-                        }
-
-
+EXTENSION_CATEGORIES = OrderedDict((('phys_device_props2', {'extends': 'VkPhysicalDeviceProperties2', 'type': 'both'}),
+                                   ('phys_device_mem_props2', {'extends': 'VkPhysicalDeviceMemoryProperties2', 'type': 'device'}),
+                                   ('phys_device_features2', {'extends': 'VkPhysicalDeviceFeatures2,VkDeviceCreateInfo', 'type': 'device'}),
+                                   ('surface_capabilities2', {'extends': 'VkSurfaceCapabilities2KHR', 'type': 'both'}),
+                                   ('format_properties2', {'extends': 'VkFormatProperties2', 'type': 'device'})
+                                   ))
 class VulkanInfoGeneratorOptions(GeneratorOptions):
     def __init__(self,
                  conventions=None,

--- a/vulkaninfo/CMakeLists.txt
+++ b/vulkaninfo/CMakeLists.txt
@@ -17,22 +17,6 @@
 
 # CMakeLists.txt file for building Vulkaninfo
 
-find_package(PythonInterp 3 QUIET)
-set (PYTHON_CMD ${PYTHON_EXECUTABLE})
-
-set(VKINFO_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(KVULKANTOOLS_SCRIPTS_DIR ${CMAKE_SOURCE_DIR}/scripts)
-
-if(PYTHONINTERP_FOUND)
-    add_custom_target(generate_vulkaninfo_hpp
-        COMMAND ${PYTHON_CMD} ${KVULKANTOOLS_SCRIPTS_DIR}/kvt_genvk.py -registry ${VulkanRegistry_DIR}/vk.xml -scripts ${VulkanRegistry_DIR} vulkaninfo.hpp
-        DEPENDS ${VulkanRegistry_DIR}/vk.xml ${VulkanRegistry_DIR}/generator.py ${KVULKANTOOLS_SCRIPTS_DIR}/vulkaninfo_generator.py ${KVULKANTOOLS_SCRIPTS_DIR}/kvt_genvk.py ${VulkanRegistry_DIR}/reg.py
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/vulkaninfo/generated
-        )
-    else()
-        message("WARNING: generate_vulkaninfo_hpp target requires python 3")
-endif()
-
 if(WIN32)
     add_executable(vulkaninfo vulkaninfo.cpp vulkaninfo.rc)
 elseif(APPLE)

--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -48,6 +48,7 @@ std::string to_hex_str(Printer &p, T i) {
     else
         return to_hex_str(i);
 }
+
 static const char *VkResultString(VkResult value) {
     switch (value) {
         case (0): return "SUCCESS";


### PR DESCRIPTION
Previously, to update the autogen for vulkaninfo required running a
separate cmake target. This commit puts it all into the same target
for ease of maintenance.

Fixes #356 

Change-Id: I98e35b01ee164e9917564f6b603e4a78c6138041