### PR TITLE
vulkaninfo: Remove install for appbundle

### DIFF
--- a/vulkaninfo/CMakeLists.txt
+++ b/vulkaninfo/CMakeLists.txt
@@ -128,9 +128,4 @@ elseif(APPLE)
     )
 endif()
 
-if(APPLE)
-    install(TARGETS vulkaninfo RUNTIME DESTINATION "vulkaninfo")
-else()
-    install(TARGETS vulkaninfo)
-endif()
-
+install(TARGETS vulkaninfo)


### PR DESCRIPTION
Not needed

FYI @mikes-lunarg who removed this in this commit: https://github.com/KhronosGroup/Vulkan-Tools/pull/723