### PR TITLE
scripts: initialize properties for VK_EXT_fragment_density_map2 for mock ICD

### DIFF
--- a/icd/generated/mock_icd.cpp
+++ b/icd/generated/mock_icd.cpp
@@ -2690,6 +2690,15 @@ static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2KHR(
         write_props->supportedDepthResolveModes = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR;
         write_props->supportedStencilResolveModes = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR;
     }
+
+    const auto *fragment_density_map2_props = lvl_find_in_chain<VkPhysicalDeviceFragmentDensityMap2PropertiesEXT>(pProperties->pNext);
+    if (fragment_density_map2_props) {
+        VkPhysicalDeviceFragmentDensityMap2PropertiesEXT* write_props = (VkPhysicalDeviceFragmentDensityMap2PropertiesEXT*)fragment_density_map2_props;
+        write_props->subsampledLoads = VK_FALSE;
+        write_props->subsampledCoarseReconstructionEarlyAccess = VK_FALSE;
+        write_props->maxSubsampledArrayLayers = 2;
+        write_props->maxDescriptorSetSubsampledSamplers = 1;
+    }
 }
 
 static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2KHR(

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -837,6 +837,15 @@ CUSTOM_C_INTERCEPTS = {
         write_props->supportedDepthResolveModes = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR;
         write_props->supportedStencilResolveModes = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR;
     }
+
+    const auto *fragment_density_map2_props = lvl_find_in_chain<VkPhysicalDeviceFragmentDensityMap2PropertiesEXT>(pProperties->pNext);
+    if (fragment_density_map2_props) {
+        VkPhysicalDeviceFragmentDensityMap2PropertiesEXT* write_props = (VkPhysicalDeviceFragmentDensityMap2PropertiesEXT*)fragment_density_map2_props;
+        write_props->subsampledLoads = VK_FALSE;
+        write_props->subsampledCoarseReconstructionEarlyAccess = VK_FALSE;
+        write_props->maxSubsampledArrayLayers = 2;
+        write_props->maxDescriptorSetSubsampledSamplers = 1;
+    }
 ''',
 'vkGetPhysicalDeviceExternalSemaphoreProperties':'''
     // Hard code support for all handle types and features


### PR DESCRIPTION

Updated version of https://github.com/KhronosGroup/Vulkan-Tools/pull/425