### PR TITLE
vulkaninfo: Allow specifying file output

### DIFF
--- a/vulkaninfo/outputprinter.h
+++ b/vulkaninfo/outputprinter.h
@@ -735,9 +735,7 @@ class ObjectWrapper {
 
 class ArrayWrapper {
   public:
-    ArrayWrapper(Printer &p, std::string array_name, size_t element_count = 0) : p(p) {
-        p.ArrayStart(array_name, element_count);
-    }
+    ArrayWrapper(Printer &p, std::string array_name, size_t element_count = 0) : p(p) { p.ArrayStart(array_name, element_count); }
     ~ArrayWrapper() { p.ArrayEnd(); }
 
   private:

--- a/vulkaninfo/outputprinter.h
+++ b/vulkaninfo/outputprinter.h
@@ -65,11 +65,17 @@ std::string VkVersionString(VulkanVersion v) {
 
 enum class OutputType { text, html, json, vkconfig_output };
 
+struct PrinterCreateDetails {
+    OutputType output_type = OutputType::text;
+    bool print_to_file = false;
+    std::string file_name = "vulkaninfo.txt";
+    std::string start_string = "";
+};
+
 class Printer {
   public:
-    Printer(OutputType output_type, std::ostream &out, const uint32_t selected_gpu, const VulkanVersion vulkan_version,
-            std::string start_string = "")
-        : output_type(output_type), out(out) {
+    Printer(const PrinterCreateDetails &details, std::ostream &out, const uint32_t selected_gpu, const VulkanVersion vulkan_version)
+        : output_type(details.output_type), out(out) {
         switch (output_type) {
             case (OutputType::text):
                 out << "==========\n";
@@ -174,7 +180,7 @@ class Printer {
             case (OutputType::json):
                 /* fall through */
             case (OutputType::vkconfig_output):
-                out << start_string;
+                out << details.start_string;
                 indents++;
                 is_first_item.push(false);
                 is_array.push(false);

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -191,6 +191,8 @@ bool operator==(AppSurface const &a, AppSurface const &b) {
 
 void DumpPresentableSurfaces(Printer &p, AppInstance &inst, const std::vector<std::unique_ptr<AppGpu>> &gpus,
                              const std::vector<std::unique_ptr<AppSurface>> &surfaces) {
+    // Don't print anything if no surfaces are found
+    if (surfaces.size() == 0) return;
     p.SetHeader();
     ObjectWrapper obj(p, "Presentable Surfaces");
     IndentWrapper indent(p);
@@ -912,9 +914,6 @@ int main(int argc, char **argv) {
         auto phys_devices = instance.FindPhysicalDevices();
 
         std::vector<std::unique_ptr<AppSurface>> surfaces;
-#if defined(VK_USE_PLATFORM_XCB_KHR) || defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_WIN32_KHR) ||      \
-    defined(VK_USE_PLATFORM_MACOS_MVK) || defined(VK_USE_PLATFORM_METAL_EXT) || defined(VK_USE_PLATFORM_WAYLAND_KHR) || \
-    defined(VK_USE_PLATFORM_DIRECTFB_EXT)
         for (auto &surface_extension : instance.surface_extensions) {
             surface_extension.create_window(instance);
             surface_extension.surface = surface_extension.create_surface(instance);
@@ -923,7 +922,6 @@ int main(int argc, char **argv) {
                     new AppSurface(instance, phys_device, surface_extension, pNext_chains.surface_capabilities2)));
             }
         }
-#endif
 
         std::vector<std::unique_ptr<AppGpu>> gpus;
 
@@ -1036,12 +1034,8 @@ int main(int argc, char **argv) {
                 p->AddNewline();
 
                 DumpLayers(*p.get(), instance.global_layers, gpus);
-
-#if defined(VK_USE_PLATFORM_XCB_KHR) || defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_WIN32_KHR) ||      \
-    defined(VK_USE_PLATFORM_MACOS_MVK) || defined(VK_USE_PLATFORM_METAL_EXT) || defined(VK_USE_PLATFORM_WAYLAND_KHR) || \
-    defined(VK_USE_PLATFORM_DIRECTFB_EXT)
+                // Doesn't print anything if no surfaces are available
                 DumpPresentableSurfaces(*p.get(), instance, gpus, surfaces);
-#endif
                 DumpGroups(*p.get(), instance);
 
                 p->SetHeader();
@@ -1054,15 +1048,10 @@ int main(int argc, char **argv) {
             }
         }
 
-#if defined(VK_USE_PLATFORM_XCB_KHR) || defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_WIN32_KHR) ||      \
-    defined(VK_USE_PLATFORM_MACOS_MVK) || defined(VK_USE_PLATFORM_METAL_EXT) || defined(VK_USE_PLATFORM_WAYLAND_KHR) || \
-    defined(VK_USE_PLATFORM_DIRECTFB_EXT)
-
         for (auto &surface_extension : instance.surface_extensions) {
             AppDestroySurface(instance, surface_extension.surface);
             surface_extension.destroy_window(instance);
         }
-#endif
     } catch (std::exception &e) {
         // Print the error to stderr and leave all outputs in a valid state (mainly for json)
         std::cerr << "ERROR at " << e.what() << "\n";

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -838,6 +838,9 @@ void print_usage(const char *argv0) {
     std::cout << "--show-formats      Display the format properties of each physical device.\n";
     std::cout << "                    Note: This option does not affect html or json output;\n";
     std::cout << "                    they will always print format properties.\n\n";
+    std::cout << "-o <filename>, --output<filename>\n";
+    std::cout << "                    Print output to a new file whose name is specified by filename.\n";
+    std::cout << "                    File will be written to the current working directory.\n";
     std::cout << "--summary           Show a summary of the instance and GPU's on a system.\n\n";
 }
 
@@ -847,7 +850,9 @@ struct ParsedResults {
     bool has_selected_gpu;  // differentiate between selecting the 0th gpu and using the default 0th value
     bool show_tool_props;
     bool show_formats;
+    bool use_custom_filename;
     char *output_path;
+    char *custom_filename;
 };
 
 util::trivial_optional<ParsedResults> parse_arguments(int argc, char **argv) {
@@ -878,6 +883,12 @@ util::trivial_optional<ParsedResults> parse_arguments(int argc, char **argv) {
         } else if (strcmp(argv[i], "--show-tool-props") == 0) {
             results.show_tool_props = true;
         } else if (strcmp(argv[i], "--show-formats") == 0) {
+            results.show_formats = true;
+        } else if ((strcmp(argv[i], "--output") == 0 || strcmp(argv[i], "-o") == 0) && argc > (i + 1)) {
+            results.use_custom_filename = true;
+            results.custom_filename = argv[i + 1];
+            ++i;
+        } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
             print_usage(argv[0]);
             return {};
         } else {
@@ -1075,10 +1086,15 @@ int main(int argc, char **argv) {
 #endif
 
         auto printer_data = get_printer_create_details(parse_data, instance, *gpus.at(parse_data.selected_gpu));
-        if (printer_data.use_file_output) {
-            file_out = std::ofstream(printer_data.file_name);
+        if (printer_data.use_file_output || (parse_data.use_custom_filename && parse_data.custom_filename)) {
+            if (parse_data.use_custom_filename) {
+                file_out = std::ofstream(parse_data.custom_filename);
+            } else {
+                file_out = std::ofstream(printer_data.file_name);
+            }
         }
-        printer = std::unique_ptr<Printer>(new Printer(printer_data.output_type, printer_data.use_file_output ? file_out : out,
+        bool use_file_out = parse_data.use_custom_filename || printer_data.use_file_output;
+        printer = std::unique_ptr<Printer>(new Printer(printer_data.output_type, use_file_out ? file_out : out,
                                                        parse_data.selected_gpu, instance.vk_version, printer_data.start_string));
 
         RunPrinter(*(printer.get()), parse_data, instance, gpus, surfaces);
@@ -1098,7 +1114,7 @@ int main(int argc, char **argv) {
     printer.reset(nullptr);
 
 #ifdef _WIN32
-    if (parse_data.output_category == OutputCategory::text) wait_for_console_destroy();
+    if (parse_data.output_category == OutputCategory::text && !parse_data.use_custom_filename) wait_for_console_destroy();
 #endif
 
     return 0;

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -858,7 +858,7 @@ struct ParsedResults {
     std::string default_filename;
 };
 
-util::trivial_optional<ParsedResults> parse_arguments(int argc, char **argv) {
+util::vulkaninfo_optional<ParsedResults> parse_arguments(int argc, char **argv) {
     ParsedResults results{};                         // default it to zero init everything
     results.output_category = OutputCategory::text;  // default output category
     results.default_filename = "vulkaninfo.txt";

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -221,7 +221,7 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DbgCallback(VkDebugReportFlagsEXT msgFlags
 
 // Helper for robustly executing the two-call pattern
 template <typename T, typename F, typename... Ts>
-auto GetVectorInit(const char *func_name, F &&f, T init, Ts &&... ts) -> std::vector<T> {
+auto GetVectorInit(const char *func_name, F &&f, T init, Ts &&...ts) -> std::vector<T> {
     uint32_t count = 0;
     std::vector<T> results;
     VkResult err;
@@ -237,7 +237,7 @@ auto GetVectorInit(const char *func_name, F &&f, T init, Ts &&... ts) -> std::ve
 }
 
 template <typename T, typename F, typename... Ts>
-auto GetVector(const char *func_name, F &&f, Ts &&... ts) -> std::vector<T> {
+auto GetVector(const char *func_name, F &&f, Ts &&...ts) -> std::vector<T> {
     return GetVectorInit(func_name, f, T(), ts...);
 }
 

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -800,17 +800,13 @@ static VkSurfaceKHR AppCreateWin32Surface(AppInstance &inst) {
     return surface;
 }
 
-static void AppDestroyWin32Window(AppInstance &inst) { CALL_PFN(DestroyWindow)(inst.h_wnd); }
+static void AppDestroyWin32Window(AppInstance &inst) { user32_handles->pfnDestroyWindow(inst.h_wnd); }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 //-----------------------------------------------------------
 
-#if defined(VK_USE_PLATFORM_XCB_KHR) || defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_WIN32_KHR) ||      \
-    defined(VK_USE_PLATFORM_MACOS_MVK) || defined(VK_USE_PLATFORM_METAL_EXT) || defined(VK_USE_PLATFORM_WAYLAND_KHR) || \
-    defined(VK_USE_PLATFORM_DIRECTFB_EXT) || defined(VK_USE_PLATFORM_ANDROID_KHR)
 static void AppDestroySurface(AppInstance &inst, VkSurfaceKHR surface) {  // same for all platforms
     inst.dll.fp_vkDestroySurfaceKHR(inst.instance, surface, nullptr);
 }
-#endif
 
 //----------------------------XCB----------------------------
 

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -511,40 +511,35 @@ void freepNextChain(VkStructureHeader *first) {
     }
 }
 
-/* An ptional contains either a value or nothing. The trivial_optional asserts if a value is trying to be gotten but none exist.
+/* An ptional contains either a value or nothing. The optional asserts if a value is trying to be gotten but none exist.
  * The interface is taken from C++17's <optional> with many aspects removed.
  * This class assumes the template type is 'trivial'
  */
 namespace util {
 template <typename T>
-struct trivial_optional {
+struct vulkaninfo_optional {
     using value_type = T;
 
     bool _contains_value = false;
-    T _value;
+    value_type _value;
 
-    void check_type_properties() {
-        static_assert(std::is_trivially_constructible<T>::value, "Type must be trivially constructable");
-        static_assert(std::is_trivially_copyable<T>::value, "Type must be trivially copyable");
-    }
-
-    trivial_optional() noexcept : _contains_value(false), _value({}) { check_type_properties(); }
-    trivial_optional(T value) noexcept : _contains_value(true), _value(value) { check_type_properties(); }
+    vulkaninfo_optional() noexcept : _contains_value(false), _value({}) {}
+    vulkaninfo_optional(T value) noexcept : _contains_value(true), _value(value) {}
 
     explicit operator bool() const noexcept { return _contains_value; }
     bool has_value() const noexcept { return _contains_value; }
 
-    T value() const noexcept {
+    value_type value() const noexcept {
         assert(_contains_value);
         return _value;
     }
     // clang-format off
-    const T* operator->() const { assert(_contains_value); return _value;}
-    T* operator->() { assert(_contains_value); return &_value;}
-    const T& operator*() const& { assert(_contains_value); return _value;}
-    T& operator*() & { assert(_contains_value); return _value;}
-    const T&& operator*() const&& { assert(_contains_value); return _value;}
-    T&& operator*() && { assert(_contains_value); return _value;}
+    const value_type* operator->() const { assert(_contains_value); return _value;}
+    value_type* operator->() { assert(_contains_value); return &_value;}
+    const value_type& operator*() const& { assert(_contains_value); return _value;}
+    value_type& operator*() & { assert(_contains_value); return _value;}
+    const value_type&& operator*() const&& { assert(_contains_value); return _value;}
+    value_type&& operator*() && { assert(_contains_value); return _value;}
     // clang-format on
 };  // namespace util
 }  // namespace util
@@ -1298,8 +1293,8 @@ std::vector<VkPhysicalDeviceProperties> GetGroupProps(AppInstance &inst, VkPhysi
     return props;
 }
 
-util::trivial_optional<VkDeviceGroupPresentCapabilitiesKHR> GetGroupCapabilities(AppInstance &inst,
-                                                                                 VkPhysicalDeviceGroupProperties group) {
+util::vulkaninfo_optional<VkDeviceGroupPresentCapabilitiesKHR> GetGroupCapabilities(AppInstance &inst,
+                                                                                    VkPhysicalDeviceGroupProperties group) {
     // Build create info for logical device made from all physical devices in this group.
     std::vector<std::string> extensions_list = {VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_DEVICE_GROUP_EXTENSION_NAME};
     VkDeviceGroupDeviceCreateInfoKHR dg_ci = {VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO_KHR, nullptr,
@@ -1374,8 +1369,8 @@ VkImageCreateInfo GetImageCreateInfo(VkImageCreateFlags flags, VkFormat format, 
             VK_IMAGE_LAYOUT_UNDEFINED};
 }
 
-util::trivial_optional<ImageTypeSupport> FillImageTypeSupport(AppInstance &inst, VkPhysicalDevice phys_device, VkDevice device,
-                                                              ImageTypeSupport::Type img_type, VkImageCreateInfo image_ci) {
+util::vulkaninfo_optional<ImageTypeSupport> FillImageTypeSupport(AppInstance &inst, VkPhysicalDevice phys_device, VkDevice device,
+                                                                 ImageTypeSupport::Type img_type, VkImageCreateInfo image_ci) {
     VkImageFormatProperties img_props;
     VkResult res = inst.dll.fp_vkGetPhysicalDeviceImageFormatProperties(
         phys_device, image_ci.format, image_ci.imageType, image_ci.tiling, image_ci.usage, image_ci.flags, &img_props);
@@ -1395,7 +1390,7 @@ util::trivial_optional<ImageTypeSupport> FillImageTypeSupport(AppInstance &inst,
         inst.dll.fp_vkDestroyImage(device, dummy_img, nullptr);
         return img_type_support;
     } else if (res == VK_ERROR_FORMAT_NOT_SUPPORTED) {
-        return {};  // return empty optional
+        return {};  // return empty util::vulkaninfo_optional
     }
     THROW_VK_ERR("vkGetPhysicalDeviceImageFormatProperties", res);
     return {};

--- a/vulkaninfo/vulkaninfo.md
+++ b/vulkaninfo/vulkaninfo.md
@@ -71,6 +71,9 @@ OPTIONS:
 --show-formats      Display the format properties of each physical device.
                     Note: This option does not affect html or json output;
                     they will always print format properties.
+-o <filename>, --output<filename>
+                    Print output to a new file whose name is specified by filename.
+                    File will be written to the current working directory.
 --summary           Show a summary of the instance and GPU's on a system.
 ```
 


### PR DESCRIPTION
This PR fixes up the code base so that adding the ability to specify a file to print to is simple. To do this requires:
* Creating a `OutputCategory` enum to hold which type of output `vulkaninfo` should print.
* Refactoring the `user32.dll` code so that it doesn't use any macros and globals are limited to a single pointer to a `User32DllHandle` class (for use in a Win32 callback)
* Creating three functions, `parse_arguments`, `get_printer_create_details`, and `RunPrinter`, that reduce the size of `main()` to a manageable level
* Clean up the logic to decide the destination of the output (stdout or file) and the start string into a very tidy switch statement.