### PR TITLE
vkcubepp: Fix implicit cast compiler warnings

### DIFF
--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -1064,7 +1064,7 @@ void Demo::init(int argc, char **argv) {
         if ((strcmp(argv[i], "--wsi") == 0) && (i < argc - 1)) {
             std::string selection_input = argv[i + 1];
             for (char &c : selection_input) {
-                c = std::tolower(c);
+                c = static_cast<char>(std::tolower(c));
             }
             WsiPlatform selection = wsi_from_string(selection_input);
             if (selection == WsiPlatform::invalid) {
@@ -2689,7 +2689,7 @@ void Demo::prepare_textures() {
                              textures[i].imageLayout, vk::AccessFlagBits::eTransferWrite, vk::PipelineStageFlagBits::eTransfer,
                              vk::PipelineStageFlagBits::eFragmentShader);
         } else {
-            assert(!"No support for R8G8B8A8_SRGB as texture image format");
+            assert(false && "No support for R8G8B8A8_SRGB as texture image format");
         }
 
         auto const samplerInfo = vk::SamplerCreateInfo()


### PR DESCRIPTION
1. std::tolower() returns an `int` value. Implicit converting an `int` to a `char` may trigger compiler warnings (-Wconversion on gcc and clang).

This change adds an explicit cast to suppress the implicit conversion warnings.

2. Previously we used `assert(!"....")` to show error messages. This does an implicit conversion from `const char*` to `bool` which triggers compiler warnings (-Wconversion).

This change replaces it with `assert(false && "...")` which doesn't trigger the warning.

Bug: https://fxbug.dev/378964821
