### PR TITLE
scripts: fix update_deps retry clone

### DIFF
--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -345,8 +345,8 @@ class GoodRepo(object):
 
     def Clone(self, retries=10, retry_seconds=60):
         print('Cloning {n} into {d}'.format(n=self.name, d=self.repo_dir))
-        distutils.dir_util.mkpath(self.repo_dir)
         for retry in range(retries):
+            distutils.dir_util.mkpath(self.repo_dir)
             try:
                 command_output(['git', 'clone', self.url, '.'], self.repo_dir)
                 # If we get here, we didn't raise an error


### PR DESCRIPTION
There was a subtle bug in the original change; "git fetch"
would retry correctly, but "git clone" failed because the
destination directory was missing (after having been removed,
to ensure a clean clone operation).

The test case that was used (hundreds of times) happened to
provoke an error on the "git fetch" path; I was unaware that
the "git clone" failure path had never been exercised.