### PR TITLE
cmake: General cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@
 # limitations under the License.
 # ~~~
 cmake_minimum_required(VERSION 3.17.2)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 project(Vulkan-Tools)
 
@@ -25,19 +26,10 @@ set(API_TYPE "vulkan")
 
 add_subdirectory(scripts)
 
-# User-interface declarations ----------------------------------------------------------------------------------------------------
-# This section contains variables that affect development GUIs (e.g. CMake GUI and IDEs), such as option(), folders, and variables
-# with the CACHE property.
-
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-
 option(BUILD_CUBE "Build cube" ON)
 option(BUILD_VULKANINFO "Build vulkaninfo" ON)
 option(BUILD_ICD "Build icd" ON)
-
-if (UNIX AND NOT APPLE) # i.e. Linux
-    option(ENABLE_ADDRESS_SANITIZER "Use addres sanitization" OFF)
-endif()
+option(ENABLE_ADDRESS_SANITIZER "Use address sanitization")
 
 if(WIN32)
     # Optional: Allow specify the exact version used in the vulkaninfo executable

--- a/cube/CMakeLists.txt
+++ b/cube/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CUBE_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
 set(SCRIPTS_DIR "${PROJECT_SOURCE_DIR}/scripts")
 
 
-if(UNIX AND NOT APPLE) # i.e. Linux
+if (CMAKE_SYSTEM_NAME MATCHES "Linux|BSD")
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
     option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
     option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
@@ -97,7 +97,7 @@ elseif(ANDROID)
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
 elseif(APPLE)
     add_definitions(-DVK_USE_PLATFORM_METAL_EXT)
-elseif(UNIX AND NOT APPLE) # i.e. Linux
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|BSD")
     if(NOT CUBE_WSI_SELECTION)
         set(CUBE_WSI_SELECTION "XCB")
     endif()
@@ -199,12 +199,6 @@ elseif(NOT WIN32)
         target_link_options(vkcube PUBLIC -fsanitize=address)
     endif ()
 else()
-    if(CMAKE_CL_64)
-        set(LIB_DIR "Win64")
-    else()
-        set(LIB_DIR "Win32")
-    endif()
-
     add_executable(vkcube
                    WIN32
                    cube.c
@@ -225,7 +219,7 @@ if(APPLE)
         fixup_bundle(\${CMAKE_INSTALL_PREFIX}/cube/vkcube.app \"\" \"${Vulkan_LIBRARY_DIR}\")
         ")
 else()
-    install(TARGETS vkcube RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(TARGETS vkcube)
 endif()
 
 # ----------------------------------------------------------------------------
@@ -249,12 +243,6 @@ elseif(NOT WIN32)
         target_link_options(vkcubepp PUBLIC -fsanitize=address)
     endif ()
 else()
-    if(CMAKE_CL_64)
-        set(LIB_DIR "Win64")
-    else()
-        set(LIB_DIR "Win32")
-    endif()
-
     add_executable(vkcubepp
                    WIN32
                    cube.cpp
@@ -275,13 +263,13 @@ if(APPLE)
         fixup_bundle(\${CMAKE_INSTALL_PREFIX}/cube/vkcubepp.app \"\" \"${Vulkan_LIBRARY_DIR}\")
         ")
 else()
-    install(TARGETS vkcubepp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(TARGETS vkcubepp)
 endif()
 
 # ----------------------------------------------------------------------------
 # vkcube-wayland
 
-if(UNIX AND NOT APPLE) # i.e. Linux
+if (CMAKE_SYSTEM_NAME MATCHES "Linux|BSD")
     if(BUILD_WSI_WAYLAND_SUPPORT AND EXISTS ${WAYLAND_PROTOCOLS_PATH}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml)
         set(CUBE_INCLUDE_DIRS ${WAYLAND_CLIENT_INCLUDE_DIR} ${CUBE_INCLUDE_DIRS})
         link_libraries(${WAYLAND_CLIENT_LIBRARIES})
@@ -305,7 +293,7 @@ if(UNIX AND NOT APPLE) # i.e. Linux
         if (NEED_RT)
             target_link_libraries(vkcube-wayland rt)
         endif()
-        install(TARGETS vkcube-wayland RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+        install(TARGETS vkcube-wayland)
 
         if (ENABLE_ADDRESS_SANITIZER)
             target_compile_options(vkcube-wayland PUBLIC -fsanitize=address)

--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -29,7 +29,7 @@ if(WIN32)
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DVK_USE_PLATFORM_WIN32_KHX -DWIN32_LEAN_AND_MEAN)
 elseif(APPLE)
     add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
-elseif(UNIX AND NOT APPLE) # i.e. Linux
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|BSD")
     if(BUILD_WSI_XCB_SUPPORT)
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR -DVK_USE_PLATFORM_XCB_KHX)
     endif()

--- a/vulkaninfo/CMakeLists.txt
+++ b/vulkaninfo/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 
 target_compile_definitions(vulkaninfo PRIVATE -DVK_ENABLE_BETA_EXTENSIONS)
 
-if(UNIX AND NOT APPLE) # i.e. Linux
+if (CMAKE_SYSTEM_NAME MATCHES "Linux|BSD")
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
     option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
     option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
@@ -97,8 +97,8 @@ if(UNIX AND NOT APPLE) # i.e. Linux
     endif()
 
     if (ENABLE_ADDRESS_SANITIZER)
-        target_compile_options(vulkaninfo PUBLIC -fsanitize=address)
-        target_link_options(vulkaninfo PUBLIC -fsanitize=address)
+        target_compile_options(vulkaninfo PRIVATE -fsanitize=address)
+        target_link_options(vulkaninfo PRIVATE -fsanitize=address)
     endif ()
 endif()
 
@@ -111,22 +111,27 @@ endif()
 target_link_libraries(vulkaninfo Vulkan::Headers)
 
 if(WIN32)
-    target_compile_definitions(vulkaninfo PUBLIC -DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN -D_CRT_SECURE_NO_WARNINGS -DVK_NO_PROTOTYPES)
-    if(MSVC AND NOT MSVC_VERSION LESS 1900)
-        # If MSVC, Enable control flow guard
-        message(STATUS "Building vulkaninfo with control flow guard")
-        add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/guard:cf>")
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf")
-    endif()
+    target_compile_definitions(vulkaninfo PRIVATE 
+        VK_USE_PLATFORM_WIN32_KHR
+        WIN32_LEAN_AND_MEAN
+        _CRT_SECURE_NO_WARNINGS
+        VK_NO_PROTOTYPES
+    )
+
+    message(STATUS "Building vulkaninfo with control flow guard")
+    target_compile_options(vulkaninfo PRIVATE /guard:cf)
+    target_link_options(vulkaninfo PRIVATE /guard:cf)
 
 elseif(APPLE)
-    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK -DVK_USE_PLATFORM_METAL_EXT)
+    target_compile_definitions(vulkaninfo PRIVATE
+        VK_USE_PLATFORM_MACOS_MVK
+        VK_USE_PLATFORM_METAL_EXT
+    )
 endif()
 
 if(APPLE)
     install(TARGETS vulkaninfo RUNTIME DESTINATION "vulkaninfo")
 else()
-    install(TARGETS vulkaninfo RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(TARGETS vulkaninfo)
 endif()
 


### PR DESCRIPTION
- APPEND CMAKE_MODULE_PATH
- Remove overly specific CMake code
- Use CMAKE_SYSTEM_NAME to detect Linux/BSD
- Remove unused code
- Simplify install target code
- Use PRIVATE instead of PUBLIC
- Prefer target based commands