### PR TITLE
[scripts] [gn] Fix Python 3.12 compatibility

### DIFF
--- a/scripts/gn/generate_vulkan_icd_json.py
+++ b/scripts/gn/generate_vulkan_icd_json.py
@@ -28,7 +28,7 @@ import platform
 import sys
 
 def glob_slash(dirname):
-    """Like regular glob but replaces \ with / in returned paths."""
+    r"""Like regular glob but replaces \ with / in returned paths."""
     return [s.replace('\\', '/') for s in glob.glob(dirname)]
 
 def main():


### PR DESCRIPTION
generate_vulkan_icd_json.py:31: SyntaxWarning: invalid escape sequence'\ '
  """Like regular glob but replaces \ with / in returned paths."""