### PR TITLE
cube: Link to Vulkan-Loader on macOS

### DIFF
--- a/cube/macOS/cube/CMakeLists.txt
+++ b/cube/macOS/cube/CMakeLists.txt
@@ -59,7 +59,7 @@ add_dependencies(vkcube MoltenVK_icd-staging-json)
 target_include_directories(vkcube PRIVATE . ${MOLTENVK_DIR}/MoltenVK/include)
 
 # We do this so vkcube is linked to an individual library and NOT a framework.
-target_link_libraries(vkcube "-framework Cocoa -framework QuartzCore")
+target_link_libraries(vkcube Vulkan::Loader "-framework Cocoa -framework QuartzCore")
 
 # Disable warnings about sprintf
 target_compile_options(vkcube PRIVATE -Wno-deprecated-declarations)

--- a/cube/macOS/cubepp/CMakeLists.txt
+++ b/cube/macOS/cubepp/CMakeLists.txt
@@ -59,7 +59,7 @@ add_dependencies(vkcubepp MoltenVK_icd-staging-json)
 target_include_directories(vkcubepp PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${MOLTENVK_DIR}/MoltenVK/include)
 
 # We do this so vkcubepp is linked to an individual library and NOT a framework.
-target_link_libraries(vkcubepp "-framework Cocoa -framework QuartzCore")
+target_link_libraries(vkcubepp Vulkan::Loader "-framework Cocoa -framework QuartzCore")
 
 set_target_properties(vkcubepp PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_LIST_DIR}/Info.plist)
 


### PR DESCRIPTION
This was accidentally undone during the changes to cube to handle runtime WSI selection. By not linking, vkcube does not work unless the SDK is installed globally (ie, moltenvk is available globally).