### PR TITLE
icd: Add VkSurfacePresentModeCompatibilityEXT support

### DIFF
--- a/icd/generated/function_definitions.h
+++ b/icd/generated/function_definitions.h
@@ -3461,6 +3461,18 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2KHR(
     VkSurfaceCapabilities2KHR*                  pSurfaceCapabilities)
 {
     GetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, pSurfaceInfo->surface, &pSurfaceCapabilities->surfaceCapabilities);
+
+    auto *present_mode_compatibility = lvl_find_mod_in_chain<VkSurfacePresentModeCompatibilityEXT>(pSurfaceCapabilities->pNext);
+    if (present_mode_compatibility) {
+        if (!present_mode_compatibility->pPresentModes) {
+            present_mode_compatibility->presentModeCount = 3;
+        } else {
+            // arbitrary
+            present_mode_compatibility->pPresentModes[0] = VK_PRESENT_MODE_IMMEDIATE_KHR;
+            present_mode_compatibility->pPresentModes[1] = VK_PRESENT_MODE_FIFO_KHR;
+            present_mode_compatibility->pPresentModes[2] = VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR;
+        }
+    }
     return VK_SUCCESS;
 }
 

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -300,6 +300,18 @@ CUSTOM_C_INTERCEPTS = {
 ''',
 'vkGetPhysicalDeviceSurfaceCapabilities2KHR': '''
     GetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, pSurfaceInfo->surface, &pSurfaceCapabilities->surfaceCapabilities);
+
+    auto *present_mode_compatibility = lvl_find_mod_in_chain<VkSurfacePresentModeCompatibilityEXT>(pSurfaceCapabilities->pNext);
+    if (present_mode_compatibility) {
+        if (!present_mode_compatibility->pPresentModes) {
+            present_mode_compatibility->presentModeCount = 3;
+        } else {
+            // arbitrary
+            present_mode_compatibility->pPresentModes[0] = VK_PRESENT_MODE_IMMEDIATE_KHR;
+            present_mode_compatibility->pPresentModes[1] = VK_PRESENT_MODE_FIFO_KHR;
+            present_mode_compatibility->pPresentModes[2] = VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR;
+        }
+    }
     return VK_SUCCESS;
 ''',
 'vkGetInstanceProcAddr': '''


### PR DESCRIPTION
Add support for `VkSurfacePresentModeCompatibilityEXT` which allows Validation Layers to test with `VK_EXT_surface_maintenance1` in CI