### PR TITLE
Log Surface Extension Error, But Don't Fail On It

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -1102,7 +1102,12 @@ int main(int argc, char **argv) {
             surface_extension.create_window(instance);
             surface_extension.surface = surface_extension.create_surface(instance);
             for (auto &phys_device : phys_devices) {
-                surfaces.push_back(std::unique_ptr<AppSurface>(new AppSurface(instance, phys_device, surface_extension)));
+                try {
+                    surfaces.push_back(std::unique_ptr<AppSurface>(new AppSurface(instance, phys_device, surface_extension)));
+                } catch (std::exception &e) {
+                    std::cerr << "ERROR while creating surface for extension " << surface_extension.name << " : " << e.what()
+                              << "\n";
+                }
             }
         }
 #endif  // defined(VULKANINFO_WSI_ENABLED)


### PR DESCRIPTION
When one surface extension fails, today, the whole `vulkaninfo` command fails without providing any information except for the error code. But `vulkaninfo` has still gathered plenty of information to display about other information related to GPU and a great deal of other details.

`vulkaninfo` should ignore failures on an extension, simply display the error, but continue to gather the rest of the info and show it to the user.

Fixes #659 