### PR TITLE
Revert "vulkaninfo: use generate_source.py for autogen"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,4 +17,4 @@
 # Generated source files will always have LF (unix) line endings on checkout.
 icd/generated/*.cpp text eol=lf
 icd/generated/*.h text eol=lf
-vulkaninfo/generated/*.hpp text eol=lf
+

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -39,72 +39,52 @@ def main(argv):
     group.add_argument('-v', '--verify', action='store_true', help='verify repo files match generator output')
     args = parser.parse_args(argv)
 
-    # output paths and the list of files in the path
-    files_to_gen = {str(os.path.join('icd','generated')) : ['vk_typemap_helper.h',
+    gen_cmds = [[common_codegen.repo_relative('scripts/kvt_genvk.py'),
+                 '-registry', os.path.abspath(os.path.join(args.registry,  'vk.xml')),
+                 '-quiet',
+                 filename] for filename in ['vk_typemap_helper.h',
                                             'mock_icd.h',
-                                            'mock_icd.cpp'],
-                    str(os.path.join('vulkaninfo','generated')): ['vulkaninfo.hpp']}
+                                            'mock_icd.cpp']]
 
-    #base directory for the source repository
-    repo_dir = common_codegen.repo_relative('')
+    repo_dir = common_codegen.repo_relative('icd/generated')
 
-    # get directory where generators will run if needed
+    # get directory where generators will run
     if args.verify or args.incremental:
         # generate in temp directory so we can compare or copy later
         temp_obj = tempfile.TemporaryDirectory(prefix='VulkanLoader_generated_source_')
         temp_dir = temp_obj.name
-        for path in files_to_gen.keys():
-            os.makedirs(os.path.join(temp_dir, path))
+        gen_dir = temp_dir
+    else:
+        # generate directly in the repo
+        gen_dir = repo_dir
 
     # run each code generator
-    for path, filenames in files_to_gen.items():
-        for filename in filenames:
-            if args.verify or args.incremental:
-                output_path = os.path.join(temp_dir, path)
-            else:
-                output_path = common_codegen.repo_relative(path)
-
-            cmd = [common_codegen.repo_relative(os.path.join('scripts','kvt_genvk.py')),
-                '-registry', os.path.abspath(os.path.join(args.registry,  'vk.xml')),
-                '-quiet', '-directory', output_path, filename]
-            print(' '.join(cmd))
-            try:
-                if args.verify or args.incremental:
-                    subprocess.check_call([sys.executable] + cmd, cwd=temp_dir)
-                else:
-                    subprocess.check_call([sys.executable] + cmd, cwd=repo_dir)
-
-            except Exception as e:
-                print('ERROR:', str(e))
-                return 1
+    for cmd in gen_cmds:
+        print(' '.join(cmd))
+        try:
+            subprocess.check_call([sys.executable] + cmd, cwd=gen_dir)
+        except Exception as e:
+            print('ERROR:', str(e))
+            return 1
 
     # optional post-generation steps
     if args.verify:
         # compare contents of temp dir and repo
-        temp_files = {}
-        for path in files_to_gen.keys():
-            temp_files[path] = set()
-            temp_files[path].update(set(os.listdir(os.path.join(temp_dir, path))))
-
-        repo_files = {}
-        for path in files_to_gen.keys():
-            repo_files[path] = set()
-            repo_files[path].update(set(os.listdir(os.path.join(repo_dir, path))) - set(verify_exclude))
-
+        temp_files = set(os.listdir(temp_dir))
+        repo_files = set(os.listdir(repo_dir))
         files_match = True
-        for path in files_to_gen.keys():
-            for filename in sorted((temp_files[path] | repo_files[path])):
-                if filename not in repo_files[path]:
-                    print('ERROR: Missing repo file', filename)
-                    files_match = False
-                elif filename not in temp_files[path]:
-                    print('ERROR: Missing generator for', filename)
-                    files_match = False
-                elif not filecmp.cmp(os.path.join(temp_dir, path, filename),
-                                   os.path.join(repo_dir, path, filename),
-                                   shallow=False):
-                    print('ERROR: Repo files do not match generator output for', filename)
-                    files_match = False
+        for filename in sorted((temp_files | repo_files) - set(verify_exclude)):
+            if filename not in repo_files:
+                print('ERROR: Missing repo file', filename)
+                files_match = False
+            elif filename not in temp_files:
+                print('ERROR: Missing generator for', filename)
+                files_match = False
+            elif not filecmp.cmp(os.path.join(temp_dir, filename),
+                               os.path.join(repo_dir, filename),
+                               shallow=False):
+                print('ERROR: Repo files do not match generator output for', filename)
+                files_match = False
 
         # return code for test scripts
         if files_match:
@@ -114,14 +94,13 @@ def main(argv):
 
     elif args.incremental:
         # copy missing or differing files from temp directory to repo
-        for path in files_to_gen.keys():
-            for filename in os.listdir(os.path.join(temp_dir,path)):
-                temp_filename = os.path.join(temp_dir, path, filename)
-                repo_filename = os.path.join(repo_dir, path, filename)
-                if not os.path.exists(repo_filename) or \
-                   not filecmp.cmp(temp_filename, repo_filename, shallow=False):
-                    print('update', repo_filename)
-                    shutil.copyfile(temp_filename, repo_filename)
+        for filename in os.listdir(temp_dir):
+            temp_filename = os.path.join(temp_dir, filename)
+            repo_filename = os.path.join(repo_dir, filename)
+            if not os.path.exists(repo_filename) or \
+               not filecmp.cmp(temp_filename, repo_filename, shallow=False):
+                print('update', repo_filename)
+                shutil.copyfile(temp_filename, repo_filename)
 
     return 0
 

--- a/scripts/kvt_genvk.py
+++ b/scripts/kvt_genvk.py
@@ -275,8 +275,6 @@ if __name__ == '__main__':
     parser.add_argument('-defaultExtensions', action='store',
                         default='vulkan',
                         help='Specify a single class of extensions to add to targets')
-    parser.add_argument('-directory', action='store',
-                        help='Specify where the built file is place')
     parser.add_argument('-extension', action='append',
                         default=[],
                         help='Specify an extension or extensions to add to targets')

--- a/scripts/vulkaninfo_generator.py
+++ b/scripts/vulkaninfo_generator.py
@@ -80,7 +80,6 @@ std::string to_hex_str(Printer &p, T i) {
     else
         return to_hex_str(i);
 }
-
 '''
 
 
@@ -105,12 +104,14 @@ predefined_types = ['char', 'VkBool32', 'uint32_t', 'uint8_t', 'int32_t',
                     'float', 'uint64_t', 'size_t', 'VkDeviceSize']
 
 # Types that need pNext Chains built. 'extends' is the xml tag used in the structextends member. 'type' can be device, instance, or both
-EXTENSION_CATEGORIES = OrderedDict((('phys_device_props2', {'extends': 'VkPhysicalDeviceProperties2', 'type': 'both'}),
-                                   ('phys_device_mem_props2', {'extends': 'VkPhysicalDeviceMemoryProperties2', 'type': 'device'}),
-                                   ('phys_device_features2', {'extends': 'VkPhysicalDeviceFeatures2,VkDeviceCreateInfo', 'type': 'device'}),
-                                   ('surface_capabilities2', {'extends': 'VkSurfaceCapabilities2KHR', 'type': 'both'}),
-                                   ('format_properties2', {'extends': 'VkFormatProperties2', 'type': 'device'})
-                                   ))
+EXTENSION_CATEGORIES = {'phys_device_props2': {'extends': 'VkPhysicalDeviceProperties2', 'type': 'both'},
+                        'phys_device_mem_props2': {'extends': 'VkPhysicalDeviceMemoryProperties2', 'type': 'device'},
+                        'phys_device_features2': {'extends': 'VkPhysicalDeviceFeatures2,VkDeviceCreateInfo', 'type': 'device'},
+                        'surface_capabilities2': {'extends': 'VkSurfaceCapabilities2KHR', 'type': 'both'},
+                        'format_properties2': {'extends': 'VkFormatProperties2', 'type': 'device'}
+                        }
+
+
 class VulkanInfoGeneratorOptions(GeneratorOptions):
     def __init__(self,
                  conventions=None,

--- a/vulkaninfo/CMakeLists.txt
+++ b/vulkaninfo/CMakeLists.txt
@@ -17,6 +17,22 @@
 
 # CMakeLists.txt file for building Vulkaninfo
 
+find_package(PythonInterp 3 QUIET)
+set (PYTHON_CMD ${PYTHON_EXECUTABLE})
+
+set(VKINFO_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(KVULKANTOOLS_SCRIPTS_DIR ${CMAKE_SOURCE_DIR}/scripts)
+
+if(PYTHONINTERP_FOUND)
+    add_custom_target(generate_vulkaninfo_hpp
+        COMMAND ${PYTHON_CMD} ${KVULKANTOOLS_SCRIPTS_DIR}/kvt_genvk.py -registry ${VulkanRegistry_DIR}/vk.xml -scripts ${VulkanRegistry_DIR} vulkaninfo.hpp
+        DEPENDS ${VulkanRegistry_DIR}/vk.xml ${VulkanRegistry_DIR}/generator.py ${KVULKANTOOLS_SCRIPTS_DIR}/vulkaninfo_generator.py ${KVULKANTOOLS_SCRIPTS_DIR}/kvt_genvk.py ${VulkanRegistry_DIR}/reg.py
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/vulkaninfo/generated
+        )
+    else()
+        message("WARNING: generate_vulkaninfo_hpp target requires python 3")
+endif()
+
 if(WIN32)
     add_executable(vulkaninfo vulkaninfo.cpp vulkaninfo.rc)
 elseif(APPLE)

--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -48,7 +48,6 @@ std::string to_hex_str(Printer &p, T i) {
     else
         return to_hex_str(i);
 }
-
 static const char *VkResultString(VkResult value) {
     switch (value) {
         case (0): return "SUCCESS";


### PR DESCRIPTION
This reverts commit 5aaa64364e7a255948a44ef151208fe85dcd5834.
The Travis script in Vulkan-ValidationLayers breaks with this commit.  Work around by reverting until we can decide what the best fix is