### PR TITLE
vulkaninfo: fix output style for memory types

### DIFF
--- a/vulkaninfo/outputprinter.h
+++ b/vulkaninfo/outputprinter.h
@@ -430,6 +430,7 @@ class Printer {
                 }
                 out << std::string(static_cast<size_t>(indents), '\t') << "\"" << array_name << "\": "
                     << "[\n";
+                assert(is_array.top() == false && "Cant start an array object inside another array, must be enclosed in an object");
                 is_first_item.push(true);
                 is_array.push(true);
                 break;

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -459,13 +459,14 @@ void GpuDumpMemoryProps(Printer &p, AppGpu &gpu) {
             auto flags = gpu.memory_props.memoryTypes[i].propertyFlags;
             DumpVkMemoryPropertyFlags(p, "propertyFlags = " + to_hex_str(flags), flags);
 
-            ArrayWrapper arr(p, "usable for", -1);
+            ObjectWrapper usable_for(p, "usable for");
             const uint32_t memtype_bit = 1U << i;
 
             // only linear and optimal tiling considered
             std::vector<VkFormat> tiling_optimal_formats;
             std::vector<VkFormat> tiling_linear_formats;
             for (auto &image_tiling : gpu.memory_image_support_types) {
+                p.SetOpenDetails();
                 ArrayWrapper arr(p, VkImageTilingString(VkImageTiling(image_tiling.tiling)), -1);
                 bool has_any_support_types = false;
                 bool regular = false;


### PR DESCRIPTION
Made the 'usable for' auto expand in html as well.

Change-Id: I97d22fc6b8f603be314e13b46fe675a199c8b7eb