### PR TITLE
Move BUILD.gn values into the scope that uses them

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -20,19 +20,6 @@ import("//build_overrides/vulkan_tools.gni")
 # TODO(spang): Port mock ICD to Fuchsia.
 assert(!is_fuchsia)
 
-vulkan_undefine_configs = []
-if (is_win && build_with_chromium) {
-  vulkan_undefine_configs += [
-    "//build/config/win:nominmax",
-    "//build/config/win:unicode",
-  ]
-}
-
-raw_vulkan_icd_dir = rebase_path("icd", root_build_dir)
-
-vulkan_data_dir = "$root_out_dir/$vulkan_data_subdir"
-raw_vulkan_data_dir = rebase_path(vulkan_data_dir, root_build_dir)
-
 config("vulkan_internal_config") {
   defines = [ "VULKAN_NON_CMAKE_BUILD" ]
   if (is_clang || !is_win) {
@@ -56,6 +43,19 @@ source_set("vulkan_tools_headers") {
 }
 
 if (!is_android) {
+  vulkan_undefine_configs = []
+  if (is_win && build_with_chromium) {
+    vulkan_undefine_configs += [
+      "//build/config/win:nominmax",
+      "//build/config/win:unicode",
+    ]
+  }
+
+  raw_vulkan_icd_dir = rebase_path("icd", root_build_dir)
+
+  vulkan_data_dir = "$root_out_dir/$vulkan_data_subdir"
+  raw_vulkan_data_dir = rebase_path(vulkan_data_dir, root_build_dir)
+
   # Vulkan Mock ICD
   # ---------------
   shared_library("VkICD_mock_icd") {


### PR DESCRIPTION
There are several values that in the build file that are only used when
the platform is not Android, but which are declared outside the
`if(!is_android)` block. This causes unused variable errors when
attempting to build chromium on Android with a dependency on this repo.

By moving the definitions into the conditional block the error is
resolved.