### PR TITLE
vulkaninfo: Support Fuchsia

### DIFF
--- a/vulkaninfo/BUILD.gn
+++ b/vulkaninfo/BUILD.gn
@@ -1,0 +1,79 @@
+# Copyright (C) 2025 The Fuchsia Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/vulkan_tools.gni")
+if (is_fuchsia) {
+  import("//build/components.gni")
+  import("//src/lib/vulkan/vulkan.gni")
+}
+
+config("vulkaninfo_warnings") {
+  cflags = [
+    "-Wno-conversion",
+    "-Wno-implicit-fallthrough",
+    "-Wno-missing-field-initializers",
+    "-Wno-extra-semi",
+    "-Wno-ambiguous-reversed-operator",
+  ]
+}
+
+executable("vulkaninfo") {
+  sources = [ "vulkaninfo.cpp" ]
+
+  include_dirs = [
+    ".",
+    "generated",
+  ]
+
+  deps = [ "$vulkan_headers_dir:vulkan_headers" ]
+  if (is_fuchsia) {
+    deps += [ "//third_party/Vulkan-Loader:libvulkan" ]
+  }
+
+  configs += [
+    ":vulkaninfo_warnings",
+    "${volk_dir}:volk_config",
+  ]
+  if (is_fuchsia) {
+    configs -= [ "//build/config:no_exceptions" ]
+  }
+
+  defines = [
+    "VK_ENABLE_BETA_EXTENSIONS",
+    "VK_NO_PROTOTYPES",
+  ]
+}
+
+if (is_fuchsia) {
+  fuchsia_test_component("vulkaninfo-component") {
+    manifest = "fuchsia/meta/vulkaninfo.cml"
+    component_name = "vulkaninfo"
+
+    deps = [
+      ":vulkaninfo",
+      "//src/lib/vulkan/swapchain:image_pipe_swapchain_fb_layer",
+      "//src/lib/vulkan/validation_layers",
+    ]
+    test_type = "vulkan"
+  }
+
+  fuchsia_test_package("vulkaninfo-package") {
+    package_name = "vulkaninfo"
+    test_components = [ ":vulkaninfo-component" ]
+
+    test_specs = {
+      environments = vulkan_envs
+    }
+  }
+}

--- a/vulkaninfo/fuchsia/meta/vulkaninfo.cml
+++ b/vulkaninfo/fuchsia/meta/vulkaninfo.cml
@@ -1,0 +1,23 @@
+// Copyright (C) 2025 The Fuchsia Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+{
+    include: [
+        "sys/testing/elf_test_runner.shard.cml",
+        "syslog/client.shard.cml",
+        "vulkan/client.shard.cml",
+    ],
+    program: {
+        binary: "bin/vulkaninfo",
+    },
+}


### PR DESCRIPTION
This change adds Fuchsia-specific build files and metadata for vulkaninfo so that it builds on Fuchsia.

Test: vulkaninfo on Fuchsia
Bug: https://fxbug.dev/378964821
