### PR TITLE
cube: Change ALooper_pollOnce to ALooper_pollAll

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -178,9 +178,6 @@ jobs:
             python-version: '3.8'
         - uses: lukka/get-cmake@latest
         - name: Configure
-          env:
-            # workaround for https://github.com/KhronosGroup/Vulkan-Tools/issues/1015
-            ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/25.2.9519653
           run: |
             cmake -S . -B build/ --toolchain $ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake \
             -D ANDROID_PLATFORM=23 \

--- a/cube/cube.c
+++ b/cube/cube.c
@@ -4505,7 +4505,7 @@ void android_main(struct android_app *app) {
     while (1) {
         int events;
         struct android_poll_source *source;
-        while (ALooper_pollAll(active ? 0 : -1, NULL, &events, (void **)&source) >= 0) {
+        while (ALooper_pollOnce(active ? 0 : -1, NULL, &events, (void **)&source) >= 0) {
             if (source) {
                 source->process(app, source);
             }


### PR DESCRIPTION
ALooper_pollAll is removed in NDK r27, switch to using ALooper_pollOnce instead. Since it was already being called in a loop, all we have to do is change the function name.

Fixes #1015