### PR TITLE
cmake: Sync FindVulkanHeaders.cmake with VVL

### DIFF
--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -38,21 +38,40 @@
 #   VulkanRegistry_DIR           - the VulkanRegistry directory
 #
 
-# Use HINTS instead of PATH to search these locations before
-# searching system environment variables like $PATH that may
-# contain SDK directories.
-find_path(VulkanHeaders_INCLUDE_DIR
-    NAMES vulkan/vulkan.h
-    HINTS
-        ${VULKAN_HEADERS_INSTALL_DIR}/include
-        "$ENV{VULKAN_HEADERS_INSTALL_DIR}/include"
-        "$ENV{VULKAN_SDK}/include")
+# Probe command-line arguments and the environment to see if they specify the
+# Vulkan headers installation path.
+if(NOT DEFINED VULKAN_HEADERS_INSTALL_DIR)
+  if (DEFINED ENV{VULKAN_HEADERS_INSTALL_DIR})
+    set(VULKAN_HEADERS_INSTALL_DIR "$ENV{VULKAN_HEADERS_INSTALL_DIR}")
+  elseif(DEFINED ENV{VULKAN_SDK})
+    set(VULKAN_HEADERS_INSTALL_DIR "$ENV{VULKAN_SDK}")
+  endif()
+endif()
 
-if(VulkanHeaders_INCLUDE_DIR)
-   get_filename_component(VULKAN_REGISTRY_PATH_HINT ${VulkanHeaders_INCLUDE_DIR} DIRECTORY)
-   find_path(VulkanRegistry_DIR
-       NAMES vk.xml
-       HINTS "${VULKAN_REGISTRY_PATH_HINT}/share/vulkan/registry")
+if(DEFINED VULKAN_HEADERS_INSTALL_DIR)
+  # When CMAKE_FIND_ROOT_PATH_INCLUDE is set to ONLY, the HINTS in find_path()
+  # are re-rooted, which prevents VULKAN_HEADERS_INSTALL_DIR to work as
+  # expected. So use NO_CMAKE_FIND_ROOT_PATH to avoid it.
+
+  # Use HINTS instead of PATH to search these locations before
+  # searching system environment variables like $PATH that may
+  # contain SDK directories.
+  find_path(VulkanHeaders_INCLUDE_DIR
+      NAMES vulkan/vulkan.h
+      HINTS ${VULKAN_HEADERS_INSTALL_DIR}/include
+      NO_CMAKE_FIND_ROOT_PATH
+      NO_DEFAULT_PATH)
+  find_path(VulkanRegistry_DIR
+      NAMES vk.xml
+      HINTS ${VULKAN_HEADERS_INSTALL_DIR}/share/vulkan/registry
+      NO_CMAKE_FIND_ROOT_PATH
+      NO_DEFAULT_PATH)
+else()
+  # If VULKAN_HEADERS_INSTALL_DIR, or one of its variants was not specified,
+  # do a normal search without hints.
+  find_path(VulkanHeaders_INCLUDE_DIR NAMES vulkan/vulkan.h)
+  get_filename_component(VULKAN_REGISTRY_PATH_HINT ${VulkanHeaders_INCLUDE_DIR} DIRECTORY)
+  find_path(VulkanRegistry_DIR NAMES vk.xml HINTS ${VULKAN_REGISTRY_PATH_HINT})
 endif()
 
 set(VulkanHeaders_INCLUDE_DIRS ${VulkanHeaders_INCLUDE_DIR})


### PR DESCRIPTION
This picks up a few fixes, notably https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/1393 which helps with cross-compiling.