### PR TITLE
icd: Add VkPhysicalDeviceDriverProperties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,27 @@ endif()
 # Default to using the static CRT
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
+# Find the Git branch & tag info for use in Mock ICD
+find_package (Git)
+if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git/HEAD")
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --always
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        OUTPUT_VARIABLE GIT_TAG_INFO)
+    string(REGEX REPLACE "\n$" "" GIT_TAG_INFO "${GIT_TAG_INFO}")
+
+    file(READ "${CMAKE_CURRENT_LIST_DIR}/.git/HEAD" GIT_HEAD_REF_INFO)
+    if (GIT_HEAD_REF_INFO)
+        string(REGEX MATCH "ref: refs/heads/(.*)" _ ${GIT_HEAD_REF_INFO})
+        if (CMAKE_MATCH_1)
+            set(GIT_BRANCH_NAME ${CMAKE_MATCH_1})
+        else()
+            set(GIT_BRANCH_NAME ${GIT_HEAD_REF_INFO})
+        endif()
+        string(REGEX REPLACE "\n$" "" GIT_BRANCH_NAME "${GIT_BRANCH_NAME}")
+    endif()
+endif()
+
 if(APPLE)
     include(mac_common.cmake)
 endif()

--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -85,6 +85,10 @@ endif()
 
 set_target_properties(VkICD_mock_icd PROPERTIES OUTPUT_NAME ${MOCK_ICD_NAME})
 
+if (DEFINED GIT_BRANCH_NAME AND DEFINED GIT_TAG_INFO)
+    target_compile_definitions(VkICD_mock_icd PRIVATE GIT_BRANCH_NAME="${GIT_BRANCH_NAME}" GIT_TAG_INFO="${GIT_TAG_INFO}")
+endif()
+
 # Installing the Mock ICD to system directories is probably not desired since this ICD is not a very complete implementation.
 # Require the user to ask that it be installed if they really want it.
 option(INSTALL_ICD "Install icd")

--- a/icd/generated/function_declarations.h
+++ b/icd/generated/function_declarations.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <cstring>
 #include <string>
 #include <unordered_map>
 #include <vulkan/vulkan.h>

--- a/icd/generated/function_definitions.h
+++ b/icd/generated/function_definitions.h
@@ -3008,7 +3008,7 @@ static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2KHR(
        VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
     };
 
-    auto *host_image_copy_props = lvl_find_mod_in_chain< VkPhysicalDeviceHostImageCopyPropertiesEXT>(pProperties->pNext);
+    auto *host_image_copy_props = lvl_find_mod_in_chain<VkPhysicalDeviceHostImageCopyPropertiesEXT>(pProperties->pNext);
     if (host_image_copy_props){
         if (host_image_copy_props->pCopyDstLayouts == nullptr) host_image_copy_props->copyDstLayoutCount = num_copy_layouts;
         else {
@@ -3024,6 +3024,16 @@ static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2KHR(
                 host_image_copy_props->pCopySrcLayouts[i] = HostCopyLayouts[i];
             }
         }
+    }
+
+    auto *driver_properties = lvl_find_mod_in_chain<VkPhysicalDeviceDriverProperties>(pProperties->pNext);
+    if (driver_properties) {
+        std::strncpy(driver_properties->driverName, "Vulkan Mock Device", VK_MAX_DRIVER_NAME_SIZE);
+#if defined(GIT_BRANCH_NAME) && defined(GIT_TAG_INFO)
+        std::strncpy(driver_properties->driverInfo, "Branch: " GIT_BRANCH_NAME " Tag Info: " GIT_TAG_INFO, VK_MAX_DRIVER_INFO_SIZE);
+#else
+        std::strncpy(driver_properties->driverInfo, "Branch: --unknown-- Tag Info: --unknown--", VK_MAX_DRIVER_INFO_SIZE);
+#endif
     }
 }
 

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -603,7 +603,7 @@ CUSTOM_C_INTERCEPTS = {
        VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
     };
 
-    auto *host_image_copy_props = lvl_find_mod_in_chain< VkPhysicalDeviceHostImageCopyPropertiesEXT>(pProperties->pNext);
+    auto *host_image_copy_props = lvl_find_mod_in_chain<VkPhysicalDeviceHostImageCopyPropertiesEXT>(pProperties->pNext);
     if (host_image_copy_props){
         if (host_image_copy_props->pCopyDstLayouts == nullptr) host_image_copy_props->copyDstLayoutCount = num_copy_layouts;
         else {
@@ -619,6 +619,16 @@ CUSTOM_C_INTERCEPTS = {
                 host_image_copy_props->pCopySrcLayouts[i] = HostCopyLayouts[i];
             }
         }
+    }
+
+    auto *driver_properties = lvl_find_mod_in_chain<VkPhysicalDeviceDriverProperties>(pProperties->pNext);
+    if (driver_properties) {
+        std::strncpy(driver_properties->driverName, "Vulkan Mock Device", VK_MAX_DRIVER_NAME_SIZE);
+#if defined(GIT_BRANCH_NAME) && defined(GIT_TAG_INFO)
+        std::strncpy(driver_properties->driverInfo, "Branch: " GIT_BRANCH_NAME " Tag Info: " GIT_TAG_INFO, VK_MAX_DRIVER_INFO_SIZE);
+#else
+        std::strncpy(driver_properties->driverInfo, "Branch: --unknown-- Tag Info: --unknown--", VK_MAX_DRIVER_INFO_SIZE);
+#endif
     }
 ''',
 'vkGetPhysicalDeviceExternalSemaphoreProperties':'''
@@ -1224,6 +1234,7 @@ class MockICDOutputGenerator(OutputGenerator):
                                 break
             write('#pragma once\n',file=self.outFile)
             write('#include <stdint.h>',file=self.outFile)
+            write('#include <cstring>',file=self.outFile)
             write('#include <string>',file=self.outFile)
             write('#include <unordered_map>',file=self.outFile)
             write('#include <vulkan/vulkan.h>',file=self.outFile)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,10 @@ if (WIN32)
 endif()
 set_target_properties(vulkan_tools_tests PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
+if (DEFINED GIT_BRANCH_NAME AND DEFINED GIT_TAG_INFO)
+    target_compile_definitions(vulkan_tools_tests PRIVATE GIT_BRANCH_NAME="${GIT_BRANCH_NAME}" GIT_TAG_INFO="${GIT_TAG_INFO}")
+endif()
+
 if (ENABLE_ADDRESS_SANITIZER)
     target_compile_options(vulkan_tools_tests PUBLIC -fsanitize=address)
     target_link_options(vulkan_tools_tests PUBLIC -fsanitize=address)

--- a/tests/icd/mock_icd_tests.cpp
+++ b/tests/icd/mock_icd_tests.cpp
@@ -569,8 +569,12 @@ TEST_F(MockICD, vkGetPhysicalDeviceProperties2) {
     fragment_density_map2_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT;
     fragment_density_map2_properties.pNext = static_cast<void*>(&mesh_shader_properties);
 
+    VkPhysicalDeviceDriverProperties driver_properties{};
+    driver_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES;
+    driver_properties.pNext = static_cast<void*>(&fragment_density_map2_properties);
+
     VkPhysicalDeviceProperties2 properties2{};
-    properties2.pNext = static_cast<void*>(&fragment_density_map2_properties);
+    properties2.pNext = static_cast<void*>(&driver_properties);
     vkGetPhysicalDeviceProperties2(physical_device, &properties2);
     ASSERT_EQ(properties2.properties.apiVersion, VK_HEADER_VERSION_COMPLETE);
     ASSERT_EQ(properties2.properties.driverVersion, 1);
@@ -624,6 +628,8 @@ TEST_F(MockICD, vkGetPhysicalDeviceProperties2) {
     ASSERT_EQ(fragment_density_map2_properties.subsampledCoarseReconstructionEarlyAccess, VK_FALSE);
     ASSERT_EQ(fragment_density_map2_properties.maxSubsampledArrayLayers, 2);
     ASSERT_EQ(fragment_density_map2_properties.maxDescriptorSetSubsampledSamplers, 1);
+    ASSERT_EQ(std::string(driver_properties.driverName), "Vulkan Mock Device");
+    ASSERT_EQ(std::string(driver_properties.driverInfo), "Branch: " GIT_BRANCH_NAME " Tag Info: " GIT_TAG_INFO);
 }
 
 TEST_F(MockICD, vkGetPhysicalDeviceExternalSemaphoreProperties) {


### PR DESCRIPTION
This commit adds support for the VkPhysicalDeviceDriverProperties struct in the output of vkGetPhysicalDeviceProperties2. This is useful for users of Mock ICD wishing to know the version of MockICD used. The driverInfo field is used for this purpose and contains the git branch & tag info data. The use of Git in CMake is how the information is seamlessly gotten and provided to the source code in the form of compile definitions.

Fixes #788 