### PR TITLE
mockicd: Remove VK_KHR_portability_subset

### DIFF
--- a/icd/generated/mock_icd.h
+++ b/icd/generated/mock_icd.h
@@ -180,7 +180,6 @@ static const std::unordered_map<std::string, uint32_t> device_extension_map = {
     {"VK_EXT_image_drm_format_modifier", 1},
     {"VK_EXT_descriptor_indexing", 2},
     {"VK_EXT_shader_viewport_index_layer", 1},
-    {"VK_KHR_portability_subset", 1},
     {"VK_NV_shading_rate_image", 3},
     {"VK_NV_ray_tracing", 3},
     {"VK_NV_representative_fragment_test", 2},

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -1185,7 +1185,7 @@ class MockICDOutputGenerator(OutputGenerator):
             device_exts = []
             instance_exts = []
             # Ignore extensions that ICDs should not implement or are not safe to report
-            ignore_exts = ['VK_EXT_validation_cache']
+            ignore_exts = ['VK_EXT_validation_cache', 'VK_KHR_portability_subset']
             for ext in self.registry.tree.findall("extensions/extension"):
                 if ext.attrib['supported'] != 'disabled': # Only include enabled extensions
                     if (ext.attrib['name'] in ignore_exts):


### PR DESCRIPTION
Don't report VK_KHR_portability_subset as being supported.

Change-Id: I84fa925cee23d3a28ca2726972cb9820c03c619c