### PR TITLE
icd: Unmap mapped memory before freeing it

### DIFF
--- a/icd/generated/function_definitions.h
+++ b/icd/generated/function_definitions.h
@@ -403,6 +403,7 @@ static VKAPI_ATTR void VKAPI_CALL FreeMemory(
     const VkAllocationCallbacks*                pAllocator)
 {
 //Destroy object
+    UnmapMemory(device, memory);
     unique_lock_t lock(global_lock);
     allocated_memory_size_map.erase(memory);
 }

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -1497,6 +1497,8 @@ class MockICDOutputGenerator(OutputGenerator):
         elif True in [ftxt in api_function_name for ftxt in ['Destroy', 'Free']]:
             self.appendSection('command', '//Destroy object')
             if 'FreeMemory' in api_function_name:
+                # If the memory is mapped, unmap it
+                self.appendSection('command', '    UnmapMemory(device, memory);')
                 # Remove from allocation map
                 self.appendSection('command', '    unique_lock_t lock(global_lock);')
                 self.appendSection('command', '    allocated_memory_size_map.erase(memory);')


### PR DESCRIPTION
### Bug description

According to the [Vulkan specification](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkFreeMemory),

> If a memory object is mapped at the time it is freed, it is implicitly unmapped.

However, the mock ICD does not perform any such unmapping in its implementation of `vkFreeMemory`. This can cause the mapped memory to leak if the client application relies on the implicit behavior and foregoes making its own explicit calls.

### Fix

Add a call to `UnmapMemory` at the start of `FreeMemory`.

One point of concern may be the related [requirement on `vkUnmapMemory`](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkUnmapMemory-memory-00689) that "memory must be currently host mapped", meaning that for unmapped memory the call is technically invalid, but the current implementation makes it safe.

### Background

For reference, this arose as a significant issue when using the mock ICD as a driver for an Unreal Engine 4.26 application. It seems that UE's Vulkan RHI doesn't bother to unmap memory before freeing it.