### PR TITLE
vulkaninfo: Prevent drivers writing out of bounds

### DIFF
--- a/scripts/vulkaninfo_generator.py
+++ b/scripts/vulkaninfo_generator.py
@@ -605,7 +605,14 @@ def PrintChainBuilders(listName, structures, all_structures):
         if s.name in structures:
             out += AddGuardHeader(s)
             if s.sTypeName is not None:
-                out += f"        {{{s.sTypeName}, sizeof({s.name})}},\n"
+                out += f"        {{{s.sTypeName}, sizeof({s.name})"
+                # Specific versions of drivers have an incorrect definition of the size of this struct.
+                # We need to artificially increase it just so the driver doesn't write 'out of bounds' and cause
+                # difficult to debug crashes. This bug comes from the in-development version of the extension having
+                # a larger size than the final version, so older drivers try to writ to members which don't exist.
+                if s.sTypeName == "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES_KHR":
+                    out += " + 256" # Really make sure a driver wont write out of bounds
+                out += f"}},\n"
             out += AddGuardFooter(s)
     out += f"    }};\n"
     return out

--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -2361,7 +2361,7 @@ pNextChainInfos get_chain_infos() {
         {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES, sizeof(VkPhysicalDeviceShaderDrawParametersFeatures)},
         {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES, sizeof(VkPhysicalDeviceShaderFloat16Int8Features)},
         {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT, sizeof(VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT)},
-        {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES_KHR, sizeof(VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR)},
+        {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES_KHR, sizeof(VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR) + 256},
         {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES, sizeof(VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures)},
         {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR, sizeof(VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR)},
         {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES_KHR, sizeof(VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR)},


### PR DESCRIPTION
The structure VkPhysicalDeviceShaderIntegerDotProdcutFeaturesKHR contains only a single
feature boolean flag. However, before the final version was published to the public, it
had many boolean flag values. Pre-release drivers often contain support for unpublished
extensions, such as VK_KHR_shader_integer_dot_product. Because the final version was
much smaller than the pre-release version, several drivers try to write to members that
do not exist in the final version, which cause out of bounds writes to the features struct
that vulkaninfo passes into the driver.

By increasing the size of the features struct allocation manually, we can prevent potential
crashes from OOBs writes from drivers.

Fixes #580 

Only discussion item I have is how much documentation of which driver versions caused the crashes should be in the code itself.