### PR TITLE
cmake: Use VULKAN_SDK paths prior to the system paths

### DIFF
--- a/cmake/FindVulkan.cmake
+++ b/cmake/FindVulkan.cmake
@@ -31,21 +31,21 @@
 if(WIN32)
   find_path(Vulkan_INCLUDE_DIR
     NAMES vulkan/vulkan.h
-    PATHS
+    HINTS
       "$ENV{VULKAN_SDK}/Include"
     )
 
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     find_library(Vulkan_LIBRARY
       NAMES vulkan-1
-      PATHS
+      HINTS
         "$ENV{VULKAN_SDK}/Lib"
         "$ENV{VULKAN_SDK}/Bin"
         )
   elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
     find_library(Vulkan_LIBRARY
       NAMES vulkan-1
-      PATHS
+      HINTS
         "$ENV{VULKAN_SDK}/Lib32"
         "$ENV{VULKAN_SDK}/Bin32"
         NO_SYSTEM_ENVIRONMENT_PATH
@@ -54,11 +54,11 @@ if(WIN32)
 else()
     find_path(Vulkan_INCLUDE_DIR
       NAMES vulkan/vulkan.h
-      PATHS
+      HINTS
         "$ENV{VULKAN_SDK}/include")
     find_library(Vulkan_LIBRARY
       NAMES vulkan
-      PATHS
+      HINTS
         "$ENV{VULKAN_SDK}/lib")
 endif()
 


### PR DESCRIPTION
### Wrong behavior

I installed a new version of Vulkan SDK and specified the VULKAN_SDK environment variable to the new version and hope the project to use the new version. However, the project always uses the old version of Vulkan SDK in the system default location and ignores the new version that is specified by the VULKAN_SDK environment variable.

### Root cause

The cmake `find_path` and `find_library` commands  search the paths in the following order:

1.  ... ...
2.  ... ...
3. Search the paths specified by the `HINTS` option.
4. ... ...
5. Search cmake variables defined in the Platform files for the current system.
6. Search the paths specified by the `PATHS` option or in the short-hand version of the command

The current code uses `PATHS` to set the search paths of Vulkan SDK by VULKAN_SDK environment variable which is after the system default location in the path search order. So the project will use the system default location and ignore the VULKAN_SDK environment variable.

CMake reference documentation:

* [find_path](https://cmake.org/cmake/help/v3.4/command/find_path.html)
* [find_library](https://cmake.org/cmake/help/v3.4/command/find_library.html)

### Fix solution

Change the `PATHS` key word to `HINTS` key word to set the VULKAN_SDK environment variable paths before the system default location paths in the path search order.
