### PR TITLE
cube: Support runtime selection of WSI platform

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -37,18 +37,18 @@ jobs:
                 cc: [ gcc ]
                 cxx: [ g++ ]
                 config: [ Debug, Release ]
-                os: [ ubuntu-20.04, ubuntu-22.04 ]
+                os: [ ubuntu-22.04, ubuntu-22.04 ]
                 include:
-                    # Test clang on ubuntu 20
-                  - cc: clang
-                    cxx: clang++
-                    config: Debug
-                    os: ubuntu-20.04
                     # Test clang on ubuntu 22
                   - cc: clang
                     cxx: clang++
-                    config: Release
+                    config: Debug
                     os: ubuntu-22.04
+                    # Test clang on ubuntu 24
+                  - cc: clang
+                    cxx: clang++
+                    config: Release
+                    os: ubuntu-24.04
 
 
         steps:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -55,7 +55,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-python@v5
               with:
-                python-version: '3.7'
+                python-version: '3.10'
             - run: |
                 sudo apt-get -qq update
                 sudo apt install --yes libwayland-dev xorg-dev wayland-protocols
@@ -114,7 +114,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-python@v5
               with:
-                python-version: '3.7'
+                python-version: '3.10'
             - uses: lukka/get-cmake@latest
             - uses: ilammy/msvc-dev-cmd@v1
               with:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -38,26 +38,17 @@ jobs:
                 cxx: [ g++ ]
                 config: [ Debug, Release ]
                 os: [ ubuntu-20.04, ubuntu-22.04 ]
-                cube_wsi: [ XCB ]
                 include:
-                    # Test WAYLAND
-                  - cc: gcc
-                    cxx: g++
-                    config: Release
-                    os: ubuntu-22.04
-                    cube_wsi: WAYLAND
-                    # Test clang on ubuntu 20 with XLIB
+                    # Test clang on ubuntu 20
                   - cc: clang
                     cxx: clang++
                     config: Debug
                     os: ubuntu-20.04
-                    cube_wsi: XLIB
-                    # Test clang on ubuntu 22 with the DISPLAY option
+                    # Test clang on ubuntu 22
                   - cc: clang
                     cxx: clang++
                     config: Release
                     os: ubuntu-22.04
-                    cube_wsi: DISPLAY
 
 
         steps:
@@ -67,14 +58,14 @@ jobs:
                 python-version: '3.7'
             - run: |
                 sudo apt-get -qq update
-                sudo apt install libwayland-dev xorg-dev wayland-protocols
+                sudo apt install --yes libwayland-dev xorg-dev wayland-protocols
             - uses: lukka/get-cmake@latest
               with:
                 cmakeVersion: 3.17.2
             - name: Setup ccache
               uses: hendrikmuhs/ccache-action@v1.2
               with:
-                key: ${{ runner.os }}-${{ matrix.config }}-${{ matrix.cc }}-${{matrix.cube_wsi}}
+                key: ${{ runner.os }}-${{ matrix.config }}-${{ matrix.cc }}
             # This is to combat a bug when using 6.6 linux kernels with thread/address sanitizer
             # https://github.com/google/sanitizers/issues/1716
             - run: sudo sysctl vm.mmap_rnd_bits=28
@@ -82,7 +73,6 @@ jobs:
               run: |
                 cmake -S. -B build -G "Ninja" \
                 -D CMAKE_BUILD_TYPE=${{matrix.config}} \
-                -D CUBE_WSI_SELECTION=${{matrix.cube_wsi}} \
                 -D UPDATE_DEPS=ON \
                 -D BUILD_WERROR=ON \
                 -D INSTALL_ICD=ON \
@@ -234,7 +224,7 @@ jobs:
         - uses: actions/setup-python@v5
           with:
             python-version: '3.10'
-        - run: sudo apt-get -qq update && sudo apt install libwayland-dev xorg-dev wayland-protocols
+        - run: sudo apt-get -qq update && sudo apt install --yes libwayland-dev xorg-dev wayland-protocols
         - run: cmake -S . -B build/ -D UPDATE_DEPS=ON -D UPDATE_DEPS_DIR=external -D TOOLS_CODEGEN=ON
         - run: cmake --build build --target tools_codegen
         - run: git diff --exit-code

--- a/cube/CMakeLists.txt
+++ b/cube/CMakeLists.txt
@@ -61,32 +61,58 @@ if(APPLE)
     endif()
 endif()
 
+if(ANDROID OR APPLE)
+    set(WSI_DISPLAY_DEFAULT_SETTING "OFF")
+else()
+    set(WSI_DISPLAY_DEFAULT_SETTING "ON")
+endif()
+
+option(BUILD_WSI_DISPLAY_SUPPORT "Build DISPLAY WSI support" ${WSI_DISPLAY_DEFAULT_SETTING})
+
 if (CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|GNU")
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
     option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
     option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
     option(BUILD_WSI_DIRECTFB_SUPPORT "Build DirectFB WSI support" OFF)
-    set(CUBE_WSI_SELECTION "XCB" CACHE STRING "Select WSI target for vkcube (XCB, XLIB, WAYLAND, DIRECTFB, DISPLAY)")
 
     find_package(PkgConfig REQUIRED QUIET) # Use PkgConfig to find Linux system libraries
 
     if(BUILD_WSI_XCB_SUPPORT)
         pkg_check_modules(XCB REQUIRED QUIET IMPORTED_TARGET xcb)
+        pkg_get_variable(XCB_INCLUDE_DIRS xcb includedir)
+        message(DEBUG "XCB_INCLUDE_DIRS = ${XCB_INCLUDE_DIRS}")
     endif()
 
     if(BUILD_WSI_XLIB_SUPPORT)
         pkg_check_modules(X11 REQUIRED QUIET IMPORTED_TARGET x11)
+        pkg_get_variable(XLIB_INCLUDE_DIRS x11 includedir)
+        message(DEBUG "XLIB_INCLUDE_DIRS = ${XLIB_INCLUDE_DIRS}")
     endif()
 
     if(BUILD_WSI_WAYLAND_SUPPORT)
         pkg_check_modules(WAYLAND_CLIENT REQUIRED IMPORTED_TARGET wayland-client)
+        pkg_get_variable(WAYLAND_INCLUDE_DIRS wayland-client includedir)
 
         pkg_get_variable(WAYLAND_SCANNER_EXECUTABLE wayland-scanner wayland_scanner)
-        message(STATUS "WAYLAND_SCANNER_EXECUTABLE = ${WAYLAND_SCANNER_EXECUTABLE}")
+        message(DEBUG "WAYLAND_SCANNER_EXECUTABLE = ${WAYLAND_SCANNER_EXECUTABLE}")
+
+        pkg_get_variable(WAYLAND_CLIENT_PATH wayland-client pkgdatadir)
+        message(DEBUG "WAYLAND_CLIENT_PATH = ${WAYLAND_CLIENT_PATH}")
+        set(WAYLAND_CODE_PROTOCOL ${WAYLAND_CLIENT_PATH}/wayland.xml)
 
         pkg_get_variable(WAYLAND_PROTOCOLS_PATH wayland-protocols pkgdatadir)
-        message(STATUS "WAYLAND_PROTOCOLS_PATH = ${WAYLAND_PROTOCOLS_PATH}")
+        message(DEBUG "WAYLAND_PROTOCOLS_PATH = ${WAYLAND_PROTOCOLS_PATH}")
         set(XDG_SHELL_PROTOCOL ${WAYLAND_PROTOCOLS_PATH}/stable/xdg-shell/xdg-shell.xml)
+
+        add_custom_command(COMMENT "Generating wayland client protocol dispatch data"
+                          OUTPUT wayland-client.c
+                          COMMAND ${WAYLAND_SCANNER_EXECUTABLE}
+                                  private-code
+                                  ${WAYLAND_CODE_PROTOCOL}
+                                  ${CMAKE_CURRENT_BINARY_DIR}/wayland-client.c
+                          MAIN_DEPENDENCY ${WAYLAND_CODE_PROTOCOL}
+                          DEPENDS ${WAYLAND_CODE_PROTOCOL} ${WAYLAND_SCANNER_EXECUTABLE})
+
         add_custom_command(COMMENT "Generating xdg-shell protocol dispatch data"
                            OUTPUT xdg-shell-code.c
                            COMMAND ${WAYLAND_SCANNER_EXECUTABLE}
@@ -121,6 +147,12 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|GNU")
                                    ${CMAKE_CURRENT_BINARY_DIR}/xdg-decoration-client-header.h
                            MAIN_DEPENDENCY ${XDG_DECORATION_PROTOCOL}
                            DEPENDS ${XDG_DECORATION_PROTOCOL} ${WAYLAND_SCANNER_EXECUTABLE})
+
+        set(WAYLAND_ADDITIONAL_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/wayland-client.c
+                           ${CMAKE_CURRENT_BINARY_DIR}/xdg-shell-code.c
+                           ${CMAKE_CURRENT_BINARY_DIR}/xdg-shell-client-header.h
+                           ${CMAKE_CURRENT_BINARY_DIR}/xdg-decoration-code.c
+                           ${CMAKE_CURRENT_BINARY_DIR}/xdg-decoration-client-header.h)
     endif()
 
     if(BUILD_WSI_DIRECTFB_SUPPORT)
@@ -128,57 +160,37 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|GNU")
     endif()
 endif()
 
+if(BUILD_WSI_DISPLAY_SUPPORT)
+    list(APPEND ENABLED_CUBE_PLATFORMS VK_USE_PLATFORM_DISPLAY_KHR)
+endif()
+
 if(WIN32)
-    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN -DNOMINMAX)
+    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX)
+    list(APPEND ENABLED_CUBE_PLATFORMS VK_USE_PLATFORM_WIN32_KHR)
 elseif(ANDROID)
-    add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
+    list(APPEND ENABLED_CUBE_PLATFORMS VK_USE_PLATFORM_ANDROID_KHR)
 elseif(APPLE)
-    add_definitions(-DVK_USE_PLATFORM_METAL_EXT)
+    list(APPEND ENABLED_CUBE_PLATFORMS VK_USE_PLATFORM_METAL_EXT)
 elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|GNU")
-    if(NOT CUBE_WSI_SELECTION)
-        set(CUBE_WSI_SELECTION "XCB")
+    if(BUILD_WSI_XCB_SUPPORT)
+        list(APPEND ENABLED_CUBE_PLATFORMS VK_USE_PLATFORM_XCB_KHR)
     endif()
-
-    if(CUBE_WSI_SELECTION STREQUAL "XCB")
-        if(NOT BUILD_WSI_XCB_SUPPORT)
-            message(FATAL_ERROR "Selected XCB for vkcube build but not building Xcb support")
-        endif()
-        link_libraries(PkgConfig::XCB)
-        set(CUBE_PLATFORM VK_USE_PLATFORM_XCB_KHR)
-    elseif(CUBE_WSI_SELECTION STREQUAL "XLIB")
-        if(NOT BUILD_WSI_XLIB_SUPPORT)
-            message(FATAL_ERROR "Selected XLIB for vkcube build but not building Xlib support")
-        endif()
-        link_libraries(PkgConfig::X11)
-        set(CUBE_PLATFORM VK_USE_PLATFORM_XLIB_KHR)
-    elseif(CUBE_WSI_SELECTION STREQUAL "WAYLAND")
-        if(NOT BUILD_WSI_WAYLAND_SUPPORT)
-            message(FATAL_ERROR "Selected Wayland for vkcube build but not building Wayland support")
-        endif()
-        link_libraries(PkgConfig::WAYLAND_CLIENT)
-        set(CUBE_PLATFORM VK_USE_PLATFORM_WAYLAND_KHR)
-        set(XDG_SHELL_PROTOCOL ${WAYLAND_PROTOCOLS_PATH}/stable/xdg-shell/xdg-shell.xml)
-        set(OPTIONAL_WAYLAND_DATA_FILES
-            ${CMAKE_CURRENT_BINARY_DIR}/xdg-shell-code.c
-            ${CMAKE_CURRENT_BINARY_DIR}/xdg-shell-client-header.h
-            ${CMAKE_CURRENT_BINARY_DIR}/xdg-decoration-code.c
-            ${CMAKE_CURRENT_BINARY_DIR}/xdg-decoration-client-header.h)
-        include_directories(${CMAKE_CURRENT_BINARY_DIR})
-    elseif(CUBE_WSI_SELECTION STREQUAL "DIRECTFB")
-        if(NOT BUILD_WSI_DIRECTFB_SUPPORT)
-            message(FATAL_ERROR "Selected DIRECTFB for vkcube build but not building DirectFB support")
-        endif()
-        link_libraries(PkgConfig::DirectFB)
-        set(CUBE_PLATFORM VK_USE_PLATFORM_DIRECTFB_EXT)
-    elseif(CUBE_WSI_SELECTION STREQUAL "DISPLAY")
-        set(CUBE_PLATFORM VK_USE_PLATFORM_DISPLAY_KHR)
-    else()
-        message(FATAL_ERROR "Unrecognized value for CUBE_WSI_SELECTION: ${CUBE_WSI_SELECTION}")
+    if(BUILD_WSI_XLIB_SUPPORT)
+        list(APPEND ENABLED_CUBE_PLATFORMS VK_USE_PLATFORM_XLIB_KHR)
     endif()
-
+    if(BUILD_WSI_WAYLAND_SUPPORT)
+        list(APPEND ENABLED_CUBE_PLATFORMS VK_USE_PLATFORM_WAYLAND_KHR)
+    endif()
+    if(BUILD_WSI_DIRECTFB_SUPPORT)
+        list(APPEND ENABLED_CUBE_PLATFORMS VK_USE_PLATFORM_DIRECTFB_EXT)
+    endif()
     link_libraries(${API_LOWERCASE} m)
 else()
     message(FATAL_ERROR "Unsupported Platform!")
+endif()
+
+if(NOT DEFINED ENABLED_CUBE_PLATFORMS)
+        message(FATAL_ERROR "There are no supported WSI platforms on this system, vkcube requires a WSI platform be available to be able to render its output")
 endif()
 
 if (COMPILE_CUBE_SHADERS)
@@ -226,7 +238,6 @@ elseif (ANDROID)
 
     add_subdirectory(android)
 
-    target_link_libraries(vkcube PRIVATE Vulkan::Headers volk::volk_headers)
 elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|GNU")
     add_executable(vkcube)
     target_sources(vkcube PRIVATE
@@ -235,15 +246,28 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|GNU")
         ${PROJECT_SOURCE_DIR}/cube/cube.frag
         cube.vert.inc
         cube.frag.inc
-        ${OPTIONAL_WAYLAND_DATA_FILES}
     )
-    target_compile_definitions(vkcube PUBLIC ${CUBE_PLATFORM})
+    target_link_libraries(vkcube  Threads::Threads)
+    if(BUILD_WSI_XCB_SUPPORT)
+        target_sources(vkcube PRIVATE xcb_loader.h)
+        target_include_directories(vkcube PRIVATE ${xcb_INCLUDE_DIRS})
+    endif()
+    if(BUILD_WSI_XLIB_SUPPORT)
+        target_sources(vkcube PRIVATE xlib_loader.h)
+        target_include_directories(vkcube PRIVATE ${XLIB_INCLUDE_DIRS})
+    endif()
+    if(BUILD_WSI_WAYLAND_SUPPORT)
+        target_include_directories(vkcube PRIVATE ${WAYLAND_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
+        target_sources(vkcube PRIVATE PRIVATE ${WAYLAND_ADDITIONAL_SOURCES})
+    endif()
+    if(BUILD_WSI_DIRECTFB_SUPPORT)
+        target_link_libraries(vkcube PkgConfig::DirectFB)
+    endif()
     include(CheckLibraryExists)
     CHECK_LIBRARY_EXISTS("rt" clock_gettime "" NEED_RT)
     if (NEED_RT)
-        target_link_libraries(vkcube PRIVATE rt)
+        target_link_libraries(vkcube  rt)
     endif()
-    target_link_libraries(vkcube PRIVATE Vulkan::Headers volk::volk_headers Threads::Threads)
 elseif(WIN32)
     add_executable(vkcube WIN32)
     target_sources(vkcube PRIVATE
@@ -253,12 +277,13 @@ elseif(WIN32)
         cube.vert.inc
         cube.frag.inc
     )
-    target_link_libraries(vkcube PRIVATE Vulkan::Headers volk::volk_headers)
 else()
     message(FATAL_ERROR "Unsupported Platform!")
 endif()
 
+target_compile_definitions(vkcube PRIVATE ${ENABLED_CUBE_PLATFORMS})
 target_include_directories(vkcube PRIVATE .)
+target_link_libraries(vkcube  Vulkan::Headers volk::volk_headers)
 
 if (ANDROID)
     install(TARGETS vkcube DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -280,6 +305,16 @@ if (ANDROID)
     return()
 endif()
 
+if (XCB_LINK_LIBRARIES)
+    target_compile_definitions(vkcube PRIVATE "XCB_LIBRARY=\"${XCB_LINK_LIBRARIES}\"")
+endif()
+if (X11_LINK_LIBRARIES)
+    target_compile_definitions(vkcube PRIVATE "XLIB_LIBRARY=\"${X11_LINK_LIBRARIES}\"")
+endif()
+if (WAYLAND_CLIENT_LINK_LIBRARIES)
+    target_compile_definitions(vkcube PRIVATE "WAYLAND_LIBRARY=\"${WAYLAND_CLIENT_LINK_LIBRARIES}\"")
+endif()
+
 # ----------------------------------------------------------------------------
 # vkcubepp
 
@@ -291,10 +326,24 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|GNU")
                    ${PROJECT_SOURCE_DIR}/cube/cube.vert
                    ${PROJECT_SOURCE_DIR}/cube/cube.frag
                    cube.vert.inc
-                   cube.frag.inc
-                   ${OPTIONAL_WAYLAND_DATA_FILES})
-    target_link_libraries(vkcubepp Vulkan::Headers volk::volk_headers Threads::Threads)
-    target_compile_definitions(vkcubepp PUBLIC ${CUBE_PLATFORM})
+                   cube.frag.inc)
+    target_link_libraries(vkcubepp  Threads::Threads)
+
+    if(BUILD_WSI_XCB_SUPPORT)
+        target_sources(vkcubepp PRIVATE xcb_loader.h)
+        target_include_directories(vkcubepp PRIVATE ${xcb_INCLUDE_DIRS})
+    endif()
+    if(BUILD_WSI_XLIB_SUPPORT)
+        target_sources(vkcubepp PRIVATE xlib_loader.h)
+        target_include_directories(vkcubepp PRIVATE ${XLIB_INCLUDE_DIRS})
+    endif()
+    if(BUILD_WSI_WAYLAND_SUPPORT)
+        target_include_directories(vkcubepp PRIVATE ${WAYLAND_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
+        target_sources(vkcubepp PRIVATE ${WAYLAND_ADDITIONAL_SOURCES})
+    endif()
+    if(BUILD_WSI_DIRECTFB_SUPPORT)
+        target_link_libraries(vkcubepp  PkgConfig::DirectFB)
+    endif()
 else()
     add_executable(vkcubepp
                    WIN32
@@ -303,9 +352,21 @@ else()
                    ${PROJECT_SOURCE_DIR}/cube/cube.frag
                    cube.vert.inc
                    cube.frag.inc)
-    target_link_libraries(vkcubepp Vulkan::Headers volk::volk_headers)
 endif()
+
 target_include_directories(vkcubepp PRIVATE .)
+target_compile_definitions(vkcubepp PRIVATE ${ENABLED_CUBE_PLATFORMS})
+target_link_libraries(vkcubepp  Vulkan::Headers volk::volk_headers)
+
+if (XCB_LINK_LIBRARIES )
+    target_compile_definitions(vkcubepp PUBLIC "XCB_LIBRARY=\"${XCB_LINK_LIBRARIES}\"")
+endif()
+if (X11_LINK_LIBRARIES)
+    target_compile_definitions(vkcubepp PUBLIC "XLIB_LIBRARY=\"${X11_LINK_LIBRARIES}\"")
+endif()
+if (WAYLAND_CLIENT_LINK_LIBRARIES)
+    target_compile_definitions(vkcubepp PUBLIC "WAYLAND_LIBRARY=\"${WAYLAND_CLIENT_LINK_LIBRARIES}\"")
+endif()
 
 if(APPLE)
     install(
@@ -319,42 +380,4 @@ if(APPLE)
     )
 else()
     install(TARGETS vkcubepp)
-endif()
-
-# ----------------------------------------------------------------------------
-# vkcube-wayland
-
-if (CMAKE_SYSTEM_NAME MATCHES "Linux|BSD")
-    if(BUILD_WSI_WAYLAND_SUPPORT AND EXISTS ${WAYLAND_PROTOCOLS_PATH}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml)
-        add_executable(vkcube-wayland)
-
-        target_sources(vkcube-wayland PRIVATE
-            cube.c
-            ${PROJECT_SOURCE_DIR}/cube/cube.vert
-            ${PROJECT_SOURCE_DIR}/cube/cube.frag
-            cube.vert.inc
-            cube.frag.inc
-            ${CMAKE_CURRENT_BINARY_DIR}/xdg-shell-code.c
-            ${CMAKE_CURRENT_BINARY_DIR}/xdg-shell-client-header.h
-            ${CMAKE_CURRENT_BINARY_DIR}/xdg-decoration-code.c
-            ${CMAKE_CURRENT_BINARY_DIR}/xdg-decoration-client-header.h
-        )
-        target_include_directories(vkcube-wayland PRIVATE
-            ${CMAKE_CURRENT_BINARY_DIR}
-            .
-        )
-        target_link_libraries(vkcube-wayland PRIVATE
-            Vulkan::Headers
-            volk::volk_headers
-            Threads::Threads
-            PkgConfig::WAYLAND_CLIENT
-        )
-        target_compile_definitions(vkcube-wayland PRIVATE VK_USE_PLATFORM_WAYLAND_KHR)
-        include(CheckLibraryExists)
-        CHECK_LIBRARY_EXISTS("rt" clock_gettime "" NEED_RT)
-        if (NEED_RT)
-            target_link_libraries(vkcube-wayland PRIVATE rt)
-        endif()
-        install(TARGETS vkcube-wayland)
-    endif()
 endif()

--- a/cube/android/CMakeLists.txt
+++ b/cube/android/CMakeLists.txt
@@ -43,7 +43,7 @@ target_sources(android_glue PRIVATE
 
 set_target_properties(vkcube PROPERTIES OUTPUT_NAME "VkCube")
 
-target_link_libraries(vkcube PRIVATE
+target_link_libraries(vkcube
     android_glue
     log
     android

--- a/cube/macOS/cube/CMakeLists.txt
+++ b/cube/macOS/cube/CMakeLists.txt
@@ -59,7 +59,7 @@ add_dependencies(vkcube MoltenVK_icd-staging-json)
 target_include_directories(vkcube PRIVATE . ${MOLTENVK_DIR}/MoltenVK/include)
 
 # We do this so vkcube is linked to an individual library and NOT a framework.
-target_link_libraries(vkcube Vulkan::Loader volk::volk_headers "-framework Cocoa -framework QuartzCore")
+target_link_libraries(vkcube "-framework Cocoa -framework QuartzCore")
 
 # Disable warnings about sprintf
 target_compile_options(vkcube PRIVATE -Wno-deprecated-declarations)

--- a/cube/macOS/cubepp/CMakeLists.txt
+++ b/cube/macOS/cubepp/CMakeLists.txt
@@ -59,7 +59,7 @@ add_dependencies(vkcubepp MoltenVK_icd-staging-json)
 target_include_directories(vkcubepp PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${MOLTENVK_DIR}/MoltenVK/include)
 
 # We do this so vkcubepp is linked to an individual library and NOT a framework.
-target_link_libraries(vkcubepp Vulkan::Loader volk::volk_headers "-framework Cocoa -framework QuartzCore")
+target_link_libraries(vkcubepp "-framework Cocoa -framework QuartzCore")
 
 set_target_properties(vkcubepp PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_LIST_DIR}/Info.plist)
 

--- a/cube/wayland_loader.h
+++ b/cube/wayland_loader.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+
+#include <wayland-client-core.h>
+
+typedef struct wl_display *(*PFN_wl_display_connect)(const char *name);
+typedef int (*PFN_wl_display_flush)(struct wl_display *display);
+typedef int (*PFN_wl_display_dispatch)(struct wl_display *display);
+typedef int (*PFN_wl_display_prepare_read)(struct wl_display *display);
+typedef int (*PFN_wl_display_dispatch_pending)(struct wl_display *display);
+typedef int (*PFN_wl_display_read_events)(struct wl_display *display);
+typedef void (*PFN_wl_proxy_marshal)(struct wl_proxy *p, uint32_t opcode, ...);
+typedef struct wl_proxy *(*PFN_wl_proxy_marshal_constructor)(struct wl_proxy *proxy, uint32_t opcode,
+                                                             const struct wl_interface *interface, ...);
+typedef struct wl_proxy *(*PFN_wl_proxy_marshal_constructor_versioned)(struct wl_proxy *proxy, uint32_t opcode,
+                                                                       const struct wl_interface *interface, uint32_t version, ...);
+typedef struct wl_proxy *(*PFN_wl_proxy_marshal_flags)(struct wl_proxy *proxy, uint32_t opcode,
+                                                       const struct wl_interface *interface, uint32_t version, uint32_t flags, ...);
+typedef uint32_t (*PFN_wl_proxy_get_version)(struct wl_proxy *proxy);
+typedef int (*PFN_wl_proxy_add_listener)(struct wl_proxy *proxy, void (**implementation)(void), void *data);
+typedef void (*PFN_wl_proxy_destroy)(struct wl_proxy *proxy);
+typedef int (*PFN_wl_display_roundtrip)(struct wl_display *display);
+typedef void (*PFN_wl_display_disconnect)(struct wl_display *display);
+
+static PFN_wl_display_connect cube_wl_display_connect = NULL;
+static PFN_wl_display_flush cube_wl_display_flush = NULL;
+static PFN_wl_display_dispatch cube_wl_display_dispatch = NULL;
+static PFN_wl_display_prepare_read cube_wl_display_prepare_read = NULL;
+static PFN_wl_display_dispatch_pending cube_wl_display_dispatch_pending = NULL;
+static PFN_wl_display_read_events cube_wl_display_read_events = NULL;
+static PFN_wl_proxy_marshal cube_wl_proxy_marshal = NULL;
+static PFN_wl_proxy_marshal_constructor cube_wl_proxy_marshal_constructor = NULL;
+static PFN_wl_proxy_marshal_constructor_versioned cube_wl_proxy_marshal_constructor_versioned = NULL;
+static PFN_wl_proxy_marshal_flags cube_wl_proxy_marshal_flags = NULL;
+static PFN_wl_proxy_get_version cube_wl_proxy_get_version = NULL;
+static PFN_wl_proxy_add_listener cube_wl_proxy_add_listener = NULL;
+static PFN_wl_proxy_destroy cube_wl_proxy_destroy = NULL;
+static PFN_wl_display_roundtrip cube_wl_display_roundtrip = NULL;
+static PFN_wl_display_disconnect cube_wl_display_disconnect = NULL;
+
+// Use macro's to redefine the PFN's as the functions in client code
+#define wl_display_connect cube_wl_display_connect
+#define wl_display_flush cube_wl_display_flush
+#define wl_display_dispatch cube_wl_display_dispatch
+#define wl_display_prepare_read cube_wl_display_prepare_read
+#define wl_display_dispatch_pending cube_wl_display_dispatch_pending
+#define wl_display_read_events cube_wl_display_read_events
+#define wl_proxy_marshal cube_wl_proxy_marshal
+#define wl_proxy_marshal_constructor cube_wl_proxy_marshal_constructor
+#define wl_proxy_marshal_constructor_versioned cube_wl_proxy_marshal_constructor_versioned
+#define wl_proxy_marshal_flags cube_wl_proxy_marshal_flags
+#define wl_proxy_get_version cube_wl_proxy_get_version
+#define wl_proxy_add_listener cube_wl_proxy_add_listener
+#define wl_proxy_destroy cube_wl_proxy_destroy
+#define wl_display_roundtrip cube_wl_display_roundtrip
+#define wl_display_disconnect cube_wl_display_disconnect
+
+static inline void *initialize_wayland() {
+    void *wayland_library = NULL;
+#if defined(WAYLAND_LIBRARY)
+    wayland_library = dlopen(WAYLAND_LIBRARY, RTLD_NOW | RTLD_LOCAL);
+#endif
+    if (NULL == wayland_library) {
+        wayland_library = dlopen("libwayland-client.so.0", RTLD_NOW | RTLD_LOCAL);
+    }
+    if (NULL == wayland_library) {
+        wayland_library = dlopen("libwayland-client.so", RTLD_NOW | RTLD_LOCAL);
+    }
+    if (NULL == wayland_library) {
+        return NULL;
+    }
+
+#ifdef __cplusplus
+#define TYPE_CONVERSION(type) reinterpret_cast<type>
+#else
+#define TYPE_CONVERSION(type)
+#endif
+    cube_wl_display_connect = TYPE_CONVERSION(PFN_wl_display_connect)(dlsym(wayland_library, "wl_display_connect"));
+    cube_wl_display_flush = TYPE_CONVERSION(PFN_wl_display_flush)(dlsym(wayland_library, "wl_display_flush"));
+    cube_wl_display_dispatch = TYPE_CONVERSION(PFN_wl_display_dispatch)(dlsym(wayland_library, "wl_display_dispatch"));
+    cube_wl_display_prepare_read = TYPE_CONVERSION(PFN_wl_display_prepare_read)(dlsym(wayland_library, "wl_display_prepare_read"));
+    cube_wl_display_dispatch_pending =
+        TYPE_CONVERSION(PFN_wl_display_dispatch_pending)(dlsym(wayland_library, "wl_display_dispatch_pending"));
+    cube_wl_display_read_events = TYPE_CONVERSION(PFN_wl_display_read_events)(dlsym(wayland_library, "wl_display_read_events"));
+    cube_wl_proxy_marshal = TYPE_CONVERSION(PFN_wl_proxy_marshal)(dlsym(wayland_library, "wl_proxy_marshal"));
+    cube_wl_proxy_marshal_constructor =
+        TYPE_CONVERSION(PFN_wl_proxy_marshal_constructor)(dlsym(wayland_library, "wl_proxy_marshal_constructor"));
+    cube_wl_proxy_marshal_constructor_versioned = TYPE_CONVERSION(PFN_wl_proxy_marshal_constructor_versioned)(
+        dlsym(wayland_library, "wl_proxy_marshal_constructor_versioned"));
+    cube_wl_proxy_marshal_flags = TYPE_CONVERSION(PFN_wl_proxy_marshal_flags)(dlsym(wayland_library, "wl_proxy_marshal_flags"));
+    cube_wl_proxy_get_version = TYPE_CONVERSION(PFN_wl_proxy_get_version)(dlsym(wayland_library, "wl_proxy_get_version"));
+    cube_wl_proxy_add_listener = TYPE_CONVERSION(PFN_wl_proxy_add_listener)(dlsym(wayland_library, "wl_proxy_add_listener"));
+    cube_wl_proxy_destroy = TYPE_CONVERSION(PFN_wl_proxy_destroy)(dlsym(wayland_library, "wl_proxy_destroy"));
+    cube_wl_display_roundtrip = TYPE_CONVERSION(PFN_wl_display_roundtrip)(dlsym(wayland_library, "wl_display_roundtrip"));
+    cube_wl_display_disconnect = TYPE_CONVERSION(PFN_wl_display_disconnect)(dlsym(wayland_library, "wl_display_disconnect"));
+
+    return wayland_library;
+}
+
+#include "xdg-shell-client-header.h"
+#include "xdg-decoration-client-header.h"

--- a/cube/xcb_loader.h
+++ b/cube/xcb_loader.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#pragma once
+
+#include <dlfcn.h>
+#include <stdlib.h>
+
+#include <xcb/xcb.h>
+
+typedef xcb_void_cookie_t (*PFN_xcb_destroy_window)(xcb_connection_t *c, xcb_window_t window);
+typedef void (*PFN_xcb_disconnect)(xcb_connection_t *c);
+typedef int (*PFN_xcb_flush)(xcb_connection_t *c);
+typedef xcb_generic_event_t *(*PFN_xcb_wait_for_event)(xcb_connection_t *c);
+typedef xcb_generic_event_t *(*PFN_xcb_poll_for_event)(xcb_connection_t *c);
+typedef uint32_t (*PFN_xcb_generate_id)(xcb_connection_t *c);
+typedef xcb_void_cookie_t (*PFN_xcb_create_window)(xcb_connection_t *c, uint8_t depth, xcb_window_t wid, xcb_window_t parent,
+                                                   int16_t x, int16_t y, uint16_t width, uint16_t height, uint16_t border_width,
+                                                   uint16_t _class, xcb_visualid_t visual, uint32_t value_mask,
+                                                   const void *value_list);
+typedef xcb_intern_atom_cookie_t (*PFN_xcb_intern_atom)(xcb_connection_t *c, uint8_t only_if_exists, uint16_t name_len,
+                                                        const char *name);
+typedef xcb_intern_atom_reply_t *(*PFN_xcb_intern_atom_reply)(xcb_connection_t *c, xcb_intern_atom_cookie_t cookie /**< */,
+                                                              xcb_generic_error_t **e);
+typedef xcb_void_cookie_t (*PFN_xcb_change_property)(xcb_connection_t *c, uint8_t mode, xcb_window_t window, xcb_atom_t property,
+                                                     xcb_atom_t type, uint8_t format, uint32_t data_len, const void *data);
+typedef xcb_void_cookie_t (*PFN_xcb_map_window)(xcb_connection_t *c, xcb_window_t window);
+typedef xcb_void_cookie_t (*PFN_xcb_configure_window)(xcb_connection_t *c, xcb_window_t window, uint16_t value_mask,
+                                                      const void *value_list);
+typedef xcb_connection_t *(*PFN_xcb_connect)(const char *displayname, int *screenp);
+typedef int (*PFN_xcb_connection_has_error)(xcb_connection_t *c);
+typedef const struct xcb_setup_t *(*PFN_xcb_get_setup)(xcb_connection_t *c);
+typedef xcb_screen_iterator_t (*PFN_xcb_setup_roots_iterator)(const xcb_setup_t *R);
+typedef void (*PFN_xcb_screen_next)(xcb_screen_iterator_t *i);
+
+static PFN_xcb_destroy_window cube_xcb_destroy_window = NULL;
+static PFN_xcb_disconnect cube_xcb_disconnect = NULL;
+static PFN_xcb_flush cube_xcb_flush = NULL;
+static PFN_xcb_wait_for_event cube_xcb_wait_for_event = NULL;
+static PFN_xcb_poll_for_event cube_xcb_poll_for_event = NULL;
+static PFN_xcb_generate_id cube_xcb_generate_id = NULL;
+static PFN_xcb_create_window cube_xcb_create_window = NULL;
+static PFN_xcb_intern_atom cube_xcb_intern_atom = NULL;
+static PFN_xcb_intern_atom_reply cube_xcb_intern_atom_reply = NULL;
+static PFN_xcb_change_property cube_xcb_change_property = NULL;
+static PFN_xcb_map_window cube_xcb_map_window = NULL;
+static PFN_xcb_configure_window cube_xcb_configure_window = NULL;
+static PFN_xcb_connect cube_xcb_connect = NULL;
+static PFN_xcb_connection_has_error cube_xcb_connection_has_error = NULL;
+static PFN_xcb_get_setup cube_xcb_get_setup = NULL;
+static PFN_xcb_setup_roots_iterator cube_xcb_setup_roots_iterator = NULL;
+static PFN_xcb_screen_next cube_xcb_screen_next = NULL;
+
+#define xcb_destroy_window cube_xcb_destroy_window
+#define xcb_disconnect cube_xcb_disconnect
+#define xcb_flush cube_xcb_flush
+#define xcb_wait_for_event cube_xcb_wait_for_event
+#define xcb_poll_for_event cube_xcb_poll_for_event
+#define xcb_generate_id cube_xcb_generate_id
+#define xcb_create_window cube_xcb_create_window
+#define xcb_intern_atom cube_xcb_intern_atom
+#define xcb_intern_atom_reply cube_xcb_intern_atom_reply
+#define xcb_change_property cube_xcb_change_property
+#define xcb_map_window cube_xcb_map_window
+#define xcb_configure_window cube_xcb_configure_window
+#define xcb_connect cube_xcb_connect
+#define xcb_connection_has_error cube_xcb_connection_has_error
+#define xcb_get_setup cube_xcb_get_setup
+#define xcb_setup_roots_iterator cube_xcb_setup_roots_iterator
+#define xcb_screen_next cube_xcb_screen_next
+
+void *initialize_xcb() {
+    void *xcb_library = NULL;
+#if defined(XCB_LIBRARY)
+    xcb_library = dlopen(XCB_LIBRARY, RTLD_NOW | RTLD_LOCAL);
+#endif
+    if (NULL == xcb_library) {
+        xcb_library = dlopen("libxcb.so.1", RTLD_NOW | RTLD_LOCAL);
+    }
+    if (NULL == xcb_library) {
+        xcb_library = dlopen("libxcb.so", RTLD_NOW | RTLD_LOCAL);
+    }
+    if (NULL == xcb_library) {
+        return NULL;
+    }
+
+#ifdef __cplusplus
+#define TYPE_CONVERSION(type) reinterpret_cast<type>
+#else
+#define TYPE_CONVERSION(type)
+#endif
+
+    cube_xcb_destroy_window = TYPE_CONVERSION(PFN_xcb_destroy_window)(dlsym(xcb_library, "xcb_destroy_window"));
+    cube_xcb_disconnect = TYPE_CONVERSION(PFN_xcb_disconnect)(dlsym(xcb_library, "xcb_disconnect"));
+    cube_xcb_flush = TYPE_CONVERSION(PFN_xcb_flush)(dlsym(xcb_library, "xcb_flush"));
+    cube_xcb_wait_for_event = TYPE_CONVERSION(PFN_xcb_wait_for_event)(dlsym(xcb_library, "xcb_wait_for_event"));
+    cube_xcb_poll_for_event = TYPE_CONVERSION(PFN_xcb_poll_for_event)(dlsym(xcb_library, "xcb_poll_for_event"));
+    cube_xcb_generate_id = TYPE_CONVERSION(PFN_xcb_generate_id)(dlsym(xcb_library, "xcb_generate_id"));
+    cube_xcb_create_window = TYPE_CONVERSION(PFN_xcb_create_window)(dlsym(xcb_library, "xcb_create_window"));
+    cube_xcb_intern_atom = TYPE_CONVERSION(PFN_xcb_intern_atom)(dlsym(xcb_library, "xcb_intern_atom"));
+    cube_xcb_intern_atom_reply = TYPE_CONVERSION(PFN_xcb_intern_atom_reply)(dlsym(xcb_library, "xcb_intern_atom_reply"));
+    cube_xcb_change_property = TYPE_CONVERSION(PFN_xcb_change_property)(dlsym(xcb_library, "xcb_change_property"));
+    cube_xcb_map_window = TYPE_CONVERSION(PFN_xcb_map_window)(dlsym(xcb_library, "xcb_map_window"));
+    cube_xcb_configure_window = TYPE_CONVERSION(PFN_xcb_configure_window)(dlsym(xcb_library, "xcb_configure_window"));
+    cube_xcb_connect = TYPE_CONVERSION(PFN_xcb_connect)(dlsym(xcb_library, "xcb_connect"));
+    cube_xcb_connection_has_error = TYPE_CONVERSION(PFN_xcb_connection_has_error)(dlsym(xcb_library, "xcb_connection_has_error"));
+    cube_xcb_get_setup = TYPE_CONVERSION(PFN_xcb_get_setup)(dlsym(xcb_library, "xcb_get_setup"));
+    cube_xcb_setup_roots_iterator = TYPE_CONVERSION(PFN_xcb_setup_roots_iterator)(dlsym(xcb_library, "xcb_setup_roots_iterator"));
+    cube_xcb_screen_next = TYPE_CONVERSION(PFN_xcb_screen_next)(dlsym(xcb_library, "xcb_screen_next"));
+
+    return xcb_library;
+}

--- a/cube/xlib_loader.h
+++ b/cube/xlib_loader.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#pragma once
+
+#include <dlfcn.h>
+#include <stdlib.h>
+
+#include <X11/Xutil.h>
+
+typedef int (*PFN_XDestroyWindow)(Display*, Window);
+typedef Display* (*PFN_XOpenDisplay)(_Xconst char*);
+typedef Colormap (*PFN_XCreateColormap)(Display*, Window, Visual*, int);
+typedef Window (*PFN_XCreateWindow)(Display*, Window, int, int, unsigned int, unsigned int, unsigned int, int, unsigned int,
+                                    Visual*, unsigned long, XSetWindowAttributes*);
+typedef int (*PFN_XSelectInput)(Display*, Window, long);
+typedef int (*PFN_XMapWindow)(Display*, Window);
+typedef Atom (*PFN_XInternAtom)(Display*, _Xconst char*, Bool);
+typedef int (*PFN_XNextEvent)(Display*, XEvent*);
+typedef int (*PFN_XPending)(Display*);
+typedef XVisualInfo* (*PFN_XGetVisualInfo)(Display*, long, XVisualInfo*, int*);
+typedef int (*PFN_XCloseDisplay)(Display* /* display */
+);
+typedef Status (*PFN_XInitThreads)(void);
+typedef int (*PFN_XFlush)(Display* /* display */
+);
+
+static PFN_XDestroyWindow cube_XDestroyWindow = NULL;
+static PFN_XOpenDisplay cube_XOpenDisplay = NULL;
+static PFN_XCreateColormap cube_XCreateColormap = NULL;
+static PFN_XCreateWindow cube_XCreateWindow = NULL;
+static PFN_XSelectInput cube_XSelectInput = NULL;
+static PFN_XMapWindow cube_XMapWindow = NULL;
+static PFN_XInternAtom cube_XInternAtom = NULL;
+static PFN_XNextEvent cube_XNextEvent = NULL;
+static PFN_XPending cube_XPending = NULL;
+static PFN_XGetVisualInfo cube_XGetVisualInfo = NULL;
+static PFN_XCloseDisplay cube_XCloseDisplay = NULL;
+static PFN_XInitThreads cube_XInitThreads = NULL;
+static PFN_XFlush cube_XFlush = NULL;
+
+#define XDestroyWindow cube_XDestroyWindow
+#define XOpenDisplay cube_XOpenDisplay
+#define XCreateColormap cube_XCreateColormap
+#define XCreateWindow cube_XCreateWindow
+#define XSelectInput cube_XSelectInput
+#define XMapWindow cube_XMapWindow
+#define XInternAtom cube_XInternAtom
+#define XNextEvent cube_XNextEvent
+#define XPending cube_XPending
+#define XGetVisualInfo cube_XGetVisualInfo
+#define XCloseDisplay cube_XCloseDisplay
+#define XInitThreads cube_XInitThreads
+#define XFlush cube_XFlush
+
+void* initialize_xlib() {
+    void* xlib_library = NULL;
+#if defined(XLIB_LIBRARY)
+    xlib_library = dlopen(XLIB_LIBRARY, RTLD_NOW | RTLD_LOCAL);
+#endif
+    if (NULL == xlib_library) {
+        xlib_library = dlopen("libX11.so.6", RTLD_NOW | RTLD_LOCAL);
+    }
+    if (NULL == xlib_library) {
+        xlib_library = dlopen("libX11.so", RTLD_NOW | RTLD_LOCAL);
+    }
+    if (NULL == xlib_library) {
+        return NULL;
+    }
+
+#ifdef __cplusplus
+#define TYPE_CONVERSION(type) reinterpret_cast<type>
+#else
+#define TYPE_CONVERSION(type)
+#endif
+
+    cube_XDestroyWindow = TYPE_CONVERSION(PFN_XDestroyWindow)(dlsym(xlib_library, "XDestroyWindow"));
+    cube_XOpenDisplay = TYPE_CONVERSION(PFN_XOpenDisplay)(dlsym(xlib_library, "XOpenDisplay"));
+    cube_XCreateColormap = TYPE_CONVERSION(PFN_XCreateColormap)(dlsym(xlib_library, "XCreateColormap"));
+    cube_XCreateWindow = TYPE_CONVERSION(PFN_XCreateWindow)(dlsym(xlib_library, "XCreateWindow"));
+    cube_XSelectInput = TYPE_CONVERSION(PFN_XSelectInput)(dlsym(xlib_library, "XSelectInput"));
+    cube_XMapWindow = TYPE_CONVERSION(PFN_XMapWindow)(dlsym(xlib_library, "XMapWindow"));
+    cube_XInternAtom = TYPE_CONVERSION(PFN_XInternAtom)(dlsym(xlib_library, "XInternAtom"));
+    cube_XNextEvent = TYPE_CONVERSION(PFN_XNextEvent)(dlsym(xlib_library, "XNextEvent"));
+    cube_XPending = TYPE_CONVERSION(PFN_XPending)(dlsym(xlib_library, "XPending"));
+    cube_XGetVisualInfo = TYPE_CONVERSION(PFN_XGetVisualInfo)(dlsym(xlib_library, "XGetVisualInfo"));
+    cube_XCloseDisplay = TYPE_CONVERSION(PFN_XCloseDisplay)(dlsym(xlib_library, "XCloseDisplay"));
+    cube_XInitThreads = TYPE_CONVERSION(PFN_XInitThreads)(dlsym(xlib_library, "XInitThreads"));
+    cube_XFlush = TYPE_CONVERSION(PFN_XFlush)(dlsym(xlib_library, "XFlush"));
+
+    return xlib_library;
+}


### PR DESCRIPTION
By changing the selection of a WSI platform from a build time choice to a runtime choice, this allows the removal of vkcube-wayland as a separate binary.

Use `--wsi <xlib|xcb|wayland|display|directfb>` to choose the WSI platform that vkcube will render with. The chosen platform must be one that vkcube was compiled with support for, so directfb will be unavailable without changing the build parameters to enable it.

These changes have been made to both vkcube and vkcubepp.

Platforms which do not have multiple WSI platforms, such as windows, android, and apple (metal is the only non-deprecated platform) do not have this option as there aren't any platforms to choose from.