### PR TITLE
vulkan tools: Fix image usage error reported by validation layers

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -1533,7 +1533,6 @@ struct AppGpu {
                 if (tiling == VK_IMAGE_TILING_LINEAR) {
                     if (format == color_format) {
                         image_ci_regular.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-                        image_ci_transient.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
                     } else {
                         // linear tiling is only applicable to color image types
                         continue;


### PR DESCRIPTION
`VUID-VkImageCreateInfo-usage-00963` says it's invalid to use `VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT` with `VK_IMAGE_USAGE_TRANSFER_SRC_BIT`.

Ran into this on linux. 