### PR TITLE
vulkaninfo: Add minImageCount/maxImageCount to VK_EXT_surface_maintenance1

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -206,6 +206,10 @@ void DumpSurfaceCapabilities(Printer &p, AppInstance &inst, AppGpu &gpu, AppSurf
 
             if (err == VK_SUCCESS) {
                 ObjectWrapper present_mode_obj(p, VkPresentModeKHRString(mode));
+
+                p.PrintKeyValue("minImageCount", surface_caps2.surfaceCapabilities.minImageCount);
+                p.PrintKeyValue("maxImageCount", surface_caps2.surfaceCapabilities.maxImageCount);
+                
                 DumpVkSurfacePresentScalingCapabilitiesEXT(p, "VkSurfacePresentScalingCapabilitiesEXT",
                                                            SurfacePresentScalingCapabilitiesEXT);
                 DumpVkSurfacePresentModeCompatibilityEXT(p, "VkSurfacePresentModeCompatibilityEXT",


### PR DESCRIPTION
This information from VkSurfaceCapabilitiesKHR is explicitly called out in the VK_EXT_surface_maintenance1 extension specification as something which will change based on the present mode used. It would be helpful for vulkaninfo to report it as such.