### PR TITLE
cube: Handle occlusion where currentExtent == 0xFFFFFFFF

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -1237,7 +1237,7 @@ static void demo_prepare_buffers(struct demo *demo) {
         demo->height = surfCapabilities.currentExtent.height;
     }
 
-    if (demo->width == 0 || demo->height == 0) {
+    if (surfCapabilities.maxImageExtent.width == 0 || surfCapabilities.maxImageExtent.height == 0) {
         demo->is_minimized = true;
         return;
     } else {


### PR DESCRIPTION
The Vulkan spec states that: "On some platforms, it is normal that maxImageExtent may become (0, 0), for example when the window is minimized. In such a case, it is not possible to create a swapchain due to the Valid Usage requirements."

Yet vkcube previously only handled this path for platforms where currentExtent != 0xFFFFFFFF.