### PR TITLE
mockicd: Fix FreeCommandBuffers leak

### DIFF
--- a/icd/generated/mock_icd.cpp
+++ b/icd/generated/mock_icd.cpp
@@ -1251,7 +1251,10 @@ static VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(
     uint32_t                                    commandBufferCount,
     const VkCommandBuffer*                      pCommandBuffers)
 {
-//Destroy object
+
+    for (auto i = 0u; i < commandBufferCount; ++i)
+        if (pCommandBuffers[i])
+            DestroyDispObjHandle((void*) pCommandBuffers[i]);
 }
 
 static VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -444,6 +444,11 @@ CUSTOM_C_INTERCEPTS = {
         DestroyDispObjHandle((void*)instance);
     }
 ''',
+'vkFreeCommandBuffers': '''
+    for (auto i = 0u; i < commandBufferCount; ++i)
+        if (pCommandBuffers[i])
+            DestroyDispObjHandle((void*) pCommandBuffers[i]);
+''',
 'vkEnumeratePhysicalDevices': '''
     VkResult result_code = VK_SUCCESS;
     if (pPhysicalDevices) {
@@ -1360,6 +1365,7 @@ class MockICDOutputGenerator(OutputGenerator):
             'vkDestroyDevice',
             'vkCreateInstance',
             'vkDestroyInstance',
+            'vkFreeCommandBuffers',
             #'vkCreateDebugReportCallbackEXT',
             #'vkDestroyDebugReportCallbackEXT',
             'vkEnumerateInstanceLayerProperties',


### PR DESCRIPTION
The handles allocated for command buffers were not ever freed.