### PR TITLE
vulkaninfo: include wayland-client because its functions are used

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -79,6 +79,10 @@
 #include "metal_view.h"
 #endif
 
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+#include <wayland-client.h>
+#endif
+
 #include <vulkan/vulkan.h>
 
 static std::string VkResultString(VkResult err);


### PR DESCRIPTION
"Include what you use": `vulkaninfo.h` calls `wl_registry_bind`, thus
ought to include `wayland-client.h`.