### PR TITLE
vulkaninfo: Fix VkShaderStageFlagBits expansion

### DIFF
--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -986,8 +986,6 @@ std::vector<const char *> VkShaderStageFlagBitsGetStrings(VkShaderStageFlagBits 
     if (VK_SHADER_STAGE_GEOMETRY_BIT & value) strings.push_back("SHADER_STAGE_GEOMETRY_BIT");
     if (VK_SHADER_STAGE_FRAGMENT_BIT & value) strings.push_back("SHADER_STAGE_FRAGMENT_BIT");
     if (VK_SHADER_STAGE_COMPUTE_BIT & value) strings.push_back("SHADER_STAGE_COMPUTE_BIT");
-    if (VK_SHADER_STAGE_ALL_GRAPHICS & value) strings.push_back("SHADER_STAGE_ALL_GRAPHICS");
-    if (VK_SHADER_STAGE_ALL & value) strings.push_back("SHADER_STAGE_ALL");
     if (VK_SHADER_STAGE_RAYGEN_BIT_KHR & value) strings.push_back("SHADER_STAGE_RAYGEN_BIT_KHR");
     if (VK_SHADER_STAGE_ANY_HIT_BIT_KHR & value) strings.push_back("SHADER_STAGE_ANY_HIT_BIT_KHR");
     if (VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR & value) strings.push_back("SHADER_STAGE_CLOSEST_HIT_BIT_KHR");


### PR DESCRIPTION
Fix bug where `SHADER_STAGE_ALL_GRAPHICS` and `SHADER_STAGE_ALL` were showing up in the list of set bits for
`VkPhysicalDeviceSubgroupProperties::supportedStages`. When expanding a FlagBits value we should only consider the single-bit options.