### PR TITLE
vulkaninfo: Enable Swapchain Colorspace ext

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -798,6 +798,9 @@ struct AppInstance {
             if (strcmp(VK_KHR_SURFACE_PROTECTED_CAPABILITIES_EXTENSION_NAME, ext.extensionName) == 0) {
                 inst_extensions.push_back(ext.extensionName);
             }
+            if (strcmp(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME, ext.extensionName) == 0) {
+                inst_extensions.push_back(ext.extensionName);
+            }
         }
     }
 


### PR DESCRIPTION
This extension may be required to be enabled to enumerate HDR formats, best to enable it if its available.