### PR TITLE
vulkaninfo: Don't print HostImageCopyProperites in Profiles

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -209,7 +209,7 @@ void DumpSurfaceCapabilities(Printer &p, AppInstance &inst, AppGpu &gpu, AppSurf
 
                 p.PrintKeyValue("minImageCount", surface_caps2.surfaceCapabilities.minImageCount);
                 p.PrintKeyValue("maxImageCount", surface_caps2.surfaceCapabilities.maxImageCount);
-                
+
                 DumpVkSurfacePresentScalingCapabilitiesEXT(p, "VkSurfacePresentScalingCapabilitiesEXT",
                                                            SurfacePresentScalingCapabilitiesEXT);
                 DumpVkSurfacePresentModeCompatibilityEXT(p, "VkSurfacePresentModeCompatibilityEXT",
@@ -700,7 +700,6 @@ void DumpGpuProfileCapabilities(Printer &p, AppGpu &gpu) {
             if (gpu.inst.CheckExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
                 void *place = gpu.props2.pNext;
                 chain_iterator_phys_device_props2(p, gpu.inst, gpu, place);
-                GetAndDumpHostImageCopyPropertiesEXT(p, gpu);
             }
         }
         {


### PR DESCRIPTION
The JSON format doesn't contain it so it shouldn't be included.