### PR TITLE
vkcube: Reorder setting of pipeline stage flags

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -1063,8 +1063,8 @@ static void demo_draw(struct demo *demo) {
     VkSubmitInfo submit_info;
     submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     submit_info.pNext = NULL;
-    submit_info.pWaitDstStageMask = &pipe_stage_flags;
     pipe_stage_flags = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    submit_info.pWaitDstStageMask = &pipe_stage_flags;
     submit_info.waitSemaphoreCount = 1;
     submit_info.pWaitSemaphores = &demo->image_acquired_semaphores[demo->frame_index];
     submit_info.commandBufferCount = 1;


### PR DESCRIPTION
Pipeline stage flags should be set before assigned to pWaitDstStageMask
in VkSubmitInfo, otherwise the assigned pointer is invalid.