### PR TITLE
vkcube: Add options --width and --height to specify width and height

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -3816,6 +3816,8 @@ static void demo_init(struct demo *demo, int argc, char **argv) {
     memset(demo, 0, sizeof(*demo));
     demo->presentMode = VK_PRESENT_MODE_FIFO_KHR;
     demo->frameCount = INT32_MAX;
+    demo->width = 500;
+    demo->height = 500;
     /* For cube demo we just grab the first physical device by default */
     demo->gpu_number = 0;
 
@@ -3851,6 +3853,16 @@ static void demo_init(struct demo *demo, int argc, char **argv) {
             i++;
             continue;
         }
+        if (strcmp(argv[i], "--width") == 0 && i < argc - 1 &&
+            sscanf(argv[i + 1], "%d", &demo->width) == 1 && demo->width > 0) {
+            i++;
+            continue;
+        }
+        if (strcmp(argv[i], "--height") == 0 && i < argc - 1 &&
+            sscanf(argv[i + 1], "%d", &demo->height) == 1 && demo->height > 0) {
+            i++;
+            continue;
+        }
         if (strcmp(argv[i], "--suppress_popups") == 0) {
             demo->suppress_popups = true;
             continue;
@@ -3878,6 +3890,7 @@ static void demo_init(struct demo *demo, int argc, char **argv) {
             "\t[--incremental_present] [--display_timing]\n"
             "\t[--gpu_number <index of physical device>]\n"
             "\t[--present_mode <present mode enum>]\n"
+            "\t[--width <width>] [--height <height>]\n"
             "\t<present_mode_enum>\n"
             "\t\tVK_PRESENT_MODE_IMMEDIATE_KHR = %d\n"
             "\t\tVK_PRESENT_MODE_MAILBOX_KHR = %d\n"
@@ -3905,9 +3918,6 @@ static void demo_init(struct demo *demo, int argc, char **argv) {
     demo_init_connection(demo);
 
     demo_init_vk(demo);
-
-    demo->width = 500;
-    demo->height = 500;
 
     demo->spin_angle = 4.0f;
     demo->spin_increment = 0.2f;

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -939,6 +939,8 @@ void Demo::init(int argc, char **argv) {
 
     presentMode = vk::PresentModeKHR::eFifo;
     frameCount = UINT32_MAX;
+    width = 500;
+    height = 500;
     use_xlib = false;
     /* For cube demo we just grab the first physical device by default */
     gpu_number = 0;
@@ -970,6 +972,16 @@ void Demo::init(int argc, char **argv) {
             i++;
             continue;
         }
+        if (strcmp(argv[i], "--width") == 0 && i < argc - 1 &&
+            sscanf(argv[i + 1], "%" SCNu32, &width) == 1 && width > 0) {
+            i++;
+            continue;
+        }
+        if (strcmp(argv[i], "--height") == 0 && i < argc - 1 &&
+            sscanf(argv[i + 1], "%" SCNu32, &height) == 1 && height > 0) {
+            i++;
+            continue;
+        }
         if (strcmp(argv[i], "--suppress_popups") == 0) {
             suppress_popups = true;
             continue;
@@ -984,6 +996,7 @@ void Demo::init(int argc, char **argv) {
               << "\t[--break] [--c <framecount>] [--suppress_popups]\n"
               << "\t[--gpu_number <index of physical device>]\n"
               << "\t[--present_mode <present mode enum>]\n"
+              << "\t[--width <width>] [--height <height>]\n"
               << "\t<present_mode_enum>\n"
               << "\t\tVK_PRESENT_MODE_IMMEDIATE_KHR = " << VK_PRESENT_MODE_IMMEDIATE_KHR << "\n"
               << "\t\tVK_PRESENT_MODE_MAILBOX_KHR = " << VK_PRESENT_MODE_MAILBOX_KHR << "\n"
@@ -1004,9 +1017,6 @@ void Demo::init(int argc, char **argv) {
     }
 
     init_vk();
-
-    width = 500;
-    height = 500;
 
     spin_angle = 4.0f;
     spin_increment = 0.2f;


### PR DESCRIPTION
This change adds --w and --h options to specify width and height when running vkcube.

Nicolas Caramelli