### PR TITLE
vulkaninfo: Use VkFormatFeatureFlags2 by default

### DIFF
--- a/scripts/vulkaninfo_generator.py
+++ b/scripts/vulkaninfo_generator.py
@@ -81,7 +81,7 @@ std::string to_hex_str(Printer &p, const T i) {
 
 # used in the .cpp code
 structures_to_gen = ['VkExtent3D', 'VkExtent2D', 'VkPhysicalDeviceLimits', 'VkPhysicalDeviceFeatures', 'VkPhysicalDeviceSparseProperties',
-                     'VkSurfaceCapabilitiesKHR', 'VkSurfaceFormatKHR', 'VkLayerProperties', 'VkPhysicalDeviceToolProperties']
+                     'VkSurfaceCapabilitiesKHR', 'VkSurfaceFormatKHR', 'VkLayerProperties', 'VkPhysicalDeviceToolProperties', 'VkFormatProperties']
 enums_to_gen = ['VkResult', 'VkFormat', 'VkPresentModeKHR',
                 'VkPhysicalDeviceType', 'VkImageTiling']
 flags_to_gen = ['VkSurfaceTransformFlagsKHR', 'VkCompositeAlphaFlagsKHR', 'VkSurfaceCounterFlagsEXT', 'VkQueueFlags',
@@ -587,6 +587,8 @@ def PrintStructure(struct, types_to_gen, structure_names, aliases):
             out += f'    p.PrintKeyValue("{v.name}", obj.{v.name});\n'
         elif v.name not in names_to_ignore:
             # if it is an enum/flag/bitmask
+            if v.typeID in ['VkFormatFeatureFlags', 'VkFormatFeatureFlags2']:
+                out += '    p.SetOpenDetails();\n' # special case so that feature flags are open in html output
             out += f'    Dump{v.typeID}(p, "{v.name}", obj.{v.name});\n'
 
     if struct.name in ["VkPhysicalDeviceLimits", "VkPhysicalDeviceSparseProperties"]:

--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -1334,6 +1334,7 @@ void DumpVkDrmFormatModifierProperties2EXT(Printer &p, std::string name, const V
     p.SetMinKeyWidth(27);
     p.PrintKeyValue("drmFormatModifier", obj.drmFormatModifier);
     p.PrintKeyValue("drmFormatModifierPlaneCount", obj.drmFormatModifierPlaneCount);
+    p.SetOpenDetails();
     DumpVkFormatFeatureFlags2(p, "drmFormatModifierTilingFeatures", obj.drmFormatModifierTilingFeatures);
 }
 void DumpVkExtent2D(Printer &p, std::string name, const VkExtent2D &obj) {
@@ -1349,10 +1350,22 @@ void DumpVkExtent3D(Printer &p, std::string name, const VkExtent3D &obj) {
     p.PrintKeyValue("height", obj.height);
     p.PrintKeyValue("depth", obj.depth);
 }
+void DumpVkFormatProperties(Printer &p, std::string name, const VkFormatProperties &obj) {
+    ObjectWrapper object{p, name};
+    p.SetOpenDetails();
+    DumpVkFormatFeatureFlags(p, "linearTilingFeatures", obj.linearTilingFeatures);
+    p.SetOpenDetails();
+    DumpVkFormatFeatureFlags(p, "optimalTilingFeatures", obj.optimalTilingFeatures);
+    p.SetOpenDetails();
+    DumpVkFormatFeatureFlags(p, "bufferFeatures", obj.bufferFeatures);
+}
 void DumpVkFormatProperties3(Printer &p, std::string name, const VkFormatProperties3 &obj) {
     ObjectWrapper object{p, name};
+    p.SetOpenDetails();
     DumpVkFormatFeatureFlags2(p, "linearTilingFeatures", obj.linearTilingFeatures);
+    p.SetOpenDetails();
     DumpVkFormatFeatureFlags2(p, "optimalTilingFeatures", obj.optimalTilingFeatures);
+    p.SetOpenDetails();
     DumpVkFormatFeatureFlags2(p, "bufferFeatures", obj.bufferFeatures);
 }
 void DumpVkLayerProperties(Printer &p, std::string name, const VkLayerProperties &obj) {


### PR DESCRIPTION
Until now, vulkaninfo was only displaying VkFormatFeatureFlagBits, which means that many of the newer capabilities of formats were not being shown. Now, vulkaninfo will default to printing VkFormatFeatureFlagsBits2 and only use VkFormatFeatureFlagBits when the VK_KHR_format_feature_flags_2 is not supported by the device.

While this PR is currently working, I need to perform more testing on the various outputs to verify everything still works as intended.

Fixes #751 