### PR TITLE
vulkaninfo: Reduce NVIDIA quaternary version field to 6 bits

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -1796,13 +1796,13 @@ struct AppGpu {
         if ((found_driver_props && driver_props.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY) ||
             (!found_driver_props && props.deviceID == 4318)) {
             return std::to_string((v >> 22) & 0x3ff) + "." + std::to_string((v >> 14) & 0x0ff) + "." +
-                   std::to_string((v >> 6) & 0x0ff) + "." + std::to_string((v)&0x003ff);
+                   std::to_string((v >> 6) & 0x0ff) + "." + std::to_string(v & 0x003f);
         } else if ((found_driver_props && driver_props.driverID == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS)
 #if defined(WIN32)
                    || (!found_driver_props && props.deviceID == 0x8086)  // only do the fallback check if running in windows
 #endif
         ) {
-            return std::to_string((v >> 14)) + "." + std::to_string((v)&0x3fff);
+            return std::to_string(v >> 14) + "." + std::to_string(v & 0x3fff);
         } else {
             // AMD uses the standard vulkan scheme
             return VulkanVersion(v).str();


### PR DESCRIPTION
The tertiary version field is shifted 6 bits to the right, meaning there are only 6 bits left to for the quaternary version field, not 10. See also:

https://github.com/SaschaWillems/vulkan.gpuinfo.org/blob/1e6ca6e3c0763daabd6a101b860ab4354a07f5d3/functions.php#L305

CC @SaschaWillems 

(EDIT: I did not test or run into this problem, just noticed this oddity while trying to understand other version parsing quirks)