### PR TITLE
icd: Add special fault injection logic

### DIFF
--- a/icd/generated/function_definitions.h
+++ b/icd/generated/function_definitions.h
@@ -377,7 +377,14 @@ static VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(
     const VkSubmitInfo*                         pSubmits,
     VkFence                                     fence)
 {
-//Not a CREATE or DESTROY function
+    // Special way to cause DEVICE_LOST
+    // Picked VkExportFenceCreateInfo because needed some struct that wouldn't get cleared by validation Safe Struct
+    // ... TODO - It would be MUCH nicer to have a layer or other setting control when this occured
+    // For now this is used to allow Validation Layers test reacting to device losts
+    auto pNext = reinterpret_cast<const VkBaseInStructure *>(pSubmits[0].pNext);
+    if (pNext && pNext->sType == VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO && pNext->pNext == nullptr) {
+        return VK_ERROR_DEVICE_LOST;
+    }
     return VK_SUCCESS;
 }
 

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -1654,6 +1654,17 @@ CUSTOM_C_INTERCEPTS = {
     *pFence = (VkFence)global_unique_handle++;
     return VK_SUCCESS;
 ''',
+'vkQueueSubmit': '''
+    // Special way to cause DEVICE_LOST
+    // Picked VkExportFenceCreateInfo because needed some struct that wouldn't get cleared by validation Safe Struct
+    // ... TODO - It would be MUCH nicer to have a layer or other setting control when this occured
+    // For now this is used to allow Validation Layers test reacting to device losts
+    auto pNext = reinterpret_cast<const VkBaseInStructure *>(pSubmits[0].pNext);
+    if (pNext && pNext->sType == VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO && pNext->pNext == nullptr) {
+        return VK_ERROR_DEVICE_LOST;
+    }
+    return VK_SUCCESS;
+''',
 }
 
 # MockICDGeneratorOptions - subclass of GeneratorOptions.


### PR DESCRIPTION
This is needed so we can test and catch regressions for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6310

I really don't like this PR, but the amount of time it will take to get a proper "fault injection layer" or "Set the return value for MockICD for each function" is higher then what the ROI is currently.

I will be MORE than happy to remove this code in the future for anything better, but for now it serves a purpose and improves validation layer testing coverage