### PR TITLE
fix README on Windows Runtime Installer folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following components are available in this repository:
 - [*Mock ICD*](icd/)
 - [*Vkcube and Vkcube++ Demo*](cube/)
 - [*VulkanInfo*](vulkaninfo/)
-- [*Windows Runtime*](winrt/)
+- [*Windows Runtime*](windows-runtime-installer/)
 
 ## Contact Information
 * [Tobin Ehlis](mailto:tobine@google.com)


### PR DESCRIPTION
I guess it's broken since https://github.com/KhronosGroup/Vulkan-Tools/pull/295