### PR TITLE
icd: Add vkGetDescriptorSetLayoutSupport

### DIFF
--- a/icd/generated/mock_icd.cpp
+++ b/icd/generated/mock_icd.cpp
@@ -2062,7 +2062,9 @@ static VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupport(
     const VkDescriptorSetLayoutCreateInfo*      pCreateInfo,
     VkDescriptorSetLayoutSupport*               pSupport)
 {
-//Not a CREATE or DESTROY function
+    if (pSupport) {
+        pSupport->supported = VK_TRUE;
+    }
 }
 
 
@@ -3759,7 +3761,7 @@ static VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupportKHR(
     const VkDescriptorSetLayoutCreateInfo*      pCreateInfo,
     VkDescriptorSetLayoutSupport*               pSupport)
 {
-//Not a CREATE or DESTROY function
+    GetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport);
 }
 
 

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -1382,6 +1382,14 @@ CUSTOM_C_INTERCEPTS = {
     pCapabilities->maxActiveReferencePictures = 4;
     return VK_SUCCESS;
 ''',
+'vkGetDescriptorSetLayoutSupport':'''
+    if (pSupport) {
+        pSupport->supported = VK_TRUE;
+    }
+''',
+'vkGetDescriptorSetLayoutSupportKHR':'''
+    GetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport);
+''',
 }
 
 # MockICDGeneratorOptions - subclass of GeneratorOptions.


### PR DESCRIPTION
Adds support for `vkGetDescriptorSetLayoutSupport` so it returns `VK_TRUE`