### PR TITLE
cmake: Add required to necessary dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 option(BUILD_CUBE "Build cube" ON)
 option(BUILD_VULKANINFO "Build vulkaninfo" ON)
 option(BUILD_ICD "Build icd" ON)
+option(BUILD_TESTS "Build the tests")
+option(BUILD_WERROR "Treat compiler warnings as errors")
+# NOTE: Our custom code generation target isn't desirable for system package managers or add_subdirectory users.
+# So this target needs to be off by default to avoid obtuse build errors or patches.
+option(TOOLS_CODEGEN "Enable helper codegen target")
 
 option(ENABLE_ADDRESS_SANITIZER "Use address sanitization")
 if (ENABLE_ADDRESS_SANITIZER)
@@ -50,13 +55,14 @@ endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-find_package(VulkanHeaders QUIET CONFIG)
-find_package(VulkanLoader QUIET CONFIG)
-find_package(volk QUIET CONFIG)
+find_package(VulkanHeaders REQUIRED QUIET CONFIG)
+find_package(volk REQUIRED QUIET CONFIG)
+if (APPLE OR BUILD_TESTS)
+    find_package(VulkanLoader REQUIRED QUIET CONFIG)
+endif()
 
 include(GNUInstallDirs)
 
-option(BUILD_WERROR "Treat compiler warnings as errors")
 if (BUILD_WERROR)
     add_compile_options("$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>")
 endif()
@@ -96,9 +102,7 @@ elseif(MSVC)
     add_compile_options("/w34245")
 endif()
 
-# NOTE: Our custom code generation target isn't desirable for system package managers or add_subdirectory users.
-# So this target needs to be off by default to avoid obtuse build errors or patches.
-option(TOOLS_CODEGEN "Enable helper codegen target")
+
 if (TOOLS_CODEGEN)
     find_package(Python3 REQUIRED QUIET)
     add_custom_target(tools_codegen
@@ -146,7 +150,6 @@ endif()
 
 add_subdirectory(windows-runtime-installer)
 
-option(BUILD_TESTS "Build the tests")
 if(BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)


### PR DESCRIPTION
The Vulkan-Headers and volk dependencies are always required, while the Vulkan-Loader dependency is only necessary on APPLE hardware or when testing is enabled.