### PR TITLE
cube: Make Volk requirement explicit

### DIFF
--- a/cube/CMakeLists.txt
+++ b/cube/CMakeLists.txt
@@ -259,7 +259,6 @@ else()
 endif()
 
 target_include_directories(vkcube PRIVATE .)
-target_compile_definitions(vkcube PRIVATE VK_NO_PROTOTYPES)
 
 if (ANDROID)
     install(TARGETS vkcube DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -307,7 +306,6 @@ else()
     target_link_libraries(vkcubepp Vulkan::Headers volk::volk_headers)
 endif()
 target_include_directories(vkcubepp PRIVATE .)
-target_compile_definitions(vkcubepp PRIVATE VK_NO_PROTOTYPES)
 
 if(APPLE)
     install(
@@ -351,7 +349,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux|BSD")
             Threads::Threads
             PkgConfig::WAYLAND_CLIENT
         )
-        target_compile_definitions(vkcube-wayland PRIVATE VK_USE_PLATFORM_WAYLAND_KHR VK_NO_PROTOTYPES)
+        target_compile_definitions(vkcube-wayland PRIVATE VK_USE_PLATFORM_WAYLAND_KHR)
         include(CheckLibraryExists)
         CHECK_LIBRARY_EXISTS("rt" clock_gettime "" NEED_RT)
         if (NEED_RT)

--- a/cube/cube.c
+++ b/cube/cube.c
@@ -49,6 +49,8 @@
 #define APP_NAME_STR_LEN 80
 #endif  // _WIN32
 
+// Volk requires VK_NO_PROTOTYPES before including vulkan.h
+#define VK_NO_PROTOTYPES
 #include <vulkan/vulkan.h>
 #define VOLK_IMPLEMENTATION
 #include "volk.h"

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -41,6 +41,9 @@
 #define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
 #define VULKAN_HPP_NO_EXCEPTIONS
 #define VULKAN_HPP_TYPESAFE_CONVERSION 1
+
+// Volk requires VK_NO_PROTOTYPES before including vulkan.hpp
+#define VK_NO_PROTOTYPES
 #include <vulkan/vulkan.hpp>
 
 #define VOLK_IMPLEMENTATION

--- a/cube/macOS/cube/DemoViewController.m
+++ b/cube/macOS/cube/DemoViewController.m
@@ -19,8 +19,6 @@
 #import "DemoViewController.h"
 #import <QuartzCore/CAMetalLayer.h>
 
-#include <MoltenVK/mvk_vulkan.h>
-
 #include "cube.c"
 
 #pragma mark -

--- a/cube/macOS/cubepp/DemoViewController.mm
+++ b/cube/macOS/cubepp/DemoViewController.mm
@@ -19,8 +19,6 @@
 #import "DemoViewController.h"
 #import <QuartzCore/CAMetalLayer.h>
 
-#include <MoltenVK/mvk_vulkan.h>
-
 #include "cube.cpp"
 
 #pragma mark -


### PR DESCRIPTION
See also:

    Cannot build DEMOS.sln
    https://gitlab.khronos.org/vulkan/Vulkan-SDK-Packaging/-/issues/1417

Volk requires that VK_NO_PROTOTYPES be defined before vulkan.h or vulkan.hpp is included.  Currently, the various flavors of vkcube hide this definition in the cube/CMakeLists.txt file, which can confuse users who may copy the source for their own use, and may require investigation to figure out why it doesn't "just work".

This change makes the #define explicit in the cube.c and cube.cpp source files, which should both be clearer and be more similar to how most applications use Volk.