### PR TITLE
build: Fix Windows build when tests are enabled

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -116,13 +116,17 @@ jobs:
                 arch: ${{ matrix.arch }}
 
             - name: Configure
-              run: cmake -S. -B build  -G "Ninja" -DCMAKE_BUILD_TYPE=${{matrix.config}} -D UPDATE_DEPS=ON -D INSTALL_ICD=ON
+              run: cmake -S. -B build  -G "Ninja" -DCMAKE_BUILD_TYPE=${{matrix.config}} -D UPDATE_DEPS=ON -D INSTALL_ICD=ON -D BUILD_TESTS=ON
 
             - name: Build
               run: cmake --build ./build
 
             - name: Install
               run: cmake --install build/ --prefix build/install
+
+            - name: Test
+              working-directory: ./build
+              run: ctest --output-on-failure
 
             - name: Verify generated source files
               run: python scripts/generate_source.py --verify external/${{matrix.config}}/Vulkan-Headers/build/install/share/vulkan/registry

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,13 +66,7 @@ if(APPLE)
 endif()
 
 find_package(VulkanHeaders REQUIRED CONFIG)
-
-# Find and create the Vulkan::Vulkan library
-find_library(Vulkan_LIBRARY NAMES vulkan vulkan-1)
-add_library(Vulkan::Vulkan UNKNOWN IMPORTED)
-set_target_properties(Vulkan::Vulkan PROPERTIES
-    IMPORTED_LOCATION ${Vulkan_LIBRARY})
-target_link_libraries(Vulkan::Vulkan INTERFACE Vulkan::Headers)
+find_package(VulkanLoader REQUIRED CONFIG)
 
 include(GNUInstallDirs)
 

--- a/cube/CMakeLists.txt
+++ b/cube/CMakeLists.txt
@@ -186,7 +186,7 @@ elseif(NOT WIN32)
                    cube.vert.inc
                    cube.frag.inc
                    ${OPTIONAL_WAYLAND_DATA_FILES})
-    target_link_libraries(vkcube Vulkan::Vulkan)
+    target_link_libraries(vkcube Vulkan::Headers Vulkan::Loader)
     target_compile_definitions(vkcube PUBLIC ${CUBE_PLATFORM})
     include(CheckLibraryExists)
     CHECK_LIBRARY_EXISTS("rt" clock_gettime "" NEED_RT)
@@ -212,7 +212,7 @@ else()
                    ${PROJECT_SOURCE_DIR}/cube/cube.frag
                    cube.vert.inc
                    cube.frag.inc)
-    target_link_libraries(vkcube Vulkan::Vulkan)
+    target_link_libraries(vkcube Vulkan::Headers Vulkan::Loader)
 endif()
 
 if(APPLE)
@@ -241,7 +241,7 @@ elseif(NOT WIN32)
                    cube.vert.inc
                    cube.frag.inc
                    ${OPTIONAL_WAYLAND_DATA_FILES})
-    target_link_libraries(vkcubepp Vulkan::Vulkan)
+    target_link_libraries(vkcubepp Vulkan::Headers Vulkan::Loader)
     target_compile_definitions(vkcubepp PUBLIC ${CUBE_PLATFORM})
 
     if (ENABLE_ADDRESS_SANITIZER)
@@ -262,7 +262,7 @@ else()
                    ${PROJECT_SOURCE_DIR}/cube/cube.frag
                    cube.vert.inc
                    cube.frag.inc)
-    target_link_libraries(vkcubepp Vulkan::Vulkan)
+    target_link_libraries(vkcubepp Vulkan::Headers Vulkan::Loader)
 endif()
 
 if(APPLE)
@@ -298,7 +298,7 @@ if(UNIX AND NOT APPLE) # i.e. Linux
                        cube.vert.inc
                        cube.frag.inc
                        ${OPTIONAL_WAYLAND_DATA_FILES})
-        target_link_libraries(vkcube-wayland Vulkan::Vulkan)
+        target_link_libraries(vkcube-wayland Vulkan::Headers Vulkan::Loader)
         target_compile_definitions(vkcube-wayland PUBLIC VK_USE_PLATFORM_WAYLAND_KHR)
         include(CheckLibraryExists)
         CHECK_LIBRARY_EXISTS("rt" clock_gettime "" NEED_RT)

--- a/cube/macOS/cube/cube.cmake
+++ b/cube/macOS/cube/cube.cmake
@@ -55,7 +55,7 @@ add_dependencies(vkcube MoltenVK_icd-staging-json)
 target_include_directories(vkcube PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${MOLTENVK_DIR}/MoltenVK/include)
 
 # We do this so vulkaninfo is linked to an individual library and NOT a framework.
-target_link_libraries(vkcube ${Vulkan_LIBRARY} "-framework Cocoa -framework QuartzCore")
+target_link_libraries(vkcube Vulkan::Loader "-framework Cocoa -framework QuartzCore")
 
 set_target_properties(vkcube PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cube/Info.plist)
 

--- a/cube/macOS/cubepp/cubepp.cmake
+++ b/cube/macOS/cubepp/cubepp.cmake
@@ -57,7 +57,7 @@ add_dependencies(vkcubepp MoltenVK_icd-staging-json)
 target_include_directories(vkcubepp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${MOLTENVK_DIR}/MoltenVK/include)
 
 # We do this so vulkaninfo is linked to an individual library and NOT a framework.
-target_link_libraries(vkcubepp ${Vulkan_LIBRARY} "-framework Cocoa -framework QuartzCore")
+target_link_libraries(vkcubepp Vulkan::Loader "-framework Cocoa -framework QuartzCore")
 
 set_target_properties(vkcubepp PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cubepp/Info.plist)
 

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -32,6 +32,9 @@
             "sub_dir": "Vulkan-Loader",
             "build_dir": "Vulkan-Loader/build",
             "install_dir": "Vulkan-Loader/build/install",
+            "cmake_options": [
+                "-DLOADER_USE_UNSAFE_FILE_SEARCH=ON"
+            ],
             "commit": "d40385b1748ae5270fcab18c5aae1a2e5a301465",
             "deps": [
                 {

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -32,7 +32,7 @@
             "sub_dir": "Vulkan-Loader",
             "build_dir": "Vulkan-Loader/build",
             "install_dir": "Vulkan-Loader/build/install",
-            "commit": "v1.3.264",
+            "commit": "d40385b1748ae5270fcab18c5aae1a2e5a301465",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,21 +15,6 @@
 # limitations under the License.
 # ~~~
 
-# On Windows, We only need the .lib to build the repo, but to run tests we need the .dll.
-# Thus, we have to fixup the Vulkan::Vulkan target to contain the correct details.
-if (WIN32)
-    list(APPEND CMAKE_PROGRAM_PATH ${VULKAN_LOADER_INSTALL_DIR})
-
-    find_program(Vulkan_LIBRARY_DLL NAMES vulkan-1.dll)
-    find_library(Vulkan_LIBRARY_IMPLIB NAMES vulkan-1)
-
-    # Change Vulkan::Vulkan's location to vulkan-1.dll and set the IMPLIB to vulkan-1.lib
-    set_target_properties(Vulkan::Vulkan PROPERTIES
-        IMPORTED_LOCATION ${Vulkan_LIBRARY_DLL})
-    set_target_properties(Vulkan::Vulkan PROPERTIES
-        IMPORTED_IMPLIB ${Vulkan_LIBRARY_IMPLIB})
-endif()
-
 # setup binary_locations_$<CONFIG>.h.in using binary_locations.h.in as a source
 file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/binary_locations_$<CONFIG>.h" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/binary_locations.h.in")
 
@@ -57,7 +42,7 @@ get_target_property(TEST_SOURCES vulkan_tools_tests SOURCES)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${TEST_SOURCES})
 
 target_include_directories(vulkan_tools_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(vulkan_tools_tests GTest::gtest Vulkan::Vulkan)
+target_link_libraries(vulkan_tools_tests GTest::gtest Vulkan::Headers Vulkan::Loader)
 add_dependencies(vulkan_tools_tests generate_binary_locations)
 if (WIN32)
     target_compile_definitions(vulkan_tools_tests PUBLIC -DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN -DNOMINMAX)
@@ -72,7 +57,7 @@ endif ()
 if (WIN32)
     # Copy the loader shared lib (if built) to the test application directory so the test app finds it.
     add_custom_command(TARGET vulkan_tools_tests POST_BUILD
-                           COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Vulkan::Vulkan> $<TARGET_FILE_DIR:vulkan_tools_tests>)
+                           COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Vulkan::Loader> $<TARGET_FILE_DIR:vulkan_tools_tests>)
 endif()
 
 include(GoogleTest)

--- a/vulkaninfo/CMakeLists.txt
+++ b/vulkaninfo/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 
 if(APPLE)
     # We do this so vulkaninfo is linked to an individual library and NOT a framework.
-    target_link_libraries(vulkaninfo ${Vulkan_LIBRARY} "-framework AppKit -framework QuartzCore")
+    target_link_libraries(vulkaninfo Vulkan::Loader "-framework AppKit -framework QuartzCore")
     target_include_directories(vulkaninfo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vulkaninfo)
 endif()
 


### PR DESCRIPTION
The Vulkan-Loader now supports find_package properly, allowing this repo to drop
the ad-hoc creation of the Vulkan::Vulkan target.

This allows enabling of tests on windows CI.