### PR TITLE
vulkaninfo: Add Android build support

### DIFF
--- a/cube/android/.gitignore
+++ b/cube/android/.gitignore
@@ -1,0 +1,3 @@
+bin
+libs
+obj

--- a/vulkaninfo/android/.gitignore
+++ b/vulkaninfo/android/.gitignore
@@ -1,0 +1,3 @@
+bin
+libs
+obj

--- a/vulkaninfo/android/jni/Android.mk
+++ b/vulkaninfo/android/jni/Android.mk
@@ -1,0 +1,28 @@
+# Copyright 2015 The Android Open Source Project
+# Copyright (C) 2015 Valve Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LOCAL_PATH := $(abspath $(call my-dir))
+SRC_DIR := $(LOCAL_PATH)/../../..
+VULKANINFO_DIR := $(SRC_DIR)/vulkaninfo
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := vulkaninfo
+LOCAL_SRC_FILES += $(VULKANINFO_DIR)/vulkaninfo.cpp
+LOCAL_C_INCLUDES += $(SRC_DIR)/build-android/third_party/Vulkan-Headers/include \
+                    $(VULKANINFO_DIR) \
+                    $(VULKANINFO_DIR)/generated
+LOCAL_CFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DVK_ENABLE_BETA_EXTENSIONS
+LOCAL_LDLIBS := -llog -landroid
+include $(BUILD_EXECUTABLE)

--- a/vulkaninfo/android/jni/Application.mk
+++ b/vulkaninfo/android/jni/Application.mk
@@ -1,0 +1,22 @@
+# Copyright 2015 The Android Open Source Project
+# Copyright (C) 2015 Valve Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
+APP_PLATFORM := android-23
+APP_STL := c++_static
+APP_MODULES := vulkaninfo
+APP_CPPFLAGS += -std=c++11 -fexceptions -Wall -Werror -Wextra -Wno-unused-parameter -Wno-missing-field-initializers
+APP_CFLAGS += -Wall -Werror -Wextra -Wno-unused-parameter -Wno-missing-field-initializers
+NDK_TOOLCHAIN_VERSION := clang


### PR DESCRIPTION
This change adds a build step to "build-android/build_all.sh" to create a command-line version of `vulkaninfo` for Android devices. Once built, `vulkaninfo` can be pushed to the device and executed using `adb`.

Because it is not possible to create `ANativeWindow` from a native command-line application, `VULKANINFO_WSI_ENABLED` is not defined for Android builds of `vulkaninfo`.