### PR TITLE
mockicd: Add more PhysicalDevice functions not in profiles

### DIFF
--- a/icd/generated/mock_icd.h
+++ b/icd/generated/mock_icd.h
@@ -2,7 +2,7 @@
 #define __mock_icd_h_ 1
 
 /*
-** Copyright (c) 2015-2018 The Khronos Group Inc.
+** Copyright (c) 2015-2018, 2023 The Khronos Group Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/scripts/kvt_genvk.py
+++ b/scripts/kvt_genvk.py
@@ -97,7 +97,7 @@ def makeGenOpts(args):
     # Copyright text prefixing all headers (list of strings).
     prefixStrings = [
         '/*',
-        '** Copyright (c) 2015-2018 The Khronos Group Inc.',
+        '** Copyright (c) 2015-2018, 2023 The Khronos Group Inc.',
         '**',
         '** Licensed under the Apache License, Version 2.0 (the "License");',
         '** you may not use this file except in compliance with the License.',


### PR DESCRIPTION
There are many `vkEnumeratePhysicalDevice*` and `vkGetPhysicalDevice` function that just giving an arbitrary value provides more test coverage when using MockICD with Profiles to test Validation