### PR TITLE
cmake: Upgrade to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,17 @@ set(API_TYPE "vulkan")
 
 add_subdirectory(scripts)
 
+set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+set(CMAKE_C_VISIBILITY_PRESET "hidden")
+set(CMAKE_VISIBILITY_INLINES_HIDDEN "YES")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 option(BUILD_CUBE "Build cube" ON)
 option(BUILD_VULKANINFO "Build vulkaninfo" ON)
 option(BUILD_ICD "Build icd" ON)
@@ -61,42 +72,37 @@ endif()
 
 include(GNUInstallDirs)
 
+# TODO: Should be OFF by default.
 option(BUILD_WERROR "Treat compiler warnings as errors" ON)
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-    set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers")
-    set(COMMON_COMPILE_FLAGS "${COMMON_COMPILE_FLAGS} -fno-strict-aliasing -fno-builtin-memcmp")
+if (BUILD_WERROR)
+    add_compile_options("$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>")
+endif()
 
-    if(MAKE_C_COMPILER_ID MATCHES "Clang")
-        set(COMMON_COMPILE_FLAGS "${COMMON_COMPILE_FLAGS} -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-string-conversion -Wno-implicit-in-conversion -Wno-enum-enum-conversion")
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
+    add_compile_options(
+        -Wall
+        -Wextra
+        -Wno-unused-parameter
+        -Wno-missing-field-initializers
+        -fno-strict-aliasing
+        -fno-builtin-memcmp
+    )
+
+    if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+        add_compile_options(-Wno-stringop-truncation)
     endif()
 
-    if(BUILD_WERROR)
-        if((CMAKE_COMPILER_IS_GNUCXX AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.3.0)) OR
-          (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0.0)))
-          set(COMMON_COMPILE_FLAGS "${COMMON_COMPILE_FLAGS} -Werror")
-        endif()
-    endif()
-
-    # For GCC version 7.1 or greater, we need to disable the implicit fallthrough warning since there's no consistent way to satisfy
-    # all compilers until they all accept the C++17 standard
-    if(CMAKE_COMPILER_IS_GNUCC AND NOT (CMAKE_CXX_COMPILER_VERSION LESS 7.1))
-        set(COMMON_COMPILE_FLAGS "${COMMON_COMPILE_FLAGS} -Wimplicit-fallthrough=0")
-    endif()
-
-    if(APPLE)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_COMPILE_FLAGS}")
-    else()
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 ${COMMON_COMPILE_FLAGS}")
-    endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_COMPILE_FLAGS} -std=c++14 -fno-rtti")
-    if(UNIX)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
+    if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+        add_compile_options(
+            -Wno-sign-conversion
+            -Wno-shorten-64-to-32
+            -Wno-string-conversion
+            -Wno-implicit-int-conversion
+            -Wno-enum-enum-conversion
+        )
     endif()
 elseif(MSVC)
-    if(BUILD_WERROR)
-        add_compile_options("/WX")
-    endif()
+    # TODO: Update to /W4
     add_compile_options("/W3")
     # Warn about nested declarations
     add_compile_options("/w34456")

--- a/cube/android/jni/Application.mk
+++ b/cube/android/jni/Application.mk
@@ -17,6 +17,4 @@ APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_PLATFORM := android-23
 APP_STL := c++_static
 APP_MODULES := VkCube
-APP_CPPFLAGS += -std=c++11 -fexceptions -Wall -Werror -Wextra -Wno-unused-parameter -DVK_NO_PROTOTYES -DGLM_FORCE_RADIANS
-APP_CFLAGS += -Wall -Werror -Wextra -Wno-unused-parameter -DVK_NO_PROTOTYES -DGLM_FORCE_RADIANS
 NDK_TOOLCHAIN_VERSION := clang

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -664,7 +664,8 @@ void Demo::destroy_texture(texture_object &tex_objs) {
 
 void Demo::draw() {
     // Ensure no more than FRAME_LAG renderings are outstanding
-    device.waitForFences(fences[frame_index], VK_TRUE, UINT64_MAX);
+    const vk::Result wait_result = device.waitForFences(fences[frame_index], VK_TRUE, UINT64_MAX);
+    VERIFY(wait_result == vk::Result::eSuccess || wait_result == vk::Result::eTimeout);
     device.resetFences({fences[frame_index]});
 
     vk::Result acquire_result;


### PR DESCRIPTION
Addresses various other issues with setting compiler flags.

CMAKE_C_FLAGS / CMAKE_CXX_FLAGS should NOT be used anymore.

Addressed one minor C++17 issue caused by [[nodiscard]].

Remove compiler flags from Application.mk since they weren't needed and will soon be entirely replaced by CMake.

closes #711