### PR TITLE
mock: Add support for DeviceBufferMemoryRequirements

### DIFF
--- a/icd/generated/mock_icd.cpp
+++ b/icd/generated/mock_icd.cpp
@@ -2447,7 +2447,12 @@ static VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirements(
     const VkDeviceBufferMemoryRequirements*     pInfo,
     VkMemoryRequirements2*                      pMemoryRequirements)
 {
-//Not a CREATE or DESTROY function
+    // TODO: Just hard-coding reqs for now
+    pMemoryRequirements->memoryRequirements.alignment = 1;
+    pMemoryRequirements->memoryRequirements.memoryTypeBits = 0xFFFF;
+
+    // Return a size based on the buffer size from the create info.
+    pMemoryRequirements->memoryRequirements.size = ((pInfo->pCreateInfo->size + 4095) / 4096) * 4096;
 }
 
 static VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirements(
@@ -4081,7 +4086,7 @@ static VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirementsKHR(
     const VkDeviceBufferMemoryRequirements*     pInfo,
     VkMemoryRequirements2*                      pMemoryRequirements)
 {
-//Not a CREATE or DESTROY function
+    GetDeviceBufferMemoryRequirements(device, pInfo, pMemoryRequirements);
 }
 
 static VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirementsKHR(

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -1000,6 +1000,17 @@ CUSTOM_C_INTERCEPTS = {
 'vkGetBufferMemoryRequirements2KHR': '''
     GetBufferMemoryRequirements(device, pInfo->buffer, &pMemoryRequirements->memoryRequirements);
 ''',
+'vkGetDeviceBufferMemoryRequirements': '''
+    // TODO: Just hard-coding reqs for now
+    pMemoryRequirements->memoryRequirements.alignment = 1;
+    pMemoryRequirements->memoryRequirements.memoryTypeBits = 0xFFFF;
+
+    // Return a size based on the buffer size from the create info.
+    pMemoryRequirements->memoryRequirements.size = ((pInfo->pCreateInfo->size + 4095) / 4096) * 4096;
+''',
+'vkGetDeviceBufferMemoryRequirementsKHR': '''
+    GetDeviceBufferMemoryRequirements(device, pInfo, pMemoryRequirements);
+''',
 'vkGetImageMemoryRequirements': '''
     pMemoryRequirements->size = 0;
     pMemoryRequirements->alignment = 1;


### PR DESCRIPTION
Needed for KhronosGroup/Vulkan-ValidationLayers/issues/5616