### PR TITLE
mockicd: Fix queue destruction for multiple devices

### DIFF
--- a/icd/generated/mock_icd.cpp
+++ b/icd/generated/mock_icd.cpp
@@ -380,14 +380,13 @@ static VKAPI_ATTR void VKAPI_CALL DestroyDevice(
     unique_lock_t lock(global_lock);
     // First destroy sub-device objects
     // Destroy Queues
-    for (auto dev_queue_map_pair : queue_map) {
-        for (auto queue_family_map_pair : queue_map[dev_queue_map_pair.first]) {
-            for (auto index_queue_pair : queue_map[dev_queue_map_pair.first][queue_family_map_pair.first]) {
-                DestroyDispObjHandle((void*)index_queue_pair.second);
-            }
+    for (auto queue_family_map_pair : queue_map[device]) {
+        for (auto index_queue_pair : queue_map[device][queue_family_map_pair.first]) {
+            DestroyDispObjHandle((void*)index_queue_pair.second);
         }
     }
-    queue_map.clear();
+
+    queue_map.erase(device);
     buffer_map.erase(device);
     image_memory_size_map.erase(device);
     // Now destroy device

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -465,14 +465,13 @@ CUSTOM_C_INTERCEPTS = {
     unique_lock_t lock(global_lock);
     // First destroy sub-device objects
     // Destroy Queues
-    for (auto dev_queue_map_pair : queue_map) {
-        for (auto queue_family_map_pair : queue_map[dev_queue_map_pair.first]) {
-            for (auto index_queue_pair : queue_map[dev_queue_map_pair.first][queue_family_map_pair.first]) {
-                DestroyDispObjHandle((void*)index_queue_pair.second);
-            }
+    for (auto queue_family_map_pair : queue_map[device]) {
+        for (auto index_queue_pair : queue_map[device][queue_family_map_pair.first]) {
+            DestroyDispObjHandle((void*)index_queue_pair.second);
         }
     }
-    queue_map.clear();
+
+    queue_map.erase(device);
     buffer_map.erase(device);
     image_memory_size_map.erase(device);
     // Now destroy device


### PR DESCRIPTION
vkDestroyDevice would previously clear the queue map which is not correct when there are multiple devices alive.