### PR TITLE
vkcube: fix crash on exit from double delete

### DIFF
--- a/cube/macOS/cube/DemoViewController.m
+++ b/cube/macOS/cube/DemoViewController.m
@@ -89,7 +89,6 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
     demo_run(demo);
     if (demo->quit) {
         CVDisplayLinkStop(displayLink);
-        CVDisplayLinkRelease(displayLink);
     }
     return kCVReturnSuccess;
 }

--- a/cube/macOS/cubepp/DemoViewController.mm
+++ b/cube/macOS/cubepp/DemoViewController.mm
@@ -88,7 +88,6 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
     demo->run();
     if (demo->quit) {
         CVDisplayLinkStop(displayLink);
-        CVDisplayLinkRelease(displayLink);
     }
     return kCVReturnSuccess;
 }


### PR DESCRIPTION
Fixed crash on exit for vkcube due to

    CVDisplayLinkRelease(displayLink);

Being called twice on shutdown. Removed redundant call that was added recently.