### PR TITLE
Fix cubepp implicit cast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,14 @@ jobs:
                 cxx: [ g++, clang++ ]
                 config: [ Debug, Release ]
                 os: [ ubuntu-18.04, ubuntu-20.04 ]
+                cube_wsi: [ XCB, XLIB, WAYLAND, DISPLAY ]
                 exclude:
                     - cc: gcc
                       cxx: clang++
                     - cc: clang
                       cxx: g++
+                    - os: ubuntu-18.04
+                      cube_wsi: WAYLAND
 
         steps:
             - uses: actions/checkout@v2
@@ -52,7 +55,7 @@ jobs:
               run: python scripts/update_deps.py --dir external
 
             - name: Generate build files
-              run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -Cexternal/helper.cmake
+              run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -DCUBE_WSI_SELECTION=${{matrix.cube_wsi}} -Cexternal/helper.cmake
               env:
                 CC: ${{matrix.cc}}
                 CXX: ${{matrix.cxx}}

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -2962,7 +2962,7 @@ vk::Result Demo::create_display_surface() {
         exit(1);
     }
 
-    vk::DisplayPlaneCapabilitiesKHR planeCaps = gpu.getDisplayPlaneCapabilitiesKHR(display_mode_prop.displayMode, plane_found);
+    vk::DisplayPlaneCapabilitiesKHR planeCaps = gpu.getDisplayPlaneCapabilitiesKHR(display_mode_prop.displayMode, plane_found).value;
     // Find a supported alpha mode
     vk::DisplayPlaneAlphaFlagBitsKHR alphaMode = vk::DisplayPlaneAlphaFlagBitsKHR::eOpaque;
     std::array<vk::DisplayPlaneAlphaFlagBitsKHR, 4> alphaModes = {


### PR DESCRIPTION
Fix a compiler error with `-DCUBE_WSI_SELECTION=DISPLAY` and Vulkan-Headers v1.3.213

Add more WSI options in addition to the default XCB to the GitHub Actions linux job to catch these types of failures in the future.

Fixes #649