### PR TITLE
icd: Add second VkCooperativeMatrixPropertiesKHR field

### DIFF
--- a/icd/generated/function_definitions.h
+++ b/icd/generated/function_definitions.h
@@ -4073,7 +4073,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixProperti
     VkCooperativeMatrixPropertiesKHR*           pProperties)
 {
     if (!pProperties) {
-        *pPropertyCount = 1;
+        *pPropertyCount = 2;
     } else {
         // arbitrary
         pProperties[0].MSize = 16;
@@ -4084,7 +4084,10 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixProperti
         pProperties[0].CType = VK_COMPONENT_TYPE_UINT32_KHR;
         pProperties[0].ResultType = VK_COMPONENT_TYPE_UINT32_KHR;
         pProperties[0].saturatingAccumulation = VK_FALSE;
-        pProperties[0].scope = VK_SCOPE_DEVICE_KHR;
+        pProperties[0].scope = VK_SCOPE_SUBGROUP_KHR;
+
+        pProperties[1] = pProperties[0];
+        pProperties[1].scope = VK_SCOPE_DEVICE_KHR;
     }
     return VK_SUCCESS;
 }

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -968,7 +968,7 @@ CUSTOM_C_INTERCEPTS = {
 ''',
 'vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR': '''
     if (!pProperties) {
-        *pPropertyCount = 1;
+        *pPropertyCount = 2;
     } else {
         // arbitrary
         pProperties[0].MSize = 16;
@@ -979,7 +979,10 @@ CUSTOM_C_INTERCEPTS = {
         pProperties[0].CType = VK_COMPONENT_TYPE_UINT32_KHR;
         pProperties[0].ResultType = VK_COMPONENT_TYPE_UINT32_KHR;
         pProperties[0].saturatingAccumulation = VK_FALSE;
-        pProperties[0].scope = VK_SCOPE_DEVICE_KHR;
+        pProperties[0].scope = VK_SCOPE_SUBGROUP_KHR;
+
+        pProperties[1] = pProperties[0];
+        pProperties[1].scope = VK_SCOPE_DEVICE_KHR;
     }
     return VK_SUCCESS;
 ''',


### PR DESCRIPTION
Most tests will need `VK_SCOPE_SUBGROUP_KHR` support