### PR TITLE
build: update volk branch to vulkan-sdk-1.4.309

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -35,7 +35,7 @@
             "cmake_options": [
                 "-DVOLK_INSTALL=ON"
             ],
-            "commit": "vulkan-tmp-1.4.309",
+            "commit": "vulkan-sdk-1.4.309",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",


### PR DESCRIPTION
Remove the reference to the vulkan-tmp-1.4.309 branch which will be deleted eventually. This vulkan-sdk-1.4.309 is branched at the same location as the tmp branch.