### PR TITLE
Vulkaninfo: Escape json strings

### DIFF
--- a/scripts/vulkaninfo_generator.py
+++ b/scripts/vulkaninfo_generator.py
@@ -545,11 +545,7 @@ def PrintStructure(struct, types_to_gen, structure_names, aliases):
             elif v.typeID == "uint8_t" and (v.arrayLength == '8' or v.arrayLength == '16'):  # VK_UUID_SIZE
                 if v.arrayLength == '8':
                     out += '    if (obj.deviceLUIDValid) { // special case\n'
-                out += f'''    if (p.Type() == OutputType::json) {{
-        ArrayWrapper arr(p, "{v.name}");
-        for (uint32_t i = 0; i < {v.arrayLength}; i++) p.PrintElement(static_cast<uint32_t>(obj.{v.name}[i]));
-    }} else
-        p.PrintKeyString("{v.name}", to_string_{v.arrayLength}(obj.{v.name}));\n'''
+                out += f'    p.PrintKeyValue("{v.name}", obj.{v.name});\n'
                 if v.arrayLength == '8':
                     out += '    }\n'
             elif struct.name == "VkQueueFamilyGlobalPriorityPropertiesKHR" and v.name == "priorities":
@@ -561,9 +557,8 @@ def PrintStructure(struct, types_to_gen, structure_names, aliases):
                 out += f'           p.PrintString(VkQueueGlobalPriorityKHRString(obj.priorities[i]));\n'
                 out += f"    }}\n"
             elif v.arrayLength.isdigit():
-                out += f'    {{   ArrayWrapper arr(p,"{v.name}", ' + v.arrayLength + ');\n'
-                for i in range(0, int(v.arrayLength)):
-                    out += f"        p.PrintElement(obj.{v.name}[{str(i)}]);\n"
+                out += f'    {{\n        ArrayWrapper arr(p,"{v.name}", ' + v.arrayLength + ');\n'
+                out += f'        for (uint32_t i = 0; i < {v.arrayLength}; i++) {{ p.PrintElement(obj.{v.name}[i]); }}\n'
                 out += f"    }}\n"
             else:  # dynamic array length based on other member
                 out += f'    ArrayWrapper arr(p,"{v.name}", obj.' + v.arrayLength + ');\n'

--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -1703,22 +1703,10 @@ void DumpVkPhysicalDeviceHostQueryResetFeatures(Printer &p, std::string name, co
 void DumpVkPhysicalDeviceIDProperties(Printer &p, std::string name, const VkPhysicalDeviceIDProperties &obj) {
     ObjectWrapper object{p, name};
     p.SetMinKeyWidth(15);
-    if (p.Type() == OutputType::json) {
-        ArrayWrapper arr(p, "deviceUUID");
-        for (uint32_t i = 0; i < 16; i++) p.PrintElement(static_cast<uint32_t>(obj.deviceUUID[i]));
-    } else
-        p.PrintKeyString("deviceUUID", to_string_16(obj.deviceUUID));
-    if (p.Type() == OutputType::json) {
-        ArrayWrapper arr(p, "driverUUID");
-        for (uint32_t i = 0; i < 16; i++) p.PrintElement(static_cast<uint32_t>(obj.driverUUID[i]));
-    } else
-        p.PrintKeyString("driverUUID", to_string_16(obj.driverUUID));
+    p.PrintKeyValue("deviceUUID", obj.deviceUUID);
+    p.PrintKeyValue("driverUUID", obj.driverUUID);
     if (obj.deviceLUIDValid) { // special case
-    if (p.Type() == OutputType::json) {
-        ArrayWrapper arr(p, "deviceLUID");
-        for (uint32_t i = 0; i < 8; i++) p.PrintElement(static_cast<uint32_t>(obj.deviceLUID[i]));
-    } else
-        p.PrintKeyString("deviceLUID", to_string_8(obj.deviceLUID));
+    p.PrintKeyValue("deviceLUID", obj.deviceLUID);
     }
     p.PrintKeyValue("deviceNodeMask", obj.deviceNodeMask);
     p.PrintKeyBool("deviceLUIDValid", static_cast<bool>(obj.deviceLUIDValid));
@@ -1837,16 +1825,14 @@ void DumpVkPhysicalDeviceLimits(Printer &p, std::string name, const VkPhysicalDe
     p.PrintKeyValue("maxFragmentDualSrcAttachments", obj.maxFragmentDualSrcAttachments);
     p.PrintKeyValue("maxFragmentCombinedOutputResources", obj.maxFragmentCombinedOutputResources);
     p.PrintKeyValue("maxComputeSharedMemorySize", obj.maxComputeSharedMemorySize);
-    {   ArrayWrapper arr(p,"maxComputeWorkGroupCount", 3);
-        p.PrintElement(obj.maxComputeWorkGroupCount[0]);
-        p.PrintElement(obj.maxComputeWorkGroupCount[1]);
-        p.PrintElement(obj.maxComputeWorkGroupCount[2]);
+    {
+        ArrayWrapper arr(p,"maxComputeWorkGroupCount", 3);
+        for (uint32_t i = 0; i < 3; i++) { p.PrintElement(obj.maxComputeWorkGroupCount[i]); }
     }
     p.PrintKeyValue("maxComputeWorkGroupInvocations", obj.maxComputeWorkGroupInvocations);
-    {   ArrayWrapper arr(p,"maxComputeWorkGroupSize", 3);
-        p.PrintElement(obj.maxComputeWorkGroupSize[0]);
-        p.PrintElement(obj.maxComputeWorkGroupSize[1]);
-        p.PrintElement(obj.maxComputeWorkGroupSize[2]);
+    {
+        ArrayWrapper arr(p,"maxComputeWorkGroupSize", 3);
+        for (uint32_t i = 0; i < 3; i++) { p.PrintElement(obj.maxComputeWorkGroupSize[i]); }
     }
     p.PrintKeyValue("subPixelPrecisionBits", obj.subPixelPrecisionBits);
     p.PrintKeyValue("subTexelPrecisionBits", obj.subTexelPrecisionBits);
@@ -1856,13 +1842,13 @@ void DumpVkPhysicalDeviceLimits(Printer &p, std::string name, const VkPhysicalDe
     p.PrintKeyValue("maxSamplerLodBias", obj.maxSamplerLodBias);
     p.PrintKeyValue("maxSamplerAnisotropy", obj.maxSamplerAnisotropy);
     p.PrintKeyValue("maxViewports", obj.maxViewports);
-    {   ArrayWrapper arr(p,"maxViewportDimensions", 2);
-        p.PrintElement(obj.maxViewportDimensions[0]);
-        p.PrintElement(obj.maxViewportDimensions[1]);
+    {
+        ArrayWrapper arr(p,"maxViewportDimensions", 2);
+        for (uint32_t i = 0; i < 2; i++) { p.PrintElement(obj.maxViewportDimensions[i]); }
     }
-    {   ArrayWrapper arr(p,"viewportBoundsRange", 2);
-        p.PrintElement(obj.viewportBoundsRange[0]);
-        p.PrintElement(obj.viewportBoundsRange[1]);
+    {
+        ArrayWrapper arr(p,"viewportBoundsRange", 2);
+        for (uint32_t i = 0; i < 2; i++) { p.PrintElement(obj.viewportBoundsRange[i]); }
     }
     p.PrintKeyValue("viewportSubPixelBits", obj.viewportSubPixelBits);
     p.PrintKeyValue("minMemoryMapAlignment", obj.minMemoryMapAlignment);
@@ -1896,13 +1882,13 @@ void DumpVkPhysicalDeviceLimits(Printer &p, std::string name, const VkPhysicalDe
     p.PrintKeyValue("maxCullDistances", obj.maxCullDistances);
     p.PrintKeyValue("maxCombinedClipAndCullDistances", obj.maxCombinedClipAndCullDistances);
     p.PrintKeyValue("discreteQueuePriorities", obj.discreteQueuePriorities);
-    {   ArrayWrapper arr(p,"pointSizeRange", 2);
-        p.PrintElement(obj.pointSizeRange[0]);
-        p.PrintElement(obj.pointSizeRange[1]);
+    {
+        ArrayWrapper arr(p,"pointSizeRange", 2);
+        for (uint32_t i = 0; i < 2; i++) { p.PrintElement(obj.pointSizeRange[i]); }
     }
-    {   ArrayWrapper arr(p,"lineWidthRange", 2);
-        p.PrintElement(obj.lineWidthRange[0]);
-        p.PrintElement(obj.lineWidthRange[1]);
+    {
+        ArrayWrapper arr(p,"lineWidthRange", 2);
+        for (uint32_t i = 0; i < 2; i++) { p.PrintElement(obj.lineWidthRange[i]); }
     }
     p.PrintKeyValue("pointSizeGranularity", obj.pointSizeGranularity);
     p.PrintKeyValue("lineWidthGranularity", obj.lineWidthGranularity);
@@ -1947,41 +1933,13 @@ void DumpVkPhysicalDeviceMaintenance4Properties(Printer &p, std::string name, co
 void DumpVkPhysicalDeviceMemoryBudgetPropertiesEXT(Printer &p, std::string name, const VkPhysicalDeviceMemoryBudgetPropertiesEXT &obj) {
     ObjectWrapper object{p, name};
     p.SetMinKeyWidth(14);
-    {   ArrayWrapper arr(p,"heapBudget", 16);
-        p.PrintElement(obj.heapBudget[0]);
-        p.PrintElement(obj.heapBudget[1]);
-        p.PrintElement(obj.heapBudget[2]);
-        p.PrintElement(obj.heapBudget[3]);
-        p.PrintElement(obj.heapBudget[4]);
-        p.PrintElement(obj.heapBudget[5]);
-        p.PrintElement(obj.heapBudget[6]);
-        p.PrintElement(obj.heapBudget[7]);
-        p.PrintElement(obj.heapBudget[8]);
-        p.PrintElement(obj.heapBudget[9]);
-        p.PrintElement(obj.heapBudget[10]);
-        p.PrintElement(obj.heapBudget[11]);
-        p.PrintElement(obj.heapBudget[12]);
-        p.PrintElement(obj.heapBudget[13]);
-        p.PrintElement(obj.heapBudget[14]);
-        p.PrintElement(obj.heapBudget[15]);
+    {
+        ArrayWrapper arr(p,"heapBudget", 16);
+        for (uint32_t i = 0; i < 16; i++) { p.PrintElement(obj.heapBudget[i]); }
     }
-    {   ArrayWrapper arr(p,"heapUsage", 16);
-        p.PrintElement(obj.heapUsage[0]);
-        p.PrintElement(obj.heapUsage[1]);
-        p.PrintElement(obj.heapUsage[2]);
-        p.PrintElement(obj.heapUsage[3]);
-        p.PrintElement(obj.heapUsage[4]);
-        p.PrintElement(obj.heapUsage[5]);
-        p.PrintElement(obj.heapUsage[6]);
-        p.PrintElement(obj.heapUsage[7]);
-        p.PrintElement(obj.heapUsage[8]);
-        p.PrintElement(obj.heapUsage[9]);
-        p.PrintElement(obj.heapUsage[10]);
-        p.PrintElement(obj.heapUsage[11]);
-        p.PrintElement(obj.heapUsage[12]);
-        p.PrintElement(obj.heapUsage[13]);
-        p.PrintElement(obj.heapUsage[14]);
-        p.PrintElement(obj.heapUsage[15]);
+    {
+        ArrayWrapper arr(p,"heapUsage", 16);
+        for (uint32_t i = 0; i < 16; i++) { p.PrintElement(obj.heapUsage[i]); }
     }
 }
 void DumpVkPhysicalDeviceMemoryPriorityFeaturesEXT(Printer &p, std::string name, const VkPhysicalDeviceMemoryPriorityFeaturesEXT &obj) {
@@ -2002,31 +1960,27 @@ void DumpVkPhysicalDeviceMeshShaderPropertiesEXT(Printer &p, std::string name, c
     ObjectWrapper object{p, name};
     p.SetMinKeyWidth(37);
     p.PrintKeyValue("maxTaskWorkGroupTotalCount", obj.maxTaskWorkGroupTotalCount);
-    {   ArrayWrapper arr(p,"maxTaskWorkGroupCount", 3);
-        p.PrintElement(obj.maxTaskWorkGroupCount[0]);
-        p.PrintElement(obj.maxTaskWorkGroupCount[1]);
-        p.PrintElement(obj.maxTaskWorkGroupCount[2]);
+    {
+        ArrayWrapper arr(p,"maxTaskWorkGroupCount", 3);
+        for (uint32_t i = 0; i < 3; i++) { p.PrintElement(obj.maxTaskWorkGroupCount[i]); }
     }
     p.PrintKeyValue("maxTaskWorkGroupInvocations", obj.maxTaskWorkGroupInvocations);
-    {   ArrayWrapper arr(p,"maxTaskWorkGroupSize", 3);
-        p.PrintElement(obj.maxTaskWorkGroupSize[0]);
-        p.PrintElement(obj.maxTaskWorkGroupSize[1]);
-        p.PrintElement(obj.maxTaskWorkGroupSize[2]);
+    {
+        ArrayWrapper arr(p,"maxTaskWorkGroupSize", 3);
+        for (uint32_t i = 0; i < 3; i++) { p.PrintElement(obj.maxTaskWorkGroupSize[i]); }
     }
     p.PrintKeyValue("maxTaskPayloadSize", obj.maxTaskPayloadSize);
     p.PrintKeyValue("maxTaskSharedMemorySize", obj.maxTaskSharedMemorySize);
     p.PrintKeyValue("maxTaskPayloadAndSharedMemorySize", obj.maxTaskPayloadAndSharedMemorySize);
     p.PrintKeyValue("maxMeshWorkGroupTotalCount", obj.maxMeshWorkGroupTotalCount);
-    {   ArrayWrapper arr(p,"maxMeshWorkGroupCount", 3);
-        p.PrintElement(obj.maxMeshWorkGroupCount[0]);
-        p.PrintElement(obj.maxMeshWorkGroupCount[1]);
-        p.PrintElement(obj.maxMeshWorkGroupCount[2]);
+    {
+        ArrayWrapper arr(p,"maxMeshWorkGroupCount", 3);
+        for (uint32_t i = 0; i < 3; i++) { p.PrintElement(obj.maxMeshWorkGroupCount[i]); }
     }
     p.PrintKeyValue("maxMeshWorkGroupInvocations", obj.maxMeshWorkGroupInvocations);
-    {   ArrayWrapper arr(p,"maxMeshWorkGroupSize", 3);
-        p.PrintElement(obj.maxMeshWorkGroupSize[0]);
-        p.PrintElement(obj.maxMeshWorkGroupSize[1]);
-        p.PrintElement(obj.maxMeshWorkGroupSize[2]);
+    {
+        ArrayWrapper arr(p,"maxMeshWorkGroupSize", 3);
+        for (uint32_t i = 0; i < 3; i++) { p.PrintElement(obj.maxMeshWorkGroupSize[i]); }
     }
     p.PrintKeyValue("maxMeshSharedMemorySize", obj.maxMeshSharedMemorySize);
     p.PrintKeyValue("maxMeshPayloadAndSharedMemorySize", obj.maxMeshPayloadAndSharedMemorySize);
@@ -2302,9 +2256,9 @@ void DumpVkPhysicalDeviceSampleLocationsPropertiesEXT(Printer &p, std::string na
     p.SetMinKeyWidth(32);
     DumpVkSampleCountFlags(p, "sampleLocationSampleCounts", obj.sampleLocationSampleCounts);
     DumpVkExtent2D(p, "maxSampleLocationGridSize", obj.maxSampleLocationGridSize);
-    {   ArrayWrapper arr(p,"sampleLocationCoordinateRange", 2);
-        p.PrintElement(obj.sampleLocationCoordinateRange[0]);
-        p.PrintElement(obj.sampleLocationCoordinateRange[1]);
+    {
+        ArrayWrapper arr(p,"sampleLocationCoordinateRange", 2);
+        for (uint32_t i = 0; i < 2; i++) { p.PrintElement(obj.sampleLocationCoordinateRange[i]); }
     }
     p.PrintKeyValue("sampleLocationSubPixelBits", obj.sampleLocationSubPixelBits);
     p.PrintKeyBool("variableSampleLocations", static_cast<bool>(obj.variableSampleLocations));
@@ -2443,11 +2397,7 @@ void DumpVkPhysicalDeviceShaderModuleIdentifierFeaturesEXT(Printer &p, std::stri
 void DumpVkPhysicalDeviceShaderModuleIdentifierPropertiesEXT(Printer &p, std::string name, const VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT &obj) {
     ObjectWrapper object{p, name};
     p.SetMinKeyWidth(39);
-    if (p.Type() == OutputType::json) {
-        ArrayWrapper arr(p, "shaderModuleIdentifierAlgorithmUUID");
-        for (uint32_t i = 0; i < 16; i++) p.PrintElement(static_cast<uint32_t>(obj.shaderModuleIdentifierAlgorithmUUID[i]));
-    } else
-        p.PrintKeyString("shaderModuleIdentifierAlgorithmUUID", to_string_16(obj.shaderModuleIdentifierAlgorithmUUID));
+    p.PrintKeyValue("shaderModuleIdentifierAlgorithmUUID", obj.shaderModuleIdentifierAlgorithmUUID);
 }
 void DumpVkPhysicalDeviceShaderSubgroupExtendedTypesFeatures(Printer &p, std::string name, const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures &obj) {
     ObjectWrapper object{p, name};
@@ -2612,22 +2562,10 @@ void DumpVkPhysicalDeviceVulkan11Features(Printer &p, std::string name, const Vk
 void DumpVkPhysicalDeviceVulkan11Properties(Printer &p, std::string name, const VkPhysicalDeviceVulkan11Properties &obj) {
     ObjectWrapper object{p, name};
     p.SetMinKeyWidth(33);
-    if (p.Type() == OutputType::json) {
-        ArrayWrapper arr(p, "deviceUUID");
-        for (uint32_t i = 0; i < 16; i++) p.PrintElement(static_cast<uint32_t>(obj.deviceUUID[i]));
-    } else
-        p.PrintKeyString("deviceUUID", to_string_16(obj.deviceUUID));
-    if (p.Type() == OutputType::json) {
-        ArrayWrapper arr(p, "driverUUID");
-        for (uint32_t i = 0; i < 16; i++) p.PrintElement(static_cast<uint32_t>(obj.driverUUID[i]));
-    } else
-        p.PrintKeyString("driverUUID", to_string_16(obj.driverUUID));
+    p.PrintKeyValue("deviceUUID", obj.deviceUUID);
+    p.PrintKeyValue("driverUUID", obj.driverUUID);
     if (obj.deviceLUIDValid) { // special case
-    if (p.Type() == OutputType::json) {
-        ArrayWrapper arr(p, "deviceLUID");
-        for (uint32_t i = 0; i < 8; i++) p.PrintElement(static_cast<uint32_t>(obj.deviceLUID[i]));
-    } else
-        p.PrintKeyString("deviceLUID", to_string_8(obj.deviceLUID));
+    p.PrintKeyValue("deviceLUID", obj.deviceLUID);
     }
     p.PrintKeyValue("deviceNodeMask", obj.deviceNodeMask);
     p.PrintKeyBool("deviceLUIDValid", static_cast<bool>(obj.deviceLUIDValid));

--- a/vulkaninfo/outputprinter.h
+++ b/vulkaninfo/outputprinter.h
@@ -32,7 +32,7 @@
 
 std::string insert_quotes(std::string s) { return "\"" + s + "\""; }
 
-std::string to_string_16(const uint8_t uid[16]) {
+std::string to_string(const std::array<uint8_t, 16> &uid) {
     std::stringstream ss;
     ss << std::hex << std::setfill('0');
     for (int i = 0; i < 16; ++i) {
@@ -41,8 +41,7 @@ std::string to_string_16(const uint8_t uid[16]) {
     }
     return ss.str();
 }
-
-std::string to_string_8(const uint8_t uid[8]) {
+std::string to_string(const std::array<uint8_t, 8> &uid) {
     std::stringstream ss;
     ss << std::hex << std::setfill('0');
     for (int i = 0; i < 8; ++i) {
@@ -513,6 +512,27 @@ class Printer {
                 }
             default:
                 break;
+        }
+    }
+
+    // Need a specialization to handle C style arrays since they are implicitly converted to pointers
+    template <size_t N>
+    void PrintKeyValue(std::string key, const uint8_t (&values)[N]) {
+        switch (output_type) {
+            case (OutputType::json): {
+                ArrayStart(key, N);
+                for (uint32_t i = 0; i < N; i++) {
+                    PrintElement(static_cast<uint32_t>(values[i]));
+                }
+                ArrayEnd();
+                break;
+            }
+            default: {
+                std::array<uint8_t, N> arr{};
+                std::copy(std::begin(values), std::end(values), std::begin(arr));
+                PrintKeyString(key, to_string(arr));
+                break;
+            }
         }
     }
 

--- a/vulkaninfo/outputprinter.h
+++ b/vulkaninfo/outputprinter.h
@@ -582,7 +582,7 @@ class Printer {
                 break;
             case (OutputType::json):
             case (OutputType::vkconfig_output):
-                PrintElement("\"" + string + "\"", value_description);
+                PrintElement("\"" + EscapeJSONCString(string) + "\"");
             default:
                 break;
         }
@@ -708,6 +708,46 @@ class Printer {
             out << std::string(static_cast<size_t>(get_top().indents), '\t') << std::string(length, '-') << "\n";
             get_top().set_next_subheader = false;
         }
+    }
+
+    // Replace special characters in strings with their escaped versions.
+    // <https://www.json.org/json-en.html>
+    std::string EscapeJSONCString(std::string string) {
+        if (output_type != OutputType::json) return string;
+        std::string out{};
+        for (size_t i = 0; i < string.size(); i++) {
+            char c = string[i];
+            char out_c = c;
+            switch (c) {
+                case '\"':
+                case '\\':
+                    out.push_back('\\');
+                    break;
+                case '\b':
+                    out.push_back('\\');
+                    out_c = 'b';
+                    break;
+                case '\f':
+                    out.push_back('\\');
+                    out_c = 'f';
+                    break;
+                case '\n':
+                    out.push_back('\\');
+                    out_c = 'n';
+                    break;
+                case '\r':
+                    out.push_back('\\');
+                    out_c = 'r';
+                    break;
+                case '\t':
+                    out.push_back('\\');
+                    out_c = 't';
+                    break;
+            }
+            out.push_back(out_c);
+        }
+
+        return out;
     }
 };
 // Purpose: When a Printer starts an object or array it will automatically indent the output. This isn't

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -301,7 +301,7 @@ void GpuDumpProps(Printer &p, AppGpu &gpu) {
         p.PrintKeyString("deviceID", to_hex_str(props.deviceID));
         p.PrintKeyString("deviceType", VkPhysicalDeviceTypeString(props.deviceType));
         p.PrintKeyString("deviceName", props.deviceName);
-        p.PrintKeyString("pipelineCacheUUID", to_string_16(props.pipelineCacheUUID));
+        p.PrintKeyValue("pipelineCacheUUID", props.pipelineCacheUUID);
     }
     p.AddNewline();
     DumpVkPhysicalDeviceLimits(p, "VkPhysicalDeviceLimits", gpu.props.limits);
@@ -821,8 +821,8 @@ void DumpSummaryGPU(Printer &p, AppGpu &gpu) {
             }
             if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES) {
                 VkPhysicalDeviceIDProperties *device_id_props = reinterpret_cast<VkPhysicalDeviceIDProperties *>(structure);
-                p.PrintKeyString("deviceUUID", to_string_16(device_id_props->deviceUUID));
-                p.PrintKeyString("driverUUID", to_string_16(device_id_props->driverUUID));
+                p.PrintKeyValue("deviceUUID", device_id_props->deviceUUID);
+                p.PrintKeyValue("driverUUID", device_id_props->driverUUID);
             }
             place = structure->pNext;
         }

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -69,7 +69,7 @@ void DumpLayers(Printer &p, std::vector<LayerExtensionList> layers, const std::v
             IndentWrapper indent(p);
 
             for (auto &layer : layers) {
-                auto v_str = VkVersionString(layer.layer_properties.specVersion);
+                std::string v_str = VulkanVersion(layer.layer_properties.specVersion);
                 auto props = layer.layer_properties;
 
                 std::string header = p.DecorateAsType(props.layerName) + " (" + props.description + ") Vulkan version " +
@@ -80,7 +80,7 @@ void DumpLayers(Printer &p, std::vector<LayerExtensionList> layers, const std::v
 
                 ArrayWrapper arr_devices(p, "Devices", gpus.size());
                 for (auto &gpu : gpus) {
-                    p.PrintKeyValue("GPU id", gpu->id, gpu->props.deviceName);
+                    p.SetValueDescription(std::string(gpu->props.deviceName)).PrintKeyValue("GPU id", gpu->id);
                     auto exts = gpu->inst.AppGetPhysicalDeviceLayerExtensions(gpu->phys_device, props.layerName);
                     DumpExtensions(p, "Layer-Device Extensions", exts);
                     p.AddNewline();
@@ -99,14 +99,14 @@ void DumpLayers(Printer &p, std::vector<LayerExtensionList> layers, const std::v
                 ObjectWrapper obj_name(p, layer.layer_properties.layerName);
                 p.SetMinKeyWidth(21);
                 p.PrintKeyString("layerName", layer.layer_properties.layerName);
-                p.PrintKeyString("version", VkVersionString(layer.layer_properties.specVersion));
+                p.PrintKeyString("version", VulkanVersion(layer.layer_properties.specVersion).str());
                 p.PrintKeyValue("implementation version", layer.layer_properties.implementationVersion);
                 p.PrintKeyString("description", layer.layer_properties.description);
                 DumpExtensions(p, "Layer Extensions", layer.extension_properties);
                 ObjectWrapper obj_devices(p, "Devices");
                 for (auto &gpu : gpus) {
                     ObjectWrapper obj_gpu(p, gpu->props.deviceName);
-                    p.PrintKeyValue("GPU id", gpu->id, gpu->props.deviceName);
+                    p.SetValueDescription(std::string(gpu->props.deviceName)).PrintKeyValue("GPU id", gpu->id);
                     auto exts = gpu->inst.AppGetPhysicalDeviceLayerExtensions(gpu->phys_device, layer.layer_properties.layerName);
                     DumpExtensions(p, "Layer-Device Extensions", exts);
                 }
@@ -295,8 +295,14 @@ void GpuDumpProps(Printer &p, AppGpu &gpu) {
     {
         ObjectWrapper obj(p, "VkPhysicalDeviceProperties");
         p.SetMinKeyWidth(17);
-        p.PrintKeyValue("apiVersion", props.apiVersion, VkVersionString(props.apiVersion));
-        p.PrintKeyValue("driverVersion", props.driverVersion, to_hex_str(props.driverVersion));
+        if (p.Type() == OutputType::json) {
+            p.PrintKeyValue("apiVersion", props.apiVersion);
+            p.PrintKeyValue("driverVersion", props.driverVersion);
+        } else {
+            p.SetValueDescription(std::to_string(props.apiVersion)).PrintKeyString("apiVersion", VulkanVersion(props.apiVersion));
+            p.SetValueDescription(std::to_string(props.driverVersion))
+                .PrintKeyString("driverVersion", gpu.GetDriverVersionString());
+        }
         p.PrintKeyString("vendorID", to_hex_str(props.vendorID));
         p.PrintKeyString("deviceID", to_hex_str(props.deviceID));
         p.PrintKeyString("deviceType", VkPhysicalDeviceTypeString(props.deviceType));
@@ -607,11 +613,12 @@ void DumpGpuProfileCapabilities(Printer &p, AppGpu &gpu) {
             {
                 ObjectWrapper props_obj(p, "VkPhysicalDeviceProperties");
                 auto props = gpu.GetDeviceProperties();
-                p.PrintKeyValue("apiVersion", props.apiVersion, VkVersionString(props.apiVersion));
+                p.PrintKeyValue("apiVersion", props.apiVersion);
                 p.PrintKeyValue("deviceID", props.deviceID);
                 p.PrintKeyString("deviceName", props.deviceName);
                 p.PrintKeyString("deviceType", std::string("VK_") + VkPhysicalDeviceTypeString(props.deviceType));
                 p.PrintKeyValue("driverVersion", props.driverVersion);
+
                 DumpVkPhysicalDeviceLimits(p, "VkPhysicalDeviceLimits", gpu.props.limits);
                 {
                     ArrayWrapper arr(p, "pipelineCacheUUID");
@@ -718,7 +725,7 @@ void PrintProfileBaseInfo(Printer &p, const std::string &device_name, uint32_t a
                           const std::vector<std::string> &capabilities) {
     ObjectWrapper vk_info(p, device_name);
     p.PrintKeyValue("version", 1);
-    p.PrintKeyString("api-version", VkVersionString(apiVersion));
+    p.PrintKeyString("api-version", VulkanVersion(apiVersion).str());
     p.PrintKeyString("label", device_label);
     p.PrintKeyString("description", "Exported from vulkaninfo");
     { ObjectWrapper contributors(p, "contributors"); }
@@ -742,9 +749,9 @@ void PrintProfileBaseInfo(Printer &p, const std::string &device_name, uint32_t a
 void DumpGpuProfileInfo(Printer &p, AppGpu &gpu) {
     ObjectWrapper profiles(p, "profiles");
 
-    std::string device_label = std::string(gpu.props.deviceName) + " driver " + VkVersionString(gpu.props.driverVersion);
+    std::string device_label = std::string(gpu.props.deviceName) + " driver " + gpu.GetDriverVersionString();
     std::string device_name =
-        std::string("VP_VULKANINFO_") + std::string(gpu.props.deviceName) + "_" + VkVersionString(gpu.props.driverVersion);
+        std::string("VP_VULKANINFO_") + std::string(gpu.props.deviceName) + "_" + gpu.GetDriverVersionString();
     ;
     for (auto &c : device_name) {
         if (c == ' ' || c == '.') c = '_';
@@ -781,10 +788,10 @@ void DumpSummaryInstance(Printer &p, AppInstance &inst) {
         auto props = layer.layer_properties;
         layer_name_max = std::max(layer_name_max, strlen(props.layerName));
         layer_desc_max = std::max(layer_desc_max, strlen(props.description));
-        layer_version_max = std::max(layer_version_max, VkVersionString(layer.layer_properties.specVersion).size());
+        layer_version_max = std::max(layer_version_max, VulkanVersion(layer.layer_properties.specVersion).str().size());
     }
     for (auto &layer : inst.global_layers) {
-        auto v_str = VkVersionString(layer.layer_properties.specVersion);
+        auto v_str = VulkanVersion(layer.layer_properties.specVersion).str();
         auto props = layer.layer_properties;
 
         auto name_padding = std::string(layer_name_max - strlen(props.layerName), ' ');
@@ -800,32 +807,26 @@ void DumpSummaryGPU(Printer &p, AppGpu &gpu) {
     ObjectWrapper obj(p, "GPU" + std::to_string(gpu.id));
     p.SetMinKeyWidth(18);
     auto props = gpu.GetDeviceProperties();
-    p.PrintKeyValue("apiVersion", props.apiVersion, VkVersionString(props.apiVersion));
-    p.PrintKeyValue("driverVersion", props.driverVersion, to_hex_str(props.driverVersion));
+    p.PrintKeyValue("apiVersion", VulkanVersion(props.apiVersion));
+    if (gpu.found_driver_props) {
+        p.PrintKeyString("driverVersion", gpu.GetDriverVersionString());
+    } else {
+        p.PrintKeyValue("driverVersion", props.driverVersion);
+    }
     p.PrintKeyString("vendorID", to_hex_str(props.vendorID));
     p.PrintKeyString("deviceID", to_hex_str(props.deviceID));
     p.PrintKeyString("deviceType", VkPhysicalDeviceTypeString(props.deviceType));
     p.PrintKeyString("deviceName", props.deviceName);
 
-    if (gpu.inst.CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) &&
-        (gpu.CheckPhysicalDeviceExtensionIncluded(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME) || gpu.api_version.minor >= 2)) {
-        void *place = gpu.props2.pNext;
-        while (place) {
-            VkBaseOutStructure *structure = static_cast<VkBaseOutStructure *>(place);
-            if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES) {
-                VkPhysicalDeviceDriverProperties *driver_props = reinterpret_cast<VkPhysicalDeviceDriverProperties *>(structure);
-                DumpVkDriverId(p, "driverID", driver_props->driverID);
-                p.PrintKeyString("driverName", driver_props->driverName);
-                p.PrintKeyString("driverInfo", driver_props->driverInfo);
-                p.PrintKeyString("conformanceVersion", VkConformanceVersionString(driver_props->conformanceVersion));
-            }
-            if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES) {
-                VkPhysicalDeviceIDProperties *device_id_props = reinterpret_cast<VkPhysicalDeviceIDProperties *>(structure);
-                p.PrintKeyValue("deviceUUID", device_id_props->deviceUUID);
-                p.PrintKeyValue("driverUUID", device_id_props->driverUUID);
-            }
-            place = structure->pNext;
-        }
+    if (gpu.found_driver_props) {
+        DumpVkDriverId(p, "driverID", gpu.driver_props.driverID);
+        p.PrintKeyString("driverName", gpu.driver_props.driverName);
+        p.PrintKeyString("driverInfo", gpu.driver_props.driverInfo);
+        p.PrintKeyValue("conformanceVersion", gpu.driver_props.conformanceVersion);
+    }
+    if (gpu.found_device_id_props) {
+        p.PrintKeyValue("deviceUUID", gpu.device_id_props.deviceUUID);
+        p.PrintKeyValue("driverUUID", gpu.device_id_props.driverUUID);
     }
 }
 
@@ -986,7 +987,7 @@ PrinterCreateDetails get_printer_create_details(ParsedResults &parse_data, AppIn
                 std::string("{\n\t\"$schema\": ") + "\"https://schema.khronos.org/vulkan/profiles-0.8-latest.json\"";
             if (parse_data.filename.empty()) {
                 create.file_name = std::string("VP_VULKANINFO_") + std::string(selected_gpu.props.deviceName) + "_" +
-                                   VkVersionString(selected_gpu.props.driverVersion);
+                                   selected_gpu.GetDriverVersionString();
                 for (auto &c : create.file_name) {
                     if (c == ' ' || c == '.') c = '_';
                 }
@@ -995,7 +996,7 @@ PrinterCreateDetails get_printer_create_details(ParsedResults &parse_data, AppIn
             break;
         case (OutputCategory::vkconfig_output):
             create.output_type = OutputType::vkconfig_output;
-            create.start_string = "{\n\t\"Vulkan Instance Version\": \"" + VkVersionString(inst.vk_version) + "\"";
+            create.start_string = "{\n\t\"Vulkan Instance Version\": \"" + VulkanVersion(inst.vk_version).str() + "\"";
             break;
     }
     return create;


### PR DESCRIPTION
Fix #696 

Also:
* Parse & print `VkPhysicalDeviceProperties:driverVersion' according to driver specific formats. Falls back on the Vulkan Major.Minor.Patch if on an unknown platform.
* Switch the `VkPhysicalDeviceProperties:apiVersion` printing to put the major.minor.patch outside of the parenthesis. `apiVersion = 1.3.245 (232343235)` is how it is now printed, instead of ` apiVersion = 232343235 (1.3.245)
* Cleanup the logic around printing UUID arrays. Took some effort but uses the operator<< rather than requiring explicit conversion to strings.