### PR TITLE
Fix twocall_chain_vectors mechanism

### DIFF
--- a/scripts/vulkaninfo_generator.py
+++ b/scripts/vulkaninfo_generator.py
@@ -901,19 +901,10 @@ void setup_{listName}_chain({chain_details['holder_type']}& start, std::unique_p
         out += '    }\n'
         out += '}\n'
 
-    should_print_twocall_func = False
-    for s in structs_to_print:
-        if not s.hasLengthmember:
-            continue
-        if s.name in STRUCT_BLACKLIST:
-            continue
-        should_print_twocall_func = True
-
-    if not should_print_twocall_func:
-        return out
-
     out += '\n'
-    out += f'void prepare_{listName}_twocall_chain_vectors(std::unique_ptr<{listName}_chain>& chain) {{\n'
+    out += f'bool prepare_{listName}_twocall_chain_vectors(std::unique_ptr<{listName}_chain>& chain) {{\n'
+    out += '    (void)chain;\n'
+    is_twocall = False
     for s in structs_to_print:
         if not s.hasLengthmember:
             continue
@@ -925,6 +916,8 @@ void setup_{listName}_chain({chain_details['holder_type']}& start, std::unique_p
                 out += f'    chain->{s.name}_{member.name}.resize(chain->{s.name[2:]}.{member.arrayLength});\n'
                 out += f'    chain->{s.name[2:]}.{member.name} = chain->{s.name}_{member.name}.data();\n'
         out += AddGuardFooter(s)
+        is_twocall = True
+    out += f'    return {"true" if is_twocall else "false"};\n'
     out += '}\n'
 
     return out

--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -4061,13 +4061,15 @@ void chain_iterator_phys_device_props2(Printer &p, AppInstance &inst, AppGpu &gp
     }
 }
 
-void prepare_phys_device_props2_twocall_chain_vectors(std::unique_ptr<phys_device_props2_chain>& chain) {
+bool prepare_phys_device_props2_twocall_chain_vectors(std::unique_ptr<phys_device_props2_chain>& chain) {
+    (void)chain;
     chain->VkPhysicalDeviceHostImageCopyPropertiesEXT_pCopySrcLayouts.resize(chain->PhysicalDeviceHostImageCopyPropertiesEXT.copySrcLayoutCount);
     chain->PhysicalDeviceHostImageCopyPropertiesEXT.pCopySrcLayouts = chain->VkPhysicalDeviceHostImageCopyPropertiesEXT_pCopySrcLayouts.data();
     chain->VkPhysicalDeviceHostImageCopyPropertiesEXT_pCopyDstLayouts.resize(chain->PhysicalDeviceHostImageCopyPropertiesEXT.copyDstLayoutCount);
     chain->PhysicalDeviceHostImageCopyPropertiesEXT.pCopyDstLayouts = chain->VkPhysicalDeviceHostImageCopyPropertiesEXT_pCopyDstLayouts.data();
     chain->VkPhysicalDeviceLayeredApiPropertiesListKHR_pLayeredApis.resize(chain->PhysicalDeviceLayeredApiPropertiesListKHR.layeredApiCount);
     chain->PhysicalDeviceLayeredApiPropertiesListKHR.pLayeredApis = chain->VkPhysicalDeviceLayeredApiPropertiesListKHR_pLayeredApis.data();
+    return true;
 }
 struct phys_device_mem_props2_chain {
     phys_device_mem_props2_chain() = default;
@@ -4096,6 +4098,11 @@ void setup_phys_device_mem_props2_chain(VkPhysicalDeviceMemoryProperties2& start
     chain->initialize_chain(gpu);
     start.pNext = chain->start_of_chain;
 };
+
+bool prepare_phys_device_mem_props2_twocall_chain_vectors(std::unique_ptr<phys_device_mem_props2_chain>& chain) {
+    (void)chain;
+    return false;
+}
 struct phys_device_features2_chain {
     phys_device_features2_chain() = default;
     phys_device_features2_chain(const phys_device_features2_chain &) = delete;
@@ -5408,6 +5415,11 @@ void chain_iterator_phys_device_features2(Printer &p, AppGpu &gpu, bool show_pro
         place = structure->pNext;
     }
 }
+
+bool prepare_phys_device_features2_twocall_chain_vectors(std::unique_ptr<phys_device_features2_chain>& chain) {
+    (void)chain;
+    return false;
+}
 struct surface_capabilities2_chain {
     surface_capabilities2_chain() = default;
     surface_capabilities2_chain(const surface_capabilities2_chain &) = delete;
@@ -5474,6 +5486,11 @@ void chain_iterator_surface_capabilities2(Printer &p, AppInstance &inst, AppGpu 
         place = structure->pNext;
     }
 }
+
+bool prepare_surface_capabilities2_twocall_chain_vectors(std::unique_ptr<surface_capabilities2_chain>& chain) {
+    (void)chain;
+    return false;
+}
 struct format_properties2_chain {
     format_properties2_chain() = default;
     format_properties2_chain(const format_properties2_chain &) = delete;
@@ -5523,6 +5540,11 @@ void chain_iterator_format_properties2(Printer &p, AppGpu &gpu, void * place) {
         }
         place = structure->pNext;
     }
+}
+
+bool prepare_format_properties2_twocall_chain_vectors(std::unique_ptr<format_properties2_chain>& chain) {
+    (void)chain;
+    return false;
 }
 struct queue_properties2_chain {
     queue_properties2_chain() = default;
@@ -5582,6 +5604,11 @@ void chain_iterator_queue_properties2(Printer &p, AppGpu &gpu, void * place) {
         }
         place = structure->pNext;
     }
+}
+
+bool prepare_queue_properties2_twocall_chain_vectors(std::unique_ptr<queue_properties2_chain>& chain) {
+    (void)chain;
+    return false;
 }
 bool operator==(const VkExtent2D & a, const VkExtent2D b);
 bool operator==(const VkSurfaceCapabilities2EXT & a, const VkSurfaceCapabilities2EXT b);

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -274,7 +274,7 @@ void setup_surface_capabilities2_chain(VkSurfaceCapabilities2KHR &start, std::un
 void setup_format_properties2_chain(VkFormatProperties2 &start, std::unique_ptr<format_properties2_chain> &chain, AppGpu &gpu);
 void setup_queue_properties2_chain(VkQueueFamilyProperties2 &start, std::unique_ptr<queue_properties2_chain> &chain, AppGpu &gpu);
 
-void prepare_phys_device_props2_twocall_chain_vectors(std::unique_ptr<phys_device_props2_chain> &chain);
+bool prepare_phys_device_props2_twocall_chain_vectors(std::unique_ptr<phys_device_props2_chain> &chain);
 
 /* An ptional contains either a value or nothing. The optional asserts if a value is trying to be gotten but none exist.
  * The interface is taken from C++17's <optional> with many aspects removed.


### PR DESCRIPTION
VulkanSC found that the twocall machinery makes the assumption that there is at least one property output struct with array members. While this breaks VulkanSC (results in unresolved external symbol), it also breaks Vulkan when used with older `vk.xml` files where this assumption may also not hold true. Also, instead of unconditionally querying properties twice, only call the query again if the given output struct has array members.

_Note: the current refinement is still "happens to work" territory, as a generic solution would need to do `n` calls to query, depending on the number of nesting of structs with array members. `twocall` works today but may break tomorrow._