### PR TITLE
vulkaninfo: fix hidden declaration warnings

### DIFF
--- a/scripts/vulkaninfo_generator.py
+++ b/scripts/vulkaninfo_generator.py
@@ -441,7 +441,7 @@ def PrintGetFlagStrings(name, bitmask):
         "GetStrings(" + name + " value) {\n"
 
     out += "    std::vector<const char *> strings;\n"
-    out += "    if (value == 0) strings.push_back(\"None\");\n"
+    out += "    if (value == 0) { strings.push_back(\"None\"); return strings; }\n"
     for v in bitmask.options:
         val = v.value if isinstance(v.value, str) else str(hex(v.value))
         out += "    if (" + val + " & value) strings.push_back(\"" + \
@@ -454,13 +454,13 @@ def PrintFlags(bitmask, name):
     out = "void Dump" + name + \
         "(Printer &p, std::string name, " + name + " value, int width = 0) {\n"
     out += "    if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }\n"
-    out += "    auto strings = " + bitmask.name + \
-        "GetStrings(static_cast<" + bitmask.name + ">(value));\n"
     out += "    if (static_cast<" + bitmask.name + ">(value) == 0) {\n"
     out += "        ArrayWrapper arr(p, name, 0);\n"
     out += "        p.SetAsType().PrintString(\"None\");\n"
     out += "        return;\n"
     out += "    }\n"
+    out += "    auto strings = " + bitmask.name + \
+        "GetStrings(static_cast<" + bitmask.name + ">(value));\n"
     out += "    ArrayWrapper arr(p, name, strings.size());\n"
     out += "    for(auto& str : strings){\n"
     out += "        p.SetAsType().PrintString(str);\n"

--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -495,7 +495,7 @@ void DumpVkShaderFloatControlsIndependence(Printer &p, std::string name, VkShade
 }
 std::vector<const char *>VkCompositeAlphaFlagBitsKHRGetStrings(VkCompositeAlphaFlagBitsKHR value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("COMPOSITE_ALPHA_OPAQUE_BIT_KHR");
     if (0x2 & value) strings.push_back("COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR");
     if (0x4 & value) strings.push_back("COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR");
@@ -504,12 +504,12 @@ std::vector<const char *>VkCompositeAlphaFlagBitsKHRGetStrings(VkCompositeAlphaF
 }
 void DumpVkCompositeAlphaFlagsKHR(Printer &p, std::string name, VkCompositeAlphaFlagsKHR value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkCompositeAlphaFlagBitsKHRGetStrings(static_cast<VkCompositeAlphaFlagBitsKHR>(value));
     if (static_cast<VkCompositeAlphaFlagBitsKHR>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkCompositeAlphaFlagBitsKHRGetStrings(static_cast<VkCompositeAlphaFlagBitsKHR>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -522,7 +522,7 @@ void DumpVkCompositeAlphaFlagBitsKHR(Printer &p, std::string name, VkCompositeAl
 
 std::vector<const char *>VkDeviceGroupPresentModeFlagBitsKHRGetStrings(VkDeviceGroupPresentModeFlagBitsKHR value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHR");
     if (0x2 & value) strings.push_back("DEVICE_GROUP_PRESENT_MODE_REMOTE_BIT_KHR");
     if (0x4 & value) strings.push_back("DEVICE_GROUP_PRESENT_MODE_SUM_BIT_KHR");
@@ -531,12 +531,12 @@ std::vector<const char *>VkDeviceGroupPresentModeFlagBitsKHRGetStrings(VkDeviceG
 }
 void DumpVkDeviceGroupPresentModeFlagsKHR(Printer &p, std::string name, VkDeviceGroupPresentModeFlagsKHR value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkDeviceGroupPresentModeFlagBitsKHRGetStrings(static_cast<VkDeviceGroupPresentModeFlagBitsKHR>(value));
     if (static_cast<VkDeviceGroupPresentModeFlagBitsKHR>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkDeviceGroupPresentModeFlagBitsKHRGetStrings(static_cast<VkDeviceGroupPresentModeFlagBitsKHR>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -549,7 +549,7 @@ void DumpVkDeviceGroupPresentModeFlagBitsKHR(Printer &p, std::string name, VkDev
 
 std::vector<const char *>VkFormatFeatureFlagBitsGetStrings(VkFormatFeatureFlagBits value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("FORMAT_FEATURE_SAMPLED_IMAGE_BIT");
     if (0x2 & value) strings.push_back("FORMAT_FEATURE_STORAGE_IMAGE_BIT");
     if (0x4 & value) strings.push_back("FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT");
@@ -585,12 +585,12 @@ std::vector<const char *>VkFormatFeatureFlagBitsGetStrings(VkFormatFeatureFlagBi
 }
 void DumpVkFormatFeatureFlags(Printer &p, std::string name, VkFormatFeatureFlags value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkFormatFeatureFlagBitsGetStrings(static_cast<VkFormatFeatureFlagBits>(value));
     if (static_cast<VkFormatFeatureFlagBits>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkFormatFeatureFlagBitsGetStrings(static_cast<VkFormatFeatureFlagBits>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -603,7 +603,7 @@ void DumpVkFormatFeatureFlagBits(Printer &p, std::string name, VkFormatFeatureFl
 
 std::vector<const char *>VkImageUsageFlagBitsGetStrings(VkImageUsageFlagBits value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("IMAGE_USAGE_TRANSFER_SRC_BIT");
     if (0x2 & value) strings.push_back("IMAGE_USAGE_TRANSFER_DST_BIT");
     if (0x4 & value) strings.push_back("IMAGE_USAGE_SAMPLED_BIT");
@@ -624,12 +624,12 @@ std::vector<const char *>VkImageUsageFlagBitsGetStrings(VkImageUsageFlagBits val
 }
 void DumpVkImageUsageFlags(Printer &p, std::string name, VkImageUsageFlags value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkImageUsageFlagBitsGetStrings(static_cast<VkImageUsageFlagBits>(value));
     if (static_cast<VkImageUsageFlagBits>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkImageUsageFlagBitsGetStrings(static_cast<VkImageUsageFlagBits>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -642,19 +642,19 @@ void DumpVkImageUsageFlagBits(Printer &p, std::string name, VkImageUsageFlagBits
 
 std::vector<const char *>VkMemoryHeapFlagBitsGetStrings(VkMemoryHeapFlagBits value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("MEMORY_HEAP_DEVICE_LOCAL_BIT");
     if (0x2 & value) strings.push_back("MEMORY_HEAP_MULTI_INSTANCE_BIT");
     return strings;
 }
 void DumpVkMemoryHeapFlags(Printer &p, std::string name, VkMemoryHeapFlags value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkMemoryHeapFlagBitsGetStrings(static_cast<VkMemoryHeapFlagBits>(value));
     if (static_cast<VkMemoryHeapFlagBits>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkMemoryHeapFlagBitsGetStrings(static_cast<VkMemoryHeapFlagBits>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -667,7 +667,7 @@ void DumpVkMemoryHeapFlagBits(Printer &p, std::string name, VkMemoryHeapFlagBits
 
 std::vector<const char *>VkMemoryPropertyFlagBitsGetStrings(VkMemoryPropertyFlagBits value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("MEMORY_PROPERTY_DEVICE_LOCAL_BIT");
     if (0x2 & value) strings.push_back("MEMORY_PROPERTY_HOST_VISIBLE_BIT");
     if (0x4 & value) strings.push_back("MEMORY_PROPERTY_HOST_COHERENT_BIT");
@@ -680,12 +680,12 @@ std::vector<const char *>VkMemoryPropertyFlagBitsGetStrings(VkMemoryPropertyFlag
 }
 void DumpVkMemoryPropertyFlags(Printer &p, std::string name, VkMemoryPropertyFlags value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkMemoryPropertyFlagBitsGetStrings(static_cast<VkMemoryPropertyFlagBits>(value));
     if (static_cast<VkMemoryPropertyFlagBits>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkMemoryPropertyFlagBitsGetStrings(static_cast<VkMemoryPropertyFlagBits>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -731,7 +731,7 @@ std::string VkQueueFlagsString(VkQueueFlags value, int width = 0) {
 }
 std::vector<const char *>VkResolveModeFlagBitsGetStrings(VkResolveModeFlagBits value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0 & value) strings.push_back("RESOLVE_MODE_NONE");
     if (0x1 & value) strings.push_back("RESOLVE_MODE_SAMPLE_ZERO_BIT");
     if (0x2 & value) strings.push_back("RESOLVE_MODE_AVERAGE_BIT");
@@ -741,12 +741,12 @@ std::vector<const char *>VkResolveModeFlagBitsGetStrings(VkResolveModeFlagBits v
 }
 void DumpVkResolveModeFlags(Printer &p, std::string name, VkResolveModeFlags value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkResolveModeFlagBitsGetStrings(static_cast<VkResolveModeFlagBits>(value));
     if (static_cast<VkResolveModeFlagBits>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkResolveModeFlagBitsGetStrings(static_cast<VkResolveModeFlagBits>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -759,7 +759,7 @@ void DumpVkResolveModeFlagBits(Printer &p, std::string name, VkResolveModeFlagBi
 
 std::vector<const char *>VkSampleCountFlagBitsGetStrings(VkSampleCountFlagBits value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("SAMPLE_COUNT_1_BIT");
     if (0x2 & value) strings.push_back("SAMPLE_COUNT_2_BIT");
     if (0x4 & value) strings.push_back("SAMPLE_COUNT_4_BIT");
@@ -771,12 +771,12 @@ std::vector<const char *>VkSampleCountFlagBitsGetStrings(VkSampleCountFlagBits v
 }
 void DumpVkSampleCountFlags(Printer &p, std::string name, VkSampleCountFlags value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkSampleCountFlagBitsGetStrings(static_cast<VkSampleCountFlagBits>(value));
     if (static_cast<VkSampleCountFlagBits>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkSampleCountFlagBitsGetStrings(static_cast<VkSampleCountFlagBits>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -789,7 +789,7 @@ void DumpVkSampleCountFlagBits(Printer &p, std::string name, VkSampleCountFlagBi
 
 std::vector<const char *>VkShaderStageFlagBitsGetStrings(VkShaderStageFlagBits value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("SHADER_STAGE_VERTEX_BIT");
     if (0x2 & value) strings.push_back("SHADER_STAGE_TESSELLATION_CONTROL_BIT");
     if (0x4 & value) strings.push_back("SHADER_STAGE_TESSELLATION_EVALUATION_BIT");
@@ -810,12 +810,12 @@ std::vector<const char *>VkShaderStageFlagBitsGetStrings(VkShaderStageFlagBits v
 }
 void DumpVkShaderStageFlags(Printer &p, std::string name, VkShaderStageFlags value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkShaderStageFlagBitsGetStrings(static_cast<VkShaderStageFlagBits>(value));
     if (static_cast<VkShaderStageFlagBits>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkShaderStageFlagBitsGetStrings(static_cast<VkShaderStageFlagBits>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -828,7 +828,7 @@ void DumpVkShaderStageFlagBits(Printer &p, std::string name, VkShaderStageFlagBi
 
 std::vector<const char *>VkSubgroupFeatureFlagBitsGetStrings(VkSubgroupFeatureFlagBits value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("SUBGROUP_FEATURE_BASIC_BIT");
     if (0x2 & value) strings.push_back("SUBGROUP_FEATURE_VOTE_BIT");
     if (0x4 & value) strings.push_back("SUBGROUP_FEATURE_ARITHMETIC_BIT");
@@ -842,12 +842,12 @@ std::vector<const char *>VkSubgroupFeatureFlagBitsGetStrings(VkSubgroupFeatureFl
 }
 void DumpVkSubgroupFeatureFlags(Printer &p, std::string name, VkSubgroupFeatureFlags value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkSubgroupFeatureFlagBitsGetStrings(static_cast<VkSubgroupFeatureFlagBits>(value));
     if (static_cast<VkSubgroupFeatureFlagBits>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkSubgroupFeatureFlagBitsGetStrings(static_cast<VkSubgroupFeatureFlagBits>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -860,18 +860,18 @@ void DumpVkSubgroupFeatureFlagBits(Printer &p, std::string name, VkSubgroupFeatu
 
 std::vector<const char *>VkSurfaceCounterFlagBitsEXTGetStrings(VkSurfaceCounterFlagBitsEXT value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("SURFACE_COUNTER_VBLANK_BIT_EXT");
     return strings;
 }
 void DumpVkSurfaceCounterFlagsEXT(Printer &p, std::string name, VkSurfaceCounterFlagsEXT value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkSurfaceCounterFlagBitsEXTGetStrings(static_cast<VkSurfaceCounterFlagBitsEXT>(value));
     if (static_cast<VkSurfaceCounterFlagBitsEXT>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkSurfaceCounterFlagBitsEXTGetStrings(static_cast<VkSurfaceCounterFlagBitsEXT>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -884,7 +884,7 @@ void DumpVkSurfaceCounterFlagBitsEXT(Printer &p, std::string name, VkSurfaceCoun
 
 std::vector<const char *>VkSurfaceTransformFlagBitsKHRGetStrings(VkSurfaceTransformFlagBitsKHR value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("SURFACE_TRANSFORM_IDENTITY_BIT_KHR");
     if (0x2 & value) strings.push_back("SURFACE_TRANSFORM_ROTATE_90_BIT_KHR");
     if (0x4 & value) strings.push_back("SURFACE_TRANSFORM_ROTATE_180_BIT_KHR");
@@ -898,12 +898,12 @@ std::vector<const char *>VkSurfaceTransformFlagBitsKHRGetStrings(VkSurfaceTransf
 }
 void DumpVkSurfaceTransformFlagsKHR(Printer &p, std::string name, VkSurfaceTransformFlagsKHR value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkSurfaceTransformFlagBitsKHRGetStrings(static_cast<VkSurfaceTransformFlagBitsKHR>(value));
     if (static_cast<VkSurfaceTransformFlagBitsKHR>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkSurfaceTransformFlagBitsKHRGetStrings(static_cast<VkSurfaceTransformFlagBitsKHR>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);
@@ -916,7 +916,7 @@ void DumpVkSurfaceTransformFlagBitsKHR(Printer &p, std::string name, VkSurfaceTr
 
 std::vector<const char *>VkToolPurposeFlagBitsEXTGetStrings(VkToolPurposeFlagBitsEXT value) {
     std::vector<const char *> strings;
-    if (value == 0) strings.push_back("None");
+    if (value == 0) { strings.push_back("None"); return strings; }
     if (0x1 & value) strings.push_back("TOOL_PURPOSE_VALIDATION_BIT_EXT");
     if (0x2 & value) strings.push_back("TOOL_PURPOSE_PROFILING_BIT_EXT");
     if (0x4 & value) strings.push_back("TOOL_PURPOSE_TRACING_BIT_EXT");
@@ -928,12 +928,12 @@ std::vector<const char *>VkToolPurposeFlagBitsEXTGetStrings(VkToolPurposeFlagBit
 }
 void DumpVkToolPurposeFlagsEXT(Printer &p, std::string name, VkToolPurposeFlagsEXT value, int width = 0) {
     if (p.Type() == OutputType::json) { p.PrintKeyValue(name, value); return; }
-    auto strings = VkToolPurposeFlagBitsEXTGetStrings(static_cast<VkToolPurposeFlagBitsEXT>(value));
     if (static_cast<VkToolPurposeFlagBitsEXT>(value) == 0) {
         ArrayWrapper arr(p, name, 0);
         p.SetAsType().PrintString("None");
         return;
     }
+    auto strings = VkToolPurposeFlagBitsEXTGetStrings(static_cast<VkToolPurposeFlagBitsEXT>(value));
     ArrayWrapper arr(p, name, strings.size());
     for(auto& str : strings){
         p.SetAsType().PrintString(str);

--- a/vulkaninfo/outputprinter.h
+++ b/vulkaninfo/outputprinter.h
@@ -272,6 +272,16 @@ class Printer {
         return *this;
     }
 
+    Printer &SetIgnoreMinWidth() {
+        ignore_min_width_parameter = true;
+        return *this;
+    }
+
+    Printer &UnsetIgnoreMinWidth() {
+        ignore_min_width_parameter = false;
+        return *this;
+    }
+
     Printer &SetElementIndex(int index) {
         assert(index >= 0 && "cannot set element index to a negative value");
         element_index = index;
@@ -462,10 +472,9 @@ class Printer {
     void PrintKeyValue(std::string key, T value, size_t min_key_width = 0, std::string value_description = "") {
         switch (output_type) {
             case (OutputType::text):
-                if (min_key_width > key.size()) {
-                    out << std::string(static_cast<size_t>(indents), '\t') << key << std::string(min_key_width - key.size(), ' ');
-                } else {
-                    out << std::string(static_cast<size_t>(indents), '\t') << key;
+                out << std::string(static_cast<size_t>(indents), '\t') << key;
+                if (min_key_width > key.size() && !ignore_min_width_parameter) {
+                    out << std::string(min_key_width - key.size(), ' ');
                 }
                 out << " = " << value;
                 if (value_description != "") {
@@ -673,6 +682,8 @@ class Printer {
 
     // make object titles the color of types
     bool set_object_name_as_type = false;
+
+    bool ignore_min_width_parameter = false;
 
     // objects which are in an array
     int element_index = -1;  // negative one is the sentinel value

--- a/vulkaninfo/outputprinter.h
+++ b/vulkaninfo/outputprinter.h
@@ -388,12 +388,12 @@ class Printer {
                 break;
         }
     }
-    void ArrayStart(std::string array_name, int32_t element_count = 0) {
+    void ArrayStart(std::string array_name, size_t element_count = 0) {
         switch (output_type) {
             case (OutputType::text): {
                 out << std::string(static_cast<size_t>(indents), '\t') << array_name << ":";
                 size_t underline_count = array_name.size() + 1;
-                if (element_count >= 0) {
+                if (element_count > 0) {
                     out << " count = " << element_count;
                     underline_count += 9 + std::to_string(element_count).size();
                 }
@@ -410,7 +410,7 @@ class Printer {
                     out << "<details>";
                 }
                 out << "<summary>" << array_name;
-                if (element_count >= 0) {
+                if (element_count > 0) {
                     out << ": count = <span class='val'>" << element_count << "</span>";
                 }
                 out << "</summary>\n";
@@ -725,7 +725,7 @@ class ObjectWrapper {
 class ArrayWrapper {
   public:
     ArrayWrapper(Printer &p, std::string array_name, size_t element_count = 0) : p(p) {
-        p.ArrayStart(array_name, static_cast<int32_t>(element_count));
+        p.ArrayStart(array_name, element_count);
     }
     ~ArrayWrapper() { p.ArrayEnd(); }
 

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -161,13 +161,7 @@ void DumpSurfaceCapabilities(Printer &p, AppInstance &inst, AppGpu &gpu, AppSurf
     if (inst.CheckExtensionEnabled(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME)) {
         p.SetSubHeader();
         ObjectWrapper obj(p, "VkSurfaceCapabilities2EXT");
-        {
-            ArrayWrapper arr(p, "supportedSurfaceCounters");
-            if (surface.surface_capabilities2_ext.supportedSurfaceCounters == 0) p.PrintString("None");
-            if (surface.surface_capabilities2_ext.supportedSurfaceCounters & VK_SURFACE_COUNTER_VBLANK_EXT) {
-                p.SetAsType().PrintString("VK_SURFACE_COUNTER_VBLANK_EXT");
-            }
-        }
+        DumpVkSurfaceCounterFlagsEXT(p, "supportedSurfaceCounters", surface.surface_capabilities2_ext.supportedSurfaceCounters);
     }
     if (inst.CheckExtensionEnabled(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME)) {
         chain_iterator_surface_capabilities2(p, inst, gpu, surface.surface_capabilities2_khr.pNext, inst.vk_version);
@@ -450,7 +444,7 @@ void GpuDumpMemoryProps(Printer &p, AppGpu &gpu) {
             // only linear and optimal tiling considered
             for (auto &image_tiling : gpu.memory_image_support_types) {
                 p.SetOpenDetails();
-                ArrayWrapper arr(p, VkImageTilingString(VkImageTiling(image_tiling.tiling)), 0);
+                ArrayWrapper arr(p, VkImageTilingString(VkImageTiling(image_tiling.tiling)));
                 bool has_any_support_types = false;
                 bool regular = false;
                 bool transient = false;

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -155,8 +155,9 @@ void DumpPresentModes(Printer &p, AppSurface &surface) {
 
 void DumpSurfaceCapabilities(Printer &p, AppInstance &inst, AppGpu &gpu, AppSurface &surface) {
     auto &surf_cap = surface.surface_capabilities;
-    p.SetSubHeader();
+    p.SetSubHeader().SetIgnoreMinWidth();
     DumpVkSurfaceCapabilitiesKHR(p, "VkSurfaceCapabilitiesKHR", surf_cap);
+    p.UnsetIgnoreMinWidth();
 
     if (inst.CheckExtensionEnabled(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME)) {
         p.SetSubHeader();


### PR DESCRIPTION
Also includes minor fixup of printing of VkSurfaceCapabilitiesKHR, slightly nicer logic in the printing functions, and using an auto-gened function instead of hand coding it.

Fixes #524 