### PR TITLE
vulkaninfo: suppress -isystem being passed

### DIFF
--- a/vulkaninfo/CMakeLists.txt
+++ b/vulkaninfo/CMakeLists.txt
@@ -22,7 +22,8 @@ set(VULKANINFO_NAME vulkaninfo)
 set(GENERATED generated)
 
 add_executable(vulkaninfo)
-set_target_properties(vulkaninfo PROPERTIES OUTPUT_NAME ${VULKANINFO_NAME})
+set_target_properties(vulkaninfo PROPERTIES OUTPUT_NAME ${VULKANINFO_NAME}
+                                            NO_SYSTEM_FROM_IMPORTED 1)
 
 target_sources(vulkaninfo PRIVATE vulkaninfo.cpp)
 


### PR DESCRIPTION
During the process of updating vulkan-tools in buildroot I ran into the following build failure:

  [ 50%] Building CXX object vulkaninfo/CMakeFiles/vulkaninfo.dir/vulkaninfo.cpp.o
  In file included from /home/alex/lsrc/tests/buildroot.git/builds/arm64/host/aarch64-buildroot-linux-gnu/include/c++/14.2.0/bits/stl_algo.h:71,
                   from /home/alex/lsrc/tests/buildroot.git/builds/arm64/host/aarch64-buildroot-linux-gnu/include/c++/14.2.0/algorithm:61,
                   from /home/alex/lsrc/tests/buildroot.git/builds/arm64/build/vulkan-tools-1.4.307/vulkaninfo/./vulkaninfo.h:31,
                   from /home/alex/lsrc/tests/buildroot.git/builds/arm64/build/vulkan-tools-1.4.307/vulkaninfo/generated/vulkaninfo.hpp:28,
                   from /home/alex/lsrc/tests/buildroot.git/builds/arm64/build/vulkan-tools-1.4.307/vulkaninfo/vulkaninfo.cpp:34:
  /home/alex/lsrc/tests/buildroot.git/builds/arm64/host/aarch64-buildroot-linux-gnu/include/c++/14.2.0/cstdlib:79:15: fatal error: stdlib.h: No such file or directory
     79 | #include_next <stdlib.h>
        |               ^~~~~~~~~~
  compilation terminated.
  make[2]: *** [vulkaninfo/CMakeFiles/vulkaninfo.dir/build.make:76: vulkaninfo/CMakeFiles/vulkaninfo.dir/vulkaninfo.cpp.o] Error 1
  make[1]: *** [CMakeFiles/Makefile2:116: vulkaninfo/CMakeFiles/vulkaninfo.dir/all] Error 2
  make: *** [Makefile:136: all] Error 2

The underlying reason was -isystem being passed to the build which I think resets the include path for system includes. This might be a bug in cmake but from looking at the CMake source I found some examples that set: NO_SYSTEM_FROM_IMPORTED 1 as a target property which seems to do the job.

This doesn't seem to affect the normal non-cross build although I wouldn't expect you need to pass -isystem anyway.