### PR TITLE
vkcube: Updated to support portability extension properly

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -25,7 +25,6 @@
  * Author: Bill Hollings <bill.hollings@brenwill.com>
  */
 
-#define VK_ENABLE_BETA_EXTENSIONS
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdarg.h>
@@ -3312,8 +3311,8 @@ static void demo_init_vk(struct demo *demo) {
                 swapchainExtFound = 1;
                 demo->extension_names[demo->enabled_extension_count++] = VK_KHR_SWAPCHAIN_EXTENSION_NAME;
             }
-            if (!strcmp(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME, device_extensions[i].extensionName)) {
-                demo->extension_names[demo->enabled_extension_count++] = VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME;
+            if (!strcmp("VK_KHR_portability_subset", device_extensions[i].extensionName)) {
+                demo->extension_names[demo->enabled_extension_count++] = "VK_KHR_portability_subset";
             }
             assert(demo->enabled_extension_count < 64);
         }

--- a/cube/cube.c
+++ b/cube/cube.c
@@ -1364,10 +1364,10 @@ static void demo_prepare_buffers(struct demo *demo) {
             .format = demo->format,
             .components =
                 {
-                    .r = VK_COMPONENT_SWIZZLE_R,
-                    .g = VK_COMPONENT_SWIZZLE_G,
-                    .b = VK_COMPONENT_SWIZZLE_B,
-                    .a = VK_COMPONENT_SWIZZLE_A,
+                    .r = VK_COMPONENT_SWIZZLE_IDENTITY,
+                    .g = VK_COMPONENT_SWIZZLE_IDENTITY,
+                    .b = VK_COMPONENT_SWIZZLE_IDENTITY,
+                    .a = VK_COMPONENT_SWIZZLE_IDENTITY,
                 },
             .subresourceRange =
                 {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = 0, .levelCount = 1, .baseArrayLayer = 0, .layerCount = 1},
@@ -1729,10 +1729,10 @@ static void demo_prepare_textures(struct demo *demo) {
             .format = tex_format,
             .components =
                 {
-                    VK_COMPONENT_SWIZZLE_R,
-                    VK_COMPONENT_SWIZZLE_G,
-                    VK_COMPONENT_SWIZZLE_B,
-                    VK_COMPONENT_SWIZZLE_A,
+                    VK_COMPONENT_SWIZZLE_IDENTITY,
+                    VK_COMPONENT_SWIZZLE_IDENTITY,
+                    VK_COMPONENT_SWIZZLE_IDENTITY,
+                    VK_COMPONENT_SWIZZLE_IDENTITY,
                 },
             .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
             .flags = 0,
@@ -3136,6 +3136,9 @@ static void demo_init_vk(struct demo *demo) {
                 demo->extension_names[demo->enabled_extension_count++] = VK_EXT_METAL_SURFACE_EXTENSION_NAME;
             }
 #endif
+            if (!strcmp(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, instance_extensions[i].extensionName)) {
+                demo->extension_names[demo->enabled_extension_count++] = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME;
+            }
             if (!strcmp(VK_EXT_DEBUG_UTILS_EXTENSION_NAME, instance_extensions[i].extensionName)) {
                 if (demo->validate) {
                     demo->extension_names[demo->enabled_extension_count++] = VK_EXT_DEBUG_UTILS_EXTENSION_NAME;
@@ -3307,6 +3310,9 @@ static void demo_init_vk(struct demo *demo) {
             if (!strcmp(VK_KHR_SWAPCHAIN_EXTENSION_NAME, device_extensions[i].extensionName)) {
                 swapchainExtFound = 1;
                 demo->extension_names[demo->enabled_extension_count++] = VK_KHR_SWAPCHAIN_EXTENSION_NAME;
+            }
+            if (!strcmp(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME, device_extensions[i].extensionName)) {
+                demo->extension_names[demo->enabled_extension_count++] = VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME;
             }
             assert(demo->enabled_extension_count < 64);
         }

--- a/cube/cube.c
+++ b/cube/cube.c
@@ -25,6 +25,7 @@
  * Author: Bill Hollings <bill.hollings@brenwill.com>
  */
 
+#define VK_ENABLE_BETA_EXTENSIONS
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdarg.h>

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -17,7 +17,7 @@
  *
  * Author: Jeremy Hayes <jeremy@lunarg.com>
  */
-
+#define VK_ENABLE_BETA_EXTENSIONS
 #if defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR)
 #include <X11/Xutil.h>
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -17,7 +17,7 @@
  *
  * Author: Jeremy Hayes <jeremy@lunarg.com>
  */
-#define VK_ENABLE_BETA_EXTENSIONS
+
 #if defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR)
 #include <X11/Xutil.h>
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
@@ -1286,8 +1286,8 @@ void Demo::init_vk() {
                 swapchainExtFound = 1;
                 extension_names[enabled_extension_count++] = VK_KHR_SWAPCHAIN_EXTENSION_NAME;
             }
-            if (!strcmp(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME, device_extensions[i].extensionName)) {
-                extension_names[enabled_extension_count++] = VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME;
+            if (!strcmp("VK_KHR_portability_subset", device_extensions[i].extensionName)) {
+                extension_names[enabled_extension_count++] = "VK_KHR_portability_subset";
             }
             assert(enabled_extension_count < 64);
         }

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -1110,6 +1110,9 @@ void Demo::init_vk() {
         VERIFY(result == vk::Result::eSuccess);
 
         for (uint32_t i = 0; i < instance_extension_count; i++) {
+            if (!strcmp(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, instance_extensions[i].extensionName)) {
+                extension_names[enabled_extension_count++] = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME;
+            }
             if (!strcmp(VK_KHR_SURFACE_EXTENSION_NAME, instance_extensions[i].extensionName)) {
                 surfaceExtFound = 1;
                 extension_names[enabled_extension_count++] = VK_KHR_SURFACE_EXTENSION_NAME;
@@ -1149,7 +1152,6 @@ void Demo::init_vk() {
                 platformSurfaceExtFound = 1;
                 extension_names[enabled_extension_count++] = VK_EXT_METAL_SURFACE_EXTENSION_NAME;
             }
-
 #endif
             assert(enabled_extension_count < 64);
         }
@@ -1283,6 +1285,9 @@ void Demo::init_vk() {
             if (!strcmp(VK_KHR_SWAPCHAIN_EXTENSION_NAME, device_extensions[i].extensionName)) {
                 swapchainExtFound = 1;
                 extension_names[enabled_extension_count++] = VK_KHR_SWAPCHAIN_EXTENSION_NAME;
+            }
+            if (!strcmp(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME, device_extensions[i].extensionName)) {
+                extension_names[enabled_extension_count++] = VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME;
             }
             assert(enabled_extension_count < 64);
         }


### PR DESCRIPTION
Updated vkcube to properly enable the VK_KHR_portability_subset. Once added, the swizzle formats were then tagged as failing validation and had to be changed to VK_COMPONENT_SWIZZLE_IDENTITY, which does not result in a change in behavior.