### PR TITLE
vkcube & vkcubepp: Select physical device before create surface if platform is WSI Display

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -5073,12 +5073,15 @@ int main(int argc, char **argv) {
 #endif
 #if defined(VK_USE_PLATFORM_DISPLAY_KHR)
         case (WSI_PLATFORM_DISPLAY):
-            // nothing to do here
+            // select physical device because display surface creation need gpu is selected.
+            demo_select_physical_device(&demo);
             break;
 #endif
     }
     demo_create_surface(&demo);
-    demo_select_physical_device(&demo);
+    if (demo.wsi_platform != WSI_PLATFORM_DISPLAY) {
+        demo_select_physical_device(&demo);
+    }
 
     demo_init_vk_swapchain(&demo);
 

--- a/cube/cube.c
+++ b/cube/cube.c
@@ -5073,7 +5073,7 @@ int main(int argc, char **argv) {
 #endif
 #if defined(VK_USE_PLATFORM_DISPLAY_KHR)
         case (WSI_PLATFORM_DISPLAY):
-            // select physical device because display surface creation need gpu is selected.
+            // select physical device because display surface creation needs a gpu to be selected.
             demo_select_physical_device(&demo);
             break;
 #endif

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -3826,7 +3826,7 @@ int main(int argc, char **argv) {
 #endif
 #if defined(VK_USE_PLATFORM_DISPLAY_KHR)
         case (WsiPlatform::display):
-            // select physical device because display surface creation need gpu is selected.
+           // select physical device because display surface creation needs a gpu to be selected.
             demo.select_physical_device();
             break;
 #endif

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -3826,14 +3826,17 @@ int main(int argc, char **argv) {
 #endif
 #if defined(VK_USE_PLATFORM_DISPLAY_KHR)
         case (WsiPlatform::display):
-            // nothing to do here
+            // select physical device because display surface creation need gpu is selected.
+            demo.select_physical_device();
             break;
 #endif
     }
 
     demo.create_surface();
 
-    demo.select_physical_device();
+    if (demo.wsi_platform != WsiPlatform::display) {
+        demo.select_physical_device();
+    }
 
     demo.init_vk_swapchain();
 


### PR DESCRIPTION
If platform is WSI Display, vkcube will use physical device when creating surface.