### PR TITLE
icd: Cleanup supported VK API version

### DIFF
--- a/icd/generated/mock_icd.cpp
+++ b/icd/generated/mock_icd.cpp
@@ -31,6 +31,7 @@ namespace vkmock {
 using std::unordered_map;
 
 static constexpr uint32_t icd_physical_device_count = 1;
+static constexpr uint32_t kSupportedVulkanAPIVersion = VK_API_VERSION_1_1;
 static unordered_map<VkInstance, std::array<VkPhysicalDevice, icd_physical_device_count>> physical_device_map;
 
 // Map device memory handle to any mapped allocations that we'll need to free on unmap
@@ -276,7 +277,7 @@ static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties(
     VkPhysicalDeviceProperties*                 pProperties)
 {
     // TODO: Just hard-coding some values for now
-    pProperties->apiVersion = VK_API_VERSION_1_1;
+    pProperties->apiVersion = kSupportedVulkanAPIVersion;
     pProperties->driverVersion = 1;
     pProperties->vendorID = 0xba5eba11;
     pProperties->deviceID = 0xf005ba11;
@@ -1694,7 +1695,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL EnumerateInstanceVersion(
     uint32_t*                                   pApiVersion)
 {
 
-    *pApiVersion = VK_API_VERSION_1_1;
+    *pApiVersion = kSupportedVulkanAPIVersion;
     return VK_SUCCESS;
 }
 

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -55,6 +55,7 @@ SOURCE_CPP_PREFIX = '''
 using std::unordered_map;
 
 static constexpr uint32_t icd_physical_device_count = 1;
+static constexpr uint32_t kSupportedVulkanAPIVersion = VK_API_VERSION_1_1;
 static unordered_map<VkInstance, std::array<VkPhysicalDevice, icd_physical_device_count>> physical_device_map;
 
 // Map device memory handle to any mapped allocations that we'll need to free on unmap
@@ -497,7 +498,7 @@ CUSTOM_C_INTERCEPTS = {
     return VK_SUCCESS;
 ''',
 'vkEnumerateInstanceVersion': '''
-    *pApiVersion = VK_API_VERSION_1_1;
+    *pApiVersion = kSupportedVulkanAPIVersion;
     return VK_SUCCESS;
 ''',
 'vkEnumerateDeviceLayerProperties': '''
@@ -769,7 +770,7 @@ CUSTOM_C_INTERCEPTS = {
 ''',
 'vkGetPhysicalDeviceProperties': '''
     // TODO: Just hard-coding some values for now
-    pProperties->apiVersion = VK_API_VERSION_1_1;
+    pProperties->apiVersion = kSupportedVulkanAPIVersion;
     pProperties->driverVersion = 1;
     pProperties->vendorID = 0xba5eba11;
     pProperties->deviceID = 0xf005ba11;


### PR DESCRIPTION
Use a single constant, kSupportedVulkanAPIVersion, everwhere
that supported API version is referenced. Current value is
VK_API_VERSION_1_1.