### PR TITLE
icd: Add external memory properties

### DIFF
--- a/icd/generated/function_definitions.h
+++ b/icd/generated/function_definitions.h
@@ -3586,9 +3586,8 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2KHR
 {
     auto *external_image_prop = lvl_find_mod_in_chain<VkExternalImageFormatProperties>(pImageFormatProperties->pNext);
     auto *external_image_format = lvl_find_in_chain<VkPhysicalDeviceExternalImageFormatInfo>(pImageFormatInfo->pNext);
-    if (external_image_prop && external_image_format && external_image_format->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) {
+    if (external_image_prop && external_image_format) {
         external_image_prop->externalMemoryProperties.externalMemoryFeatures = VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT;
-        external_image_prop->externalMemoryProperties.compatibleHandleTypes = external_image_format->handleType;
         external_image_prop->externalMemoryProperties.compatibleHandleTypes = external_image_format->handleType;
     }
 
@@ -3757,7 +3756,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandlePropertiesKHR(
     HANDLE                                      handle,
     VkMemoryWin32HandlePropertiesKHR*           pMemoryWin32HandleProperties)
 {
-//Not a CREATE or DESTROY function
+    pMemoryWin32HandleProperties->memoryTypeBits = 0xFFFF;
     return VK_SUCCESS;
 }
 #endif /* VK_USE_PLATFORM_WIN32_KHR */

--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -531,9 +531,8 @@ CUSTOM_C_INTERCEPTS = {
 'vkGetPhysicalDeviceImageFormatProperties2KHR': '''
     auto *external_image_prop = lvl_find_mod_in_chain<VkExternalImageFormatProperties>(pImageFormatProperties->pNext);
     auto *external_image_format = lvl_find_in_chain<VkPhysicalDeviceExternalImageFormatInfo>(pImageFormatInfo->pNext);
-    if (external_image_prop && external_image_format && external_image_format->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) {
+    if (external_image_prop && external_image_format) {
         external_image_prop->externalMemoryProperties.externalMemoryFeatures = VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT;
-        external_image_prop->externalMemoryProperties.compatibleHandleTypes = external_image_format->handleType;
         external_image_prop->externalMemoryProperties.compatibleHandleTypes = external_image_format->handleType;
     }
 
@@ -1667,6 +1666,10 @@ CUSTOM_C_INTERCEPTS = {
     }
     return VK_SUCCESS;
 ''',
+'vkGetMemoryWin32HandlePropertiesKHR': '''
+    pMemoryWin32HandleProperties->memoryTypeBits = 0xFFFF;
+    return VK_SUCCESS;
+'''
 }
 
 # MockICDGeneratorOptions - subclass of GeneratorOptions.


### PR DESCRIPTION
Updates external memory properties to be able to write tests for: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7790

Tested with VVL here: https://github.com/artem-lunarg/Vulkan-ValidationLayers/commits/artem-test-mock/
