### PR TITLE
vulkaninfo: fix queues not reporting presentation

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -1603,9 +1603,8 @@ struct AppQueueFamilyProperties {
             const bool first = (surface_ext == gpu.inst.surface_extensions.at(0));
             if (!first && platforms_support_present != surface_ext.supports_present) {
                 is_present_platform_agnostic = false;
-
-                platforms_support_present = surface_ext.supports_present;
             }
+            platforms_support_present = surface_ext.supports_present;
         }
     }
 };


### PR DESCRIPTION
Fixes #385

Cause: 
```c
if (!first && platforms_support_present != surface_ext.supports_present) {
        is_present_platform_agnostic = false;
        platforms_support_present = surface_ext.supports_present;
}
```
should be 
```c
if (!first && platforms_support_present != surface_ext.supports_present) {
        is_present_platform_agnostic = false;
}
platforms_support_present = surface_ext.supports_present;
```
Change-Id: I4d01c5a9b3eb6809a732cd994854a06fee49a24c