### PR TITLE
icd: Add vkGetMemoryFdKHR support

### DIFF
--- a/icd/generated/function_definitions.h
+++ b/icd/generated/function_definitions.h
@@ -3201,7 +3201,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHR(
     const VkMemoryGetFdInfoKHR*                 pGetFdInfo,
     int*                                        pFd)
 {
-//Not a CREATE or DESTROY function
+    *pFd = 1;
     return VK_SUCCESS;
 }
 

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -1056,6 +1056,10 @@ CUSTOM_C_INTERCEPTS = {
     pGranularity->width = 1;
     pGranularity->height = 1;
 ''',
+'vkGetMemoryFdKHR': '''
+    *pFd = 1;
+    return VK_SUCCESS;
+''',
 'vkGetAndroidHardwareBufferPropertiesANDROID': '''
     pProperties->allocationSize = 65536;
     pProperties->memoryTypeBits = 1 << 5; // DEVICE_LOCAL only type


### PR DESCRIPTION
Allows MockICD test to return a non-negative `fd` for `vkGetMemoryFdKHR`