### PR TITLE
Trigger demo quit from applicationWillTerminate

### DIFF
--- a/cube/macOS/cube/AppDelegate.m
+++ b/cube/macOS/cube/AppDelegate.m
@@ -17,6 +17,7 @@
  */
 
 #import "AppDelegate.h"
+#import "DemoViewController.h"
 
 @interface AppDelegate ()
 
@@ -29,7 +30,15 @@
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification {
-    // Insert code here to tear down your application
+    NSApplication *app = aNotification.object;
+    NSArray<NSWindow *> *windows = app.windows;
+    for (NSUInteger i = 0; i < windows.count; ++i) {
+        NSViewController *viewController = windows[i].contentViewController;
+        if ([viewController isKindOfClass:[DemoViewController class]]) {
+            [(DemoViewController *)viewController quit];
+            break;
+        }
+    }
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {

--- a/cube/macOS/cube/DemoViewController.h
+++ b/cube/macOS/cube/DemoViewController.h
@@ -23,6 +23,9 @@
 
 /** The main view controller for the demo storyboard. */
 @interface DemoViewController : NSViewController
+
+- (void)quit;
+
 @end
 
 #pragma mark -

--- a/cube/macOS/cube/DemoViewController.m
+++ b/cube/macOS/cube/DemoViewController.m
@@ -33,9 +33,13 @@
 }
 
 - (void)dealloc {
-    demo_cleanup(&demo);
-    CVDisplayLinkRelease(_displayLink);
+    [self quit];
     [super dealloc];
+}
+
+- (void)quit {
+    CVDisplayLinkRelease(_displayLink);
+    demo_cleanup(&demo);
 }
 
 /** Since this is a single-view app, initialize Vulkan during view loading. */

--- a/cube/macOS/cubepp/AppDelegate.mm
+++ b/cube/macOS/cubepp/AppDelegate.mm
@@ -17,6 +17,7 @@
  */
 
 #import "AppDelegate.h"
+#import "DemoViewController.h"
 
 @interface AppDelegate ()
 
@@ -29,7 +30,15 @@
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification {
-    // Insert code here to tear down your application
+    NSApplication *app = aNotification.object;
+    NSArray<NSWindow *> *windows = app.windows;
+    for (NSUInteger i = 0; i < windows.count; ++i) {
+        NSViewController *viewController = windows[i].contentViewController;
+        if ([viewController isKindOfClass:[DemoViewController class]]) {
+            [(DemoViewController *)viewController quit];
+            break;
+        }
+    }
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {

--- a/cube/macOS/cubepp/DemoViewController.h
+++ b/cube/macOS/cubepp/DemoViewController.h
@@ -23,6 +23,9 @@
 
 /** The main view controller for the demo storyboard. */
 @interface DemoViewController : NSViewController
+
+- (void)quit;
+
 @end
 
 #pragma mark -

--- a/cube/macOS/cubepp/DemoViewController.mm
+++ b/cube/macOS/cubepp/DemoViewController.mm
@@ -33,9 +33,13 @@
 }
 
 - (void)dealloc {
-    demo.cleanup();
-    CVDisplayLinkRelease(_displayLink);
+    [self quit];
     [super dealloc];
+}
+
+- (void)quit {
+    CVDisplayLinkRelease(_displayLink);
+    demo.cleanup();
 }
 
 /** Since this is a single-view app, initialize Vulkan during view loading. */


### PR DESCRIPTION
#### Outcome 

A clean shutdown of the rendering thread (`CVDisplayLink`) whilst the main thread is exiting.

#### Problem

Locally I am working with the Mac version of `RenderDoc` and using samples like the cube projects as part of my local manual testing of the `Vulkan` implementation.

Whilst capturing the cube project with `RenderDoc`. I discovered a crash during shutdown which only happens when `RenderDoc` is attached. I tracked this back to the cube project rendering thread bring active whilst the main thread exit flow is executing ie. static destructors. 

#### Notes

This PR is not critical. I am happy to keep it local to help my testing of the Mac `Vulkan` version of `RenderDoc`.

This PR is one proposed way to fix the shutdown crash when capturing from `RenderDoc` by quitting the demo from the application event `applicationWillTerminate`.

I also changed the exiting `dealloc` implementation because it appeared to be calling things in the wrong ie. demo cleanup was called before stopping the rendering thread which in principal could have left the rendering thread active whilst the demo was being deleted. In my local testing the `dealloc` method did not appear to be called.

I have a different (a bit simpler) implementation to solve the problem which is to stop and start the `CVDisplayLink` from the `DemoViewController` events `viewWillDisappear`  & `viewWillAppear`.

#### Testing

Locally on M1 MacBookAir for the vkcube & vkcubepp applications (debug and release builds) attached and unattached to RenderDoc Mac.