### PR TITLE
[cube] cmake/FindWaylandProtocols: fix wayland protocol path 

### DIFF
--- a/cmake/FindWaylandProtocols.cmake
+++ b/cmake/FindWaylandProtocols.cmake
@@ -6,8 +6,9 @@
 
 if(NOT WIN32)
     find_package(PkgConfig)
-    pkg_check_modules(PKG_WAYLAND_PROTOCOLS QUIET wayland-protocols)
-    set(WAYLAND_PROTOCOLS_PATH ${PKG_WAYLAND_PROTOCOLS_PREFIX}/share/wayland-protocols)
+    pkg_check_modules(WAYLAND_PROTOCOLS_PATH REQUIRED wayland-protocols)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir wayland-protocols
+       OUTPUT_VARIABLE WAYLAND_PROTOCOLS_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
     find_package_handle_standard_args(WAYLAND DEFAULT_MSG WAYLAND_PROTOCOLS_PATH)
     mark_as_advanced(WAYLAND_PROTOCOLS_PATH)
 endif()


### PR DESCRIPTION
- if you cross compile `${PKG_WAYLAND_PROTOCOLS_PREFIX}/share/wayland-protocols` would generate a fixed path pointing to e.g. `/usr/share/wayland-protocols` instead of `path_to_toolchain/usr/share/wayland-protocols` and you'll end up with a missing pkg.