### PR TITLE
vulkaninfo: fix device ext list having bad items

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -240,6 +240,7 @@ auto GetVectorInit(const char *func_name, F &&f, T init, Ts &&... ts) -> std::ve
         if (err) THROW_VK_ERR(func_name, err);
         results.resize(count, init);
         err = f(ts..., &count, results.data());
+        results.resize(count);
     } while (err == VK_INCOMPLETE);
     if (err) THROW_VK_ERR(func_name, err);
     return results;


### PR DESCRIPTION
vkconfig exposed an issue in the vulkan-loader which resulted in two different sizes
returned from vkEnumerateDeviceExtensionProperties(). A full fix requires a change to
the loader, but this commit stops the issue from happening in vulkaninfo. The issue is
because the count might be less on the second enumerate call, so resizing the vector
again trims the extraneous elements away.

Change-Id: I808d1fd13868711675aae5c91ea5100ec8cbc316