### PR TITLE
build: Add API_TYPE variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ cmake_minimum_required(VERSION 3.17.2)
 
 project(Vulkan-Tools)
 
+# This variable enables downstream users to customize the target API
+# variant (e.g. Vulkan SC)
+set(API_TYPE "vulkan")
+
 add_subdirectory(scripts)
 
 # User-interface declarations ----------------------------------------------------------------------------------------------------
@@ -33,8 +37,6 @@ option(BUILD_ICD "Build icd" ON)
 # Installing the Mock ICD to system directories is probably not desired since this ICD is not a very complete implementation.
 # Require the user to ask that it be installed if they really want it.
 option(INSTALL_ICD "Install icd" OFF)
-
-set(API_TYPE "vulkan")
 
 if (UNIX AND NOT APPLE) # i.e. Linux
     option(ENABLE_ADDRESS_SANITIZER "Use addres sanitization" OFF)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -40,6 +40,8 @@ if (UPDATE_DEPS)
     endif()
     list(APPEND update_dep_command "--config")
     list(APPEND update_dep_command "${_build_type}")
+    list(APPEND update_dep_command "--api")
+    list(APPEND update_dep_command "${API_TYPE}")
 
     set(UPDATE_DEPS_DIR_SUFFIX "${_build_type}")
     if (ANDROID)


### PR DESCRIPTION
This is analogous to the same variable type used in VVL to indicate target API variant and is used to specify the `--api` argument of `update_deps.py`.

To be clear, previously, `update_deps.py` was not automatically invoked in the tools build system, hence the new use of the `API_TYPE` cmake variable.