### PR TITLE
build: Factor out typemap_helper header in rules

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -46,17 +46,25 @@ config("vulkan_internal_config") {
   }
 }
 
+# Vulkan tool generated utility headers
+source_set("vulkan_tools_headers") {
+  public_deps = [ "$vulkan_headers_dir:vulkan_headers" ]
+  sources = [
+      "icd/generated/vk_typemap_helper.h",
+  ]
+}
+
 if (!is_android) {
   # Vulkan Mock ICD
   # ---------------
   shared_library("VkICD_mock_icd") {
     configs -= vulkan_undefine_configs
+    deps = [ ":vulkan_tools_headers" ]
     public_deps = [ "$vulkan_headers_dir:vulkan_headers" ]
     data_deps = [ ":vulkan_gen_icd_json_file" ]
     sources = [
       "icd/generated/mock_icd.cpp",
       "icd/generated/mock_icd.h",
-      "icd/generated/vk_typemap_helper.h",
     ]
     if (is_win) {
       sources += [ "icd/VkICD_mock_icd.def" ]


### PR DESCRIPTION
For reusability in Dawn without depending on entire icd lib, it is helpful to factor out the header into a separate source set so that we don't need to depend on the shared library.