### PR TITLE
vulkaninfo: Make json output print extensions

### DIFF
--- a/vulkaninfo/outputprinter.h
+++ b/vulkaninfo/outputprinter.h
@@ -603,6 +603,10 @@ class Printer {
                     << DecorateAsValue(std::to_string(revision)) << "</summary></details>\n";
                 break;
             case (OutputType::json):
+                ObjectStart("");
+                PrintKeyString("extensionName", ext_name);
+                PrintKeyValue("specVersion", revision);
+                ObjectEnd();
                 break;
             case (OutputType::vkconfig_output):
                 ObjectStart(ext_name);

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -698,6 +698,13 @@ void DumpGpuJson(Printer &p, AppGpu &gpu) {
             GpuDumpQueuePropsJson(p, gpu.inst.surface_extensions, queue_props);
         }
     }
+    {
+        ArrayWrapper arr(p, "ArrayOfVkExtensionProperties");
+        for (auto &ext : gpu.device_extensions) {
+            p.PrintExtension(ext.extensionName, ext.specVersion);
+        }
+    }
+
     GpuDumpMemoryPropsJson(p, gpu);
     DumpVkPhysicalDeviceFeatures(p, "VkPhysicalDeviceFeatures", gpu.features);
     GpuDevDumpJson(p, gpu);


### PR DESCRIPTION
The json schema includes an array of extensions, yet vulkaninfo was not
printing them. This commit remedies that.

Change-Id: I4ae8627660f16d7c831704ba4b082870b5e62bb5