### PR TITLE
cmake: Silence warnings.

### DIFF
--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -62,8 +62,10 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(VulkanHeaders
     DEFAULT_MSG
     VulkanHeaders_INCLUDE_DIR)
+set(FPHSA_NAME_MISMATCHED TRUE)
 find_package_handle_standard_args(VulkanRegistry
     DEFAULT_MSG
     VulkanRegistry_DIR)
+unset(FPHSA_NAME_MISMATCHED)
 
 mark_as_advanced(VulkanHeaders_INCLUDE_DIR VulkanRegistry_DIR)

--- a/cmake/FindXCB.cmake
+++ b/cmake/FindXCB.cmake
@@ -35,15 +35,15 @@ foreach(comp ${XCB_FIND_COMPONENTS})
         ${PC_${comp}_LIBRARY_DIRS}
         )
 
-    find_package_handle_standard_args(${comp}
-        FOUND_VAR ${comp}_FOUND
+    find_package_handle_standard_args(${compname}
+        FOUND_VAR ${compname}_FOUND
         REQUIRED_VARS ${compname}_INCLUDE_DIR ${compname}_LIBRARY)
     mark_as_advanced(${compname}_INCLUDE_DIR ${compname}_LIBRARY)
 
     list(APPEND XCB_INCLUDE_DIRS ${${compname}_INCLUDE_DIR})
     list(APPEND XCB_LIBRARIES ${${compname}_LIBRARY})
 
-    if(NOT ${comp}_FOUND)
+    if(NOT ${compname}_FOUND)
         set(XCB_FOUND false)
     endif()
 endforeach()


### PR DESCRIPTION
Silences two cmake verbose warnings as reproduced with `cmake-3.18.4`.
```
CMake Warning (dev) at /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:273 (message):
  The package name passed to `find_package_handle_standard_args`
  (VulkanRegistry) does not match the name of the calling package
  (VulkanHeaders).  This can lead to problems in calling code that expects
  `find_package` result variables (e.g., `_FOUND`) to follow a certain
  pattern.
Call Stack (most recent call first):
  cmake/FindVulkanHeaders.cmake:65 (find_package_handle_standard_args)
  CMakeLists.txt:97 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
```
CMake Warning (dev) at /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:273 (message):
  The package name passed to `find_package_handle_standard_args` (xcb) does
  not match the name of the calling package (XCB).  This can lead to problems
  in calling code that expects `find_package` result variables (e.g.,
  `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/FindXCB.cmake:38 (find_package_handle_standard_args)
  cube/CMakeLists.txt:53 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
For reference please see this related PR for Vulkan-ValidationLayers.

https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/2303