### PR TITLE
ci: Add tests to github actions runs for linux and mac

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -63,7 +63,7 @@ jobs:
               with:
                 key: ${{ runner.os }}-${{ matrix.config }}-${{ matrix.cc }}-${{matrix.cube_wsi}}
             - name: Configure
-              run: cmake -S. -B build -G "Ninja" -DCMAKE_BUILD_TYPE=${{matrix.config}} -DCUBE_WSI_SELECTION=${{matrix.cube_wsi}} -D UPDATE_DEPS=ON -D INSTALL_ICD=ON
+              run: cmake -S. -B build -G "Ninja" -DCMAKE_BUILD_TYPE=${{matrix.config}} -DCUBE_WSI_SELECTION=${{matrix.cube_wsi}} -D UPDATE_DEPS=ON -D INSTALL_ICD=ON -D BUILD_TESTS=ON
               env:
                 CC: ${{matrix.cc}}
                 CXX: ${{matrix.cxx}}
@@ -75,6 +75,10 @@ jobs:
 
             - name: Install
               run: cmake --install build/ --prefix build/install
+
+            - name: Test
+              working-directory: ./build
+              run: ctest --output-on-failure
 
             - name: Verify generated source files
               run: python scripts/generate_source.py --verify external/${{ matrix.config }}/Vulkan-Headers/build/install/share/vulkan/registry
@@ -129,12 +133,16 @@ jobs:
               run: echo "/usr/lib/ccache:/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
 
             - name: Configure
-              run: cmake -S. -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -D UPDATE_DEPS=ON -D INSTALL_ICD=ON
+              run: cmake -S. -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -D UPDATE_DEPS=ON -D INSTALL_ICD=ON -D BUILD_TESTS=ON
               env:
                 MACOSX_DEPLOYMENT_TARGET: 10.15
 
             - name: Build
               run: cmake --build build
+
+            - name: Test
+              working-directory: ./build
+              run: ctest --output-on-failure
 
             - name: Verify generated source files
               run: python scripts/generate_source.py --verify external/Release/Vulkan-Headers/build/install/share/vulkan/registry

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -34,18 +34,31 @@ jobs:
 
         strategy:
             matrix:
-                cc: [ gcc, clang ]
-                cxx: [ g++, clang++ ]
+                cc: [ gcc ]
+                cxx: [ g++ ]
                 config: [ Debug, Release ]
                 os: [ ubuntu-20.04, ubuntu-22.04 ]
-                cube_wsi: [ XCB, XLIB, WAYLAND, DISPLAY ]
-                exclude:
-                    - cc: gcc
-                      cxx: clang++
-                    - cc: clang
-                      cxx: g++
-                    - os: ubuntu-20.04
-                      cube_wsi: WAYLAND
+                cube_wsi: [ XCB ]
+                include:
+                    # Test WAYLAND
+                  - cc: gcc
+                    cxx: g++
+                    config: Release
+                    os: ubuntu-22.04
+                    cube_wsi: WAYLAND
+                    # Test clang on ubuntu 20 with XLIB
+                  - cc: clang
+                    cxx: clang++
+                    config: Debug
+                    os: ubuntu-20.04
+                    cube_wsi: XLIB
+                    # Test clang on ubuntu 22 with the DISPLAY option
+                  - cc: clang
+                    cxx: clang++
+                    config: Release
+                    os: ubuntu-22.04
+                    cube_wsi: DISPLAY
+
 
         steps:
             - uses: actions/checkout@v3

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -39,9 +39,6 @@
                     "repo_name": "Vulkan-Headers"
                 }
             ],
-            "cmake_options": [
-                "-DBUILD_TESTS=NO"
-            ],
             "build_platforms": [
                 "linux",
                 "darwin"


### PR DESCRIPTION
ci: Add tests to github actions runs

Some tests do not need installed drivers, such as MockICD testing, so is
a prime candidate for cloud based CI.

Added the first of many tests for mock ICD that should outline the current capabilities so that current users aren't affected by more invasive modifications.