### PR TITLE
icd: Document parametization for VulkanSC

### DIFF
--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -16,6 +16,8 @@
 # limitations under the License.
 # ~~~
 
+# These variables enable downstream users to customize the CMake targets
+# based on the target API variant (e.g. Vulkan SC)
 set(MOCK_ICD_NAME VkICD_mock_icd)
 set(GENERATED generated)
 


### PR DESCRIPTION
Added so that future maintainers know why these variables exist.