### PR TITLE
cube: prefer Wayland over X11 when available

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -3665,6 +3665,30 @@ static const char *demo_init_wayland_connection(struct demo *demo) {
 // If the wsi_platform is AUTO, this function also sets wsi_platform to the first available WSI platform
 // Otherwise, it errors out if the specified wsi_platform isn't available
 static void demo_check_and_set_wsi_platform(struct demo *demo) {
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+    if (demo->wsi_platform == WSI_PLATFORM_WAYLAND || demo->wsi_platform == WSI_PLATFORM_AUTO) {
+        bool wayland_extension_available = false;
+        for (uint32_t i = 0; i < demo->enabled_extension_count; i++) {
+            if (strcmp(demo->extension_names[i], VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) == 0) {
+                wayland_extension_available = true;
+                break;
+            }
+        }
+        if (wayland_extension_available) {
+            const char *error_msg = demo_init_wayland_connection(demo);
+            if (error_msg != NULL) {
+                if (demo->wsi_platform == WSI_PLATFORM_WAYLAND) {
+                    fprintf(stderr, "%s\nExiting ...\n", error_msg);
+                    fflush(stdout);
+                    exit(1);
+                }
+            } else {
+                demo->wsi_platform = WSI_PLATFORM_WAYLAND;
+                return;
+            }
+        }
+    }
+#endif
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     if (demo->wsi_platform == WSI_PLATFORM_XCB || demo->wsi_platform == WSI_PLATFORM_AUTO) {
         bool xcb_extension_available = false;
@@ -3708,30 +3732,6 @@ static void demo_check_and_set_wsi_platform(struct demo *demo) {
                 }
             } else {
                 demo->wsi_platform = WSI_PLATFORM_XLIB;
-                return;
-            }
-        }
-    }
-#endif
-#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-    if (demo->wsi_platform == WSI_PLATFORM_WAYLAND || demo->wsi_platform == WSI_PLATFORM_AUTO) {
-        bool wayland_extension_available = false;
-        for (uint32_t i = 0; i < demo->enabled_extension_count; i++) {
-            if (strcmp(demo->extension_names[i], VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) == 0) {
-                wayland_extension_available = true;
-                break;
-            }
-        }
-        if (wayland_extension_available) {
-            const char *error_msg = demo_init_wayland_connection(demo);
-            if (error_msg != NULL) {
-                if (demo->wsi_platform == WSI_PLATFORM_WAYLAND) {
-                    fprintf(stderr, "%s\nExiting ...\n", error_msg);
-                    fflush(stdout);
-                    exit(1);
-                }
-            } else {
-                demo->wsi_platform = WSI_PLATFORM_WAYLAND;
                 return;
             }
         }

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -1209,6 +1209,25 @@ const char *Demo::init_wayland_connection() {
 #endif
 
 void Demo::check_and_set_wsi_platform() {
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+    if (wsi_platform == WsiPlatform::wayland || wsi_platform == WsiPlatform::auto_) {
+        auto found = std::find_if(enabled_instance_extensions.begin(), enabled_instance_extensions.end(),
+                                  [](const char *str) { return 0 == strcmp(str, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME); });
+        if (found != enabled_instance_extensions.end()) {
+            const char *error_msg = init_wayland_connection();
+            if (error_msg != NULL) {
+                if (wsi_platform == WsiPlatform::wayland) {
+                    fprintf(stderr, "%s\nExiting ...\n", error_msg);
+                    fflush(stdout);
+                    exit(1);
+                }
+            } else {
+                wsi_platform = WsiPlatform::wayland;
+                return;
+            }
+        }
+    }
+#endif
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     if (wsi_platform == WsiPlatform::xcb || wsi_platform == WsiPlatform::auto_) {
         auto found = std::find_if(enabled_instance_extensions.begin(), enabled_instance_extensions.end(),
@@ -1242,25 +1261,6 @@ void Demo::check_and_set_wsi_platform() {
                 }
             } else {
                 wsi_platform = WsiPlatform::xlib;
-                return;
-            }
-        }
-    }
-#endif
-#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-    if (wsi_platform == WsiPlatform::wayland || wsi_platform == WsiPlatform::auto_) {
-        auto found = std::find_if(enabled_instance_extensions.begin(), enabled_instance_extensions.end(),
-                                  [](const char *str) { return 0 == strcmp(str, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME); });
-        if (found != enabled_instance_extensions.end()) {
-            const char *error_msg = init_wayland_connection();
-            if (error_msg != NULL) {
-                if (wsi_platform == WsiPlatform::wayland) {
-                    fprintf(stderr, "%s\nExiting ...\n", error_msg);
-                    fflush(stdout);
-                    exit(1);
-                }
-            } else {
-                wsi_platform = WsiPlatform::wayland;
                 return;
             }
         }


### PR DESCRIPTION
In Wayland sessions, X11 is still available through a compatibility layer, but should effectively never be used over a native Wayland connection if the application is capable of that.