### PR TITLE
vulkaninfo: Support VK_EXT_surface_maintenance1 properly

### DIFF
--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -3845,24 +3845,18 @@ struct surface_capabilities2_chain {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     VkSurfaceCapabilitiesFullScreenExclusiveEXT SurfaceCapabilitiesFullScreenExclusiveEXT{};
 #endif  // VK_USE_PLATFORM_WIN32_KHR
-    VkSurfacePresentModeCompatibilityEXT SurfacePresentModeCompatibilityEXT{};
-    VkSurfacePresentScalingCapabilitiesEXT SurfacePresentScalingCapabilitiesEXT{};
     VkSurfaceProtectedCapabilitiesKHR SurfaceProtectedCapabilitiesKHR{};
     void initialize_chain() noexcept {
         SharedPresentSurfaceCapabilitiesKHR.sType = VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         SurfaceCapabilitiesFullScreenExclusiveEXT.sType = VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
-        SurfacePresentModeCompatibilityEXT.sType = VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_COMPATIBILITY_EXT;
-        SurfacePresentScalingCapabilitiesEXT.sType = VK_STRUCTURE_TYPE_SURFACE_PRESENT_SCALING_CAPABILITIES_EXT;
         SurfaceProtectedCapabilitiesKHR.sType = VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR;
         std::vector<VkBaseOutStructure*> chain_members;
         chain_members.push_back(reinterpret_cast<VkBaseOutStructure*>(&SharedPresentSurfaceCapabilitiesKHR));
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         chain_members.push_back(reinterpret_cast<VkBaseOutStructure*>(&SurfaceCapabilitiesFullScreenExclusiveEXT));
 #endif  // VK_USE_PLATFORM_WIN32_KHR
-        chain_members.push_back(reinterpret_cast<VkBaseOutStructure*>(&SurfacePresentModeCompatibilityEXT));
-        chain_members.push_back(reinterpret_cast<VkBaseOutStructure*>(&SurfacePresentScalingCapabilitiesEXT));
         chain_members.push_back(reinterpret_cast<VkBaseOutStructure*>(&SurfaceProtectedCapabilitiesKHR));
 
         for(size_t i = 0; i < chain_members.size() - 1; i++){
@@ -5070,18 +5064,6 @@ void chain_iterator_surface_capabilities2(Printer &p, AppInstance &inst, AppGpu 
             p.AddNewline();
         }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
-        if (structure->sType == VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_COMPATIBILITY_EXT &&
-           (inst.CheckExtensionEnabled(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME))) {
-            VkSurfacePresentModeCompatibilityEXT* props = (VkSurfacePresentModeCompatibilityEXT*)structure;
-            DumpVkSurfacePresentModeCompatibilityEXT(p, "VkSurfacePresentModeCompatibilityEXT", *props);
-            p.AddNewline();
-        }
-        if (structure->sType == VK_STRUCTURE_TYPE_SURFACE_PRESENT_SCALING_CAPABILITIES_EXT &&
-           (inst.CheckExtensionEnabled(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME))) {
-            VkSurfacePresentScalingCapabilitiesEXT* props = (VkSurfacePresentScalingCapabilitiesEXT*)structure;
-            DumpVkSurfacePresentScalingCapabilitiesEXT(p, "VkSurfacePresentScalingCapabilitiesEXT", *props);
-            p.AddNewline();
-        }
         if (structure->sType == VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR &&
            (inst.CheckExtensionEnabled(VK_KHR_SURFACE_PROTECTED_CAPABILITIES_EXTENSION_NAME))) {
             VkSurfaceProtectedCapabilitiesKHR* props = (VkSurfaceProtectedCapabilitiesKHR*)structure;

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -631,8 +631,8 @@ struct AppInstance {
     ANativeWindow *window;
 #endif
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
-    struct _screen_context* context;
-    struct _screen_window* window;
+    struct _screen_context *context;
+    struct _screen_window *window;
 #endif
     AppInstance() {
         VkResult dllErr = dll.Initialize();
@@ -811,6 +811,9 @@ struct AppInstance {
                 inst_extensions.push_back(ext.extensionName);
             }
             if (strcmp(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME, ext.extensionName) == 0) {
+                inst_extensions.push_back(ext.extensionName);
+            }
+            if (strcmp(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME, ext.extensionName) == 0) {
                 inst_extensions.push_back(ext.extensionName);
             }
         }
@@ -1237,8 +1240,7 @@ static VkSurfaceKHR AppCreateScreenSurface(AppInstance &inst) {
     return surface;
 }
 
-static void AppDestroyScreenWindow(AppInstance &inst)
-{
+static void AppDestroyScreenWindow(AppInstance &inst) {
     screen_destroy_window(inst.window);
     screen_destroy_context(inst.context);
 }


### PR DESCRIPTION
The struct VkSurfacePresentModeCompatibilityEXT and VkSurfacePresentScalingCapabilitiesEXT can only be included in the VkSurfaceCapabilities2KHR pNext chain if a VkSurfacePresentModeEXT struct is in the pNext chain for VkPhysicalDeviceSurfaceInfo2KHR. In other words, the autogen for this extension is not adequate and needs to be special cased.

This is doubly true because the aformentioned structs are 'per-present-mode' so the output needs to handle printing each struct once per present mode available, which is not possible with autogenerated code currently.

The easiest solution is to just remove the surface_maintenance1 structs from autogen in the pNext chain (but keep the autogenerated printing functions). Then setup the pNext chains appropriate and make the necessary calls, before printing the data directly.

Fixes #846 

Example output:
```
Presentable Surfaces:
=====================
GPU id : 0 (AMD Radeon RX 480 Graphics (RADV POLARIS10)):
        Surface types: count = 2
                VK_KHR_xcb_surface
                VK_KHR_xlib_surface
        Formats: count = 2
                SurfaceFormat[0]:
                        format = FORMAT_B8G8R8A8_SRGB
                        colorSpace = COLOR_SPACE_SRGB_NONLINEAR_KHR
                SurfaceFormat[1]:
                        format = FORMAT_B8G8R8A8_UNORM
                        colorSpace = COLOR_SPACE_SRGB_NONLINEAR_KHR
        Present Modes: count = 4
                PRESENT_MODE_IMMEDIATE_KHR
                PRESENT_MODE_MAILBOX_KHR
                PRESENT_MODE_FIFO_KHR
                PRESENT_MODE_FIFO_RELAXED_KHR
        VkSurfaceCapabilitiesKHR:
        -------------------------
                minImageCount = 3
                maxImageCount = 0
                currentExtent:
                        width  = 256
                        height = 256
                minImageExtent:
                        width  = 256
                        height = 256
                maxImageExtent:
                        width  = 256
                        height = 256
                maxImageArrayLayers = 1
                supportedTransforms: count = 1
                        SURFACE_TRANSFORM_IDENTITY_BIT_KHR
                currentTransform = SURFACE_TRANSFORM_IDENTITY_BIT_KHR
                supportedCompositeAlpha: count = 2
                        COMPOSITE_ALPHA_OPAQUE_BIT_KHR
                        COMPOSITE_ALPHA_INHERIT_BIT_KHR
                supportedUsageFlags: count = 7
                        IMAGE_USAGE_TRANSFER_SRC_BIT
                        IMAGE_USAGE_TRANSFER_DST_BIT
                        IMAGE_USAGE_SAMPLED_BIT
                        IMAGE_USAGE_STORAGE_BIT
                        IMAGE_USAGE_COLOR_ATTACHMENT_BIT
                        IMAGE_USAGE_INPUT_ATTACHMENT_BIT
                        IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT
        VkSurfaceProtectedCapabilitiesKHR:
        ----------------------------------
                supportsProtected = false

        VK_EXT_surface_maintenance_1:
        -----------------------------
                PRESENT_MODE_IMMEDIATE_KHR:
                        VkSurfacePresentScalingCapabilitiesEXT:
                                supportedPresentScaling:
                                        None
                                supportedPresentGravityX:
                                        None
                                supportedPresentGravityY:
                                        None
                                minScaledImageExtent:
                                        width  = 256
                                        height = 256
                                maxScaledImageExtent:
                                        width  = 256
                                        height = 256
                        VkSurfacePresentModeCompatibilityEXT:
                                presentModeCount                = 1
                                pPresentModes: count = 1
                                        pPresentModes = PRESENT_MODE_IMMEDIATE_KHR
                PRESENT_MODE_MAILBOX_KHR:
                        VkSurfacePresentScalingCapabilitiesEXT:
                                supportedPresentScaling:
                                        None
                                supportedPresentGravityX:
                                        None
                                supportedPresentGravityY:
                                        None
                                minScaledImageExtent:
                                        width  = 256
                                        height = 256
                                maxScaledImageExtent:
                                        width  = 256
                                        height = 256
                        VkSurfacePresentModeCompatibilityEXT:
                                presentModeCount                = 1
                                pPresentModes: count = 1
                                        pPresentModes = PRESENT_MODE_MAILBOX_KHR
                PRESENT_MODE_FIFO_KHR:
                        VkSurfacePresentScalingCapabilitiesEXT:
                                supportedPresentScaling:
                                        None
                                supportedPresentGravityX:
                                        None
                                supportedPresentGravityY:
                                        None
                                minScaledImageExtent:
                                        width  = 256
                                        height = 256
                                maxScaledImageExtent:
                                        width  = 256
                                        height = 256
                        VkSurfacePresentModeCompatibilityEXT:
                                presentModeCount                = 1
                                pPresentModes: count = 1
                                        pPresentModes = PRESENT_MODE_FIFO_KHR
                PRESENT_MODE_FIFO_RELAXED_KHR:
                        VkSurfacePresentScalingCapabilitiesEXT:
                                supportedPresentScaling:
                                        None
                                supportedPresentGravityX:
                                        None
                                supportedPresentGravityY:
                                        None
                                minScaledImageExtent:
                                        width  = 256
                                        height = 256
                                maxScaledImageExtent:
                                        width  = 256
                                        height = 256
                        VkSurfacePresentModeCompatibilityEXT:
                                presentModeCount                = 1
                                pPresentModes: count = 1
                                        pPresentModes = PRESENT_MODE_FIFO_RELAXED_KHR
```