### PR TITLE
vkcube: Fix disturbed rotation after many iterations

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -882,7 +882,8 @@ void demo_update_data_buffer(struct demo *demo) {
 
     // Rotate around the Y axis
     mat4x4_dup(Model, demo->model_matrix);
-    mat4x4_rotate(demo->model_matrix, Model, 0.0f, 1.0f, 0.0f, (float)degreesToRadians(demo->spin_angle));
+    mat4x4_rotate_Y(demo->model_matrix, Model, (float)degreesToRadians(demo->spin_angle));
+    mat4x4_orthonormalize(demo->model_matrix, demo->model_matrix);
     mat4x4_mul(MVP, VP, demo->model_matrix);
 
     memcpy(demo->swapchain_image_resources[demo->current_buffer].uniform_memory_ptr, (const void *)&MVP[0][0], matrixSize);

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -91,13 +91,6 @@ static char const *const tex_files[] = {"lunarg.ppm"};
 
 static int validation_error = 0;
 
-struct vkcube_vs_uniform {
-    // Must start with MVP
-    float mvp[4][4];
-    float position[12 * 3][4];
-    float color[12 * 3][4];
-};
-
 struct vktexcube_vs_uniform {
     // Must start with MVP
     float mvp[4][4];
@@ -2472,7 +2465,8 @@ void Demo::update_data_buffer() {
     // Rotate around the Y axis
     mat4x4 Model;
     mat4x4_dup(Model, model_matrix);
-    mat4x4_rotate(model_matrix, Model, 0.0f, 1.0f, 0.0f, (float)degreesToRadians(spin_angle));
+    mat4x4_rotate_Y(model_matrix, Model, (float)degreesToRadians(spin_angle));
+    mat4x4_orthonormalize(model_matrix, model_matrix);
 
     mat4x4 MVP;
     mat4x4_mul(MVP, VP, model_matrix);


### PR DESCRIPTION
vkcube computes the model matrix for the cube by repeatedly multiplying
a rotation matrix with it. After a sufficient number of iterations the
matrix becomes disturbed (likely due to numerical errors) and stops
being orthogonal and the cube vertices start scaling along the
XY plane. Over multiple days the cube turns into a rectangular prism.

* Orthonormalize the model matrix after each multiplication to prevent
the scaling.
* Use mat4x4_rotate_Y() instead of mat4x4_rotate() as it is less
verbose.
* Remove unused duplicate vkcube_vs_uniform struct.