### PR TITLE
windows: updated runtime copyrights to 2017, 2021

### DIFF
--- a/windows-runtime-installer/VulkanRT-License.txt
+++ b/windows-runtime-installer/VulkanRT-License.txt
@@ -1,8 +1,8 @@
-Copyright (c) 2015-2020 The Khronos Group Inc.
-Copyright (c) 2015-2020 LunarG, Inc.
-Copyright (c) 2015-2020 Valve Corporation
+Copyright (c) 2015-2021 The Khronos Group Inc.
+Copyright (c) 2015-2021 LunarG, Inc.
+Copyright (c) 2015-2021 Valve Corporation
 
-The Vulkan Runtime is comprised of 100% open source components (MIT, and
+The Vulkan Runtime is comprised of 100% open-source components (MIT, and
 Apache 2.0). The text of such licenses is included below along with the
 copyrights.
 
@@ -30,9 +30,9 @@ under the License.
 ============================MIT============================
 
 Copyright (c) 2009 Dave Gamble
-Copyright (c) 2015-2016 The Khronos Group Inc.
-Copyright (c) 2015-2016 Valve Corporation
-Copyright (c) 2015-2016 LunarG, Inc.
+Copyright (c) 2015-2017 The Khronos Group Inc.
+Copyright (c) 2015-2017 Valve Corporation
+Copyright (c) 2015-2017 LunarG, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -55,9 +55,9 @@ THE SOFTWARE.
 ============================MIT============================
 
 Copyright (c) 2014 joseph werle <joseph.werle@gmail.com>
-Copyright (c) 2015-2016 The Khronos Group Inc.
-Copyright (c) 2015-2016 Valve Corporation
-Copyright (c) 2015-2016 LunarG, Inc.
+Copyright (c) 2015-2017 The Khronos Group Inc.
+Copyright (c) 2015-2017 Valve Corporation
+Copyright (c) 2015-2017 LunarG, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and/or associated documentation files (the "Materials"), to


### PR DESCRIPTION
This is needed to upright the copyright notice for the Vulkan SDK Runtime Installer, as per:

https://gitlab.khronos.org/vulkan/Vulkan-SDK-Packaging/-/issues/760

I'm not sure whether all the copyrights should be updated,
or just the ones at the top (as the others haven't been modified
since 2016, apparently).  Hopefully reviewers will tell me
whether this is correct.

I also corrected the spelling of "open-source".