### PR TITLE
Add dependency on wayland-protocols for cube

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
                 python-version: '3.7'
             - run: |
                 sudo apt-get -qq update
-                sudo apt install libxkbcommon-dev libwayland-dev libmirclient-dev libxrandr-dev libx11-xcb-dev
+                sudo apt install libxkbcommon-dev libwayland-dev libmirclient-dev libxrandr-dev libx11-xcb-dev wayland-protocols
 
             - name: Fetch and install headers
               run: python scripts/update_deps.py --dir external

--- a/BUILD.md
+++ b/BUILD.md
@@ -383,7 +383,7 @@ repository to other Linux distributions.
 #### Required Package List
 
     sudo apt-get install git cmake build-essential libx11-xcb-dev \
-        libxkbcommon-dev libwayland-dev libxrandr-dev
+        libxkbcommon-dev libwayland-dev libxrandr-dev wayland-protocols
 
 ### Linux Build
 


### PR DESCRIPTION
Prerequisite for #591 and adding a Wayland build target to cube.