### PR TITLE
vulkaninfo: WIP: Modified for use from iOS

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -865,14 +865,7 @@ int main(int argc, char **argv) {
 // On iOS, we'll call this ourselves from a parent routine in the GUI
 int vulkanInfoMain(int argc, char **argv) {
 #endif
-    
-    bool human_readable_output = true;
-    bool html_output = false;
-    bool json_output = false;
-    bool vkconfig_output = false;
-    bool portability_json = false;
-    bool summary = false;
-    
+        
 #ifdef _WIN32
     if (ConsoleIsExclusive()) ConsoleEnlarge();
     if (!LoadUser32Dll()) {

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -859,11 +859,11 @@ void print_usage(const char *argv0) {
     std::cout << "--summary           Show a summary of the instance and GPU's on a system.\n\n";
 }
 
-#ifndef VK_USE_PLATFORM_IOS_MVK
-int main(int argc, char **argv) {
-#else
+#ifdef VK_USE_PLATFORM_IOS_MVK
 // On iOS, we'll call this ourselves from a parent routine in the GUI
 int vulkanInfoMain(int argc, char **argv) {
+#else
+int main(int argc, char **argv) {
 #endif
         
 #ifdef _WIN32
@@ -979,13 +979,13 @@ int vulkanInfoMain(int argc, char **argv) {
                 "\t\"comments\": {\n\t\t\"desc\": \"JSON configuration file describing GPU " + std::to_string(selected_gpu) +
                 ". Generated using the vulkaninfo program.\",\n\t\t\"vulkanApiVersion\": \"" +
                 VkVersionString(instance.vk_version) + "\"\n" + "\t}";
-#ifndef VK_USE_PLATFORM_IOS_MVK
-            printers.push_back(
-                std::unique_ptr<Printer>(new Printer(OutputType::json, out, selected_gpu, instance.vk_version, start_string)));
-#else
+#ifdef VK_USE_PLATFORM_IOS_MVK
             json_out = std::ofstream("vulkaninfo.json");
             printers.push_back(
                 std::unique_ptr<Printer>(new Printer(OutputType::json, json_out, selected_gpu, instance.vk_version, start_string)));
+#else
+            printers.push_back(
+                std::unique_ptr<Printer>(new Printer(OutputType::json, out, selected_gpu, instance.vk_version, start_string)));
 #endif
         }
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
@@ -1002,13 +1002,13 @@ int vulkanInfoMain(int argc, char **argv) {
                     "'s portability features and properties. Generated using the vulkaninfo program.\",\n\t\t\"vulkanApiVersion\": "
                     "\"" +
                     VkVersionString(instance.vk_version) + "\"\n" + "\t}";
-#ifndef VK_USE_PLATFORM_IOS_MVK
-                printers.push_back(
-                    std::unique_ptr<Printer>(new Printer(OutputType::json, out, selected_gpu, instance.vk_version, start_string)));
-#else
-                portability_out = std::ofstream("portabiliyt.json");
+#ifdef VK_USE_PLATFORM_IOS_MVK
+                portability_out = std::ofstream("portability.json");
                 printers.push_back(
                     std::unique_ptr<Printer>(new Printer(OutputType::json, portability_out, selected_gpu, instance.vk_version, start_string)));
+#else
+                printers.push_back(
+                    std::unique_ptr<Printer>(new Printer(OutputType::json, out, selected_gpu, instance.vk_version, start_string)));
 #endif
             }
         }
@@ -1025,7 +1025,7 @@ int vulkanInfoMain(int argc, char **argv) {
         }
 
         for (auto &p : printers) {
-#if defined(VK_USE_PLATFORM_IOS_MVK)
+#ifdef VK_USE_PLATFORM_IOS_MVK
             p->SetAlwaysOpenDetails(true);
 #endif
             if (summary) {

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -865,7 +865,7 @@ int vulkanInfoMain(int argc, char **argv) {
 #else
 int main(int argc, char **argv) {
 #endif
-        
+
 #ifdef _WIN32
     if (ConsoleIsExclusive()) ConsoleEnlarge();
     if (!LoadUser32Dll()) {
@@ -1004,8 +1004,8 @@ int main(int argc, char **argv) {
                     VkVersionString(instance.vk_version) + "\"\n" + "\t}";
 #ifdef VK_USE_PLATFORM_IOS_MVK
                 portability_out = std::ofstream("portability.json");
-                printers.push_back(
-                    std::unique_ptr<Printer>(new Printer(OutputType::json, portability_out, selected_gpu, instance.vk_version, start_string)));
+                printers.push_back(std::unique_ptr<Printer>(
+                    new Printer(OutputType::json, portability_out, selected_gpu, instance.vk_version, start_string)));
 #else
                 printers.push_back(
                     std::unique_ptr<Printer>(new Printer(OutputType::json, out, selected_gpu, instance.vk_version, start_string)));

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -108,14 +108,6 @@ struct VulkanException : std::runtime_error {
 };
 #define THROW_VK_ERR(func_name, err) throw VulkanException(func_name, __FILE__, __LINE__, err);
 
-// global configuration
-bool human_readable_output = true;
-bool html_output = false;
-bool json_output = false;
-bool vkconfig_output = false;
-bool portability_json = false;
-bool summary = false;
-
 #ifdef _WIN32
 
 #define strdup _strdup

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -108,6 +108,14 @@ struct VulkanException : std::runtime_error {
 };
 #define THROW_VK_ERR(func_name, err) throw VulkanException(func_name, __FILE__, __LINE__, err);
 
+bool human_readable_output = true;
+bool html_output = false;
+bool json_output = false;
+bool vkconfig_output = false;
+bool portability_json = false;
+bool summary = false;
+
+
 #ifdef _WIN32
 
 #define strdup _strdup

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -116,7 +116,6 @@ bool vkconfig_output = false;
 bool portability_json = false;
 bool summary = false;
 
-
 #ifdef _WIN32
 
 #define strdup _strdup

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -108,6 +108,7 @@ struct VulkanException : std::runtime_error {
 };
 #define THROW_VK_ERR(func_name, err) throw VulkanException(func_name, __FILE__, __LINE__, err);
 
+// Global configuration (Used by Windows WAIT_FOR_CONSOLE_DESTROY MACRO)
 bool human_readable_output = true;
 bool html_output = false;
 bool json_output = false;


### PR DESCRIPTION
Work in progress. Modifications to support use from iOS where console output is not available, but json and portability output is directly captured to .json files. For iOS, main() is now vulkainInfoMain() and is called from an iOS host GUI process still in development.