### PR TITLE
Fix uninitialized variable use in the cube demo

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -3766,7 +3766,7 @@ static void demo_init_connection(struct demo *demo) {
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     const xcb_setup_t *setup;
     xcb_screen_iterator_t iter;
-    int scr;
+    int scr = 0;
 
     const char *display_envar = getenv("DISPLAY");
     if (display_envar == NULL || display_envar[0] == '\0') {


### PR DESCRIPTION
I was doing some admittedly questionable stuff with LD_PRELOAD and stumbled upon an odd segfault:
```
(gdb) set environment LD_PRELOAD /home/lahvuun/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so:/home/lahvuun/git/xcbtoxlib/buildrelease/libxcbtoxlib.so
(gdb) r
Starting program: /usr/bin/vkcube
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7f3b8de in xcb_screen_sizeof (_buffer=_buffer@entry=0x5555555d9ff4) at xproto.c:508
508         for(i=0; i<_aux->allowed_depths_len; i++) {
```

For some reason setting LD_PRELOAD changed the value of `scr` in `demo_init_connection`.
Without LD_PRELOAD:
```
(gdb) b demo_init_connection
Breakpoint 1 at 0x4996: file /usr/src/debug/dev-util/vulkan-tools-1.2.141/Vulkan-Tools-1.2.141/cube/cube.c, line 3656.
(gdb) r
Starting program: /usr/bin/vkcube
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".

Breakpoint 1, demo_init_connection (demo=0x7fffffffcb00) at /usr/src/debug/dev-util/vulkan-tools-1.2.141/Vulkan-Tools-1.2.141/cube/cube.c:3656
3656    static void demo_init_connection(struct demo *demo) {
(gdb) n
3662        const char *display_envar = getenv("DISPLAY");
(gdb) p scr
$1 = 0
```

With:
```
(gdb) set environment LD_PRELOAD /home/lahvuun/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so:/home/lahvuun/git/xcbtoxlib/buildrelease/libxcbtoxlib.so
(gdb) b demo_init_connection
Breakpoint 1 at 0x4996: file /usr/src/debug/dev-util/vulkan-tools-1.2.141/Vulkan-Tools-1.2.141/cube/cube.c, line 3656.
(gdb) r
Starting program: /usr/bin/vkcube
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".

Breakpoint 1, demo_init_connection (demo=0x7fffffffca70) at /usr/src/debug/dev-util/vulkan-tools-1.2.141/Vulkan-Tools-1.2.141/cube/cube.c:3656
3656    static void demo_init_connection(struct demo *demo) {
(gdb) n
3662        const char *display_envar = getenv("DISPLAY");
(gdb) p scr
$1 = 32767
```

Which then breaks the `while` check:
```while (scr-- > 0)```
and eventually leads to a segfault while iterating over `xcb_screen`s.

I wonder why the compiler doesn't pick this up?