### PR TITLE
vulkaninfo: Flush before exiting

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -1139,6 +1139,8 @@ int main(int argc, char **argv) {
 
         RunPrinter(*(printer.get()), parse_data, instance, gpus, surfaces);
 
+        // Call the printer's destructor before the file handle gets closed
+        printer.reset(nullptr);
 #if defined(VULKANINFO_WSI_ENABLED)
         for (auto &surface_extension : instance.surface_extensions) {
             AppDestroySurface(instance, surface_extension.surface);
@@ -1152,9 +1154,10 @@ int main(int argc, char **argv) {
             printer->FinishOutput();
         }
         return_code = 1;
+
+        // Call the printer's destructor before the file handle gets closed
+        printer.reset(nullptr);
     }
-    // Call the printer's destructor before the file handle gets closed
-    printer.reset(nullptr);
 
 #ifdef _WIN32
     if (parse_data.output_category == OutputCategory::text && !parse_data.print_to_file) wait_for_console_destroy();


### PR DESCRIPTION
Vulkaninfo does not manually flush the output before exiting, which means that if a crash were to happen during teardown, the stdout buffer may not have finished writing.

To implement this, it was necessary to turn the destructor of Printer into a function, as the lifetime of the printer is longer than the various Vulkan objects that are liable to crash.

This PR comes about to work around issues where some layers/drivers/systems will crash during vkDestroyDevice.