### PR TITLE
Fix negative gpu selection in vkcube & vkcubepp

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -366,6 +366,7 @@ struct demo {
     bool use_staging_buffer;
     bool separate_present_queue;
     bool is_minimized;
+    bool invalid_gpu_selection;
     int32_t gpu_number;
 
     bool VK_KHR_incremental_present_enabled;
@@ -3391,7 +3392,7 @@ static void demo_init_vk(struct demo *demo) {
     VkPhysicalDevice *physical_devices = malloc(sizeof(VkPhysicalDevice) * gpu_count);
     err = vkEnumeratePhysicalDevices(demo->inst, &gpu_count, physical_devices);
     assert(!err);
-    if (demo->gpu_number >= 0 && !((uint32_t)demo->gpu_number < gpu_count)) {
+    if (demo->invalid_gpu_selection || (demo->gpu_number >= 0 && !((uint32_t)demo->gpu_number < gpu_count))) {
         fprintf(stderr, "GPU %d specified is not present, GPU count = %u\n", demo->gpu_number, gpu_count);
         ERR_EXIT("Specified GPU number is not present", "User Error");
     }
@@ -4041,7 +4042,7 @@ static void demo_init(struct demo *demo, int argc, char **argv) {
         }
         if ((strcmp(argv[i], "--gpu_number") == 0) && (i < argc - 1)) {
             demo->gpu_number = atoi(argv[i + 1]);
-            assert(demo->gpu_number >= 0);
+            if (demo->gpu_number < 0) demo->invalid_gpu_selection = true;
             i++;
             continue;
         }

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -1242,7 +1242,8 @@ void Demo::init_vk() {
                          .setPApplicationName(APP_SHORT_NAME)
                          .setApplicationVersion(0)
                          .setPEngineName(APP_SHORT_NAME)
-                         .setEngineVersion(0);
+                         .setEngineVersion(0)
+                         .setApiVersion(VK_API_VERSION_1_0);
     auto const inst_info = vk::InstanceCreateInfo()
                                .setFlags(portabilityEnumerationActive ? vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR
                                                                       : static_cast<vk::InstanceCreateFlagBits>(0))

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -330,6 +330,7 @@ struct Demo {
     bool use_staging_buffer = false;
     bool use_xlib = false;
     bool separate_present_queue = false;
+    bool invalid_gpu_selection = false;
     int32_t gpu_number = 0;
 
     vk::Instance inst;
@@ -902,7 +903,7 @@ void Demo::init(int argc, char **argv) {
         }
         if ((strcmp(argv[i], "--gpu_number") == 0) && (i < argc - 1)) {
             gpu_number = atoi(argv[i + 1]);
-            assert(gpu_number >= 0);
+            if (gpu_number < 0) invalid_gpu_selection = true;
             i++;
             continue;
         }
@@ -1295,7 +1296,7 @@ void Demo::init_vk() {
             "vkEnumeratePhysicalDevices Failure");
     }
 
-    if (gpu_number >= 0 && !(static_cast<uint32_t>(gpu_number) < physical_devices.size())) {
+    if (invalid_gpu_selection || (gpu_number >= 0 && !(static_cast<uint32_t>(gpu_number) < physical_devices.size()))) {
         fprintf(stderr, "GPU %d specified is not present, GPU count = %zu\n", gpu_number, physical_devices.size());
         ERR_EXIT("Specified GPU number is not present", "User Error");
     }


### PR DESCRIPTION
Fix the crash when trying to select a negative GPU index and the validation error stating that the apiVersion wasn't set. 