### PR TITLE
build: Also include XCB header path

### DIFF
--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -23,6 +23,8 @@ elseif(APPLE)
     add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
 elseif(UNIX AND NOT APPLE) # i.e. Linux
     if(BUILD_WSI_XCB_SUPPORT)
+        find_package(XCB REQUIRED)
+        include_directories(${XCB_INCLUDE_DIR})
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR -DVK_USE_PLATFORM_XCB_KHX)
     endif()
 


### PR DESCRIPTION
```
[ 91%] Building CXX object icd/CMakeFiles/VkICD_mock_icd.dir/generated/mock_icd.cpp.o
In file included from /home/brad/tmp/Vulkan-Tools/icd/generated/mock_icd.cpp:22:
In file included from /home/brad/tmp/Vulkan-Tools/icd/generated/mock_icd.h:29:
In file included from /usr/local/include/vulkan/vk_icd.h:26:
/usr/local/include/vulkan/vulkan.h:53:10: fatal error: 'xcb/xcb.h' file not found
#include <xcb/xcb.h>
         ^~~~~~~~~~~
1 error generated.
```