### PR TITLE
icd: Add vkGetMemoryHostPointerPropertiesEXT support

### DIFF
--- a/icd/generated/function_definitions.h
+++ b/icd/generated/function_definitions.h
@@ -5095,7 +5095,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetMemoryHostPointerPropertiesEXT(
     const void*                                 pHostPointer,
     VkMemoryHostPointerPropertiesEXT*           pMemoryHostPointerProperties)
 {
-//Not a CREATE or DESTROY function
+    pMemoryHostPointerProperties->memoryTypeBits = 1 << 5; // DEVICE_LOCAL only type
     return VK_SUCCESS;
 }
 

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -1060,6 +1060,10 @@ CUSTOM_C_INTERCEPTS = {
     *pFd = 1;
     return VK_SUCCESS;
 ''',
+'vkGetMemoryHostPointerPropertiesEXT': '''
+    pMemoryHostPointerProperties->memoryTypeBits = 1 << 5; // DEVICE_LOCAL only type
+    return VK_SUCCESS;
+''',
 'vkGetAndroidHardwareBufferPropertiesANDROID': '''
     pProperties->allocationSize = 65536;
     pProperties->memoryTypeBits = 1 << 5; // DEVICE_LOCAL only type


### PR DESCRIPTION
add `vkGetMemoryHostPointerPropertiesEXT` to return a valid memory type for `VK_EXT_external_memory_host` tests