### PR TITLE
ci: Prevent double-running ci in main repo

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -29,10 +29,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-    linux:        
+    linux:
         needs: tools_codegen
         runs-on: ${{matrix.os}}
-
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
         strategy:
             matrix:
                 cc: [ gcc ]
@@ -102,9 +102,10 @@ jobs:
         - run: scripts/update_deps.py --dir ext --no-build
         - run: scripts/generate_source.py --verify ext/Vulkan-Headers/registry/
 
-    windows:       
+    windows:
         needs: tools_codegen
         runs-on: ${{matrix.os}}
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
         strategy:
             matrix:
@@ -139,6 +140,7 @@ jobs:
         # mac is 10x expensive to run on GitHub machines, so only run if we know something else fast/simple passed as well
         needs: chromium
         runs-on: macos-latest
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-python@v5
@@ -163,9 +165,10 @@ jobs:
 
             - run: cmake --install build --prefix /tmp
 
-    android:      
+    android:
       needs: tools_codegen
       runs-on: ubuntu-22.04
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
       strategy:
         matrix:
           abi: [ armeabi-v7a, arm64-v8a ]
@@ -197,6 +200,7 @@ jobs:
 
     mingw:
         needs: tools_codegen
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
         runs-on: windows-latest
         defaults:
           run:
@@ -225,6 +229,7 @@ jobs:
 
     tools_codegen:
       needs: codegen
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
@@ -238,6 +243,7 @@ jobs:
 
     chromium:
       needs: tools_codegen
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4


### PR DESCRIPTION
Prevents pushes to branches on the main repo from having ci run if there is an active PR on that branch to main.