### PR TITLE
cube: Update missing WSI extension messages 

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -1704,19 +1704,16 @@ bool loadTexture(const char *filename, uint8_t *rgba_data, VkSubresourceLayout *
     if ((unsigned char *)cPtr >= (lunarg_ppm + lunarg_ppm_len) || strncmp(cPtr, "P6\n", 3)) {
         return false;
     }
-    while (strncmp(cPtr++, "\n", 1))
-        ;
+    while (strncmp(cPtr++, "\n", 1));
     sscanf(cPtr, "%u %u", width, height);
     if (rgba_data == NULL) {
         return true;
     }
-    while (strncmp(cPtr++, "\n", 1))
-        ;
+    while (strncmp(cPtr++, "\n", 1));
     if ((unsigned char *)cPtr >= (lunarg_ppm + lunarg_ppm_len) || strncmp(cPtr, "255\n", 4)) {
         return false;
     }
-    while (strncmp(cPtr++, "\n", 1))
-        ;
+    while (strncmp(cPtr++, "\n", 1));
     for (int y = 0; y < *height; y++) {
         uint8_t *rowPtr = rgba_data;
         for (int x = 0; x < *width; x++) {

--- a/cube/cube.c
+++ b/cube/cube.c
@@ -4060,98 +4060,95 @@ static void demo_init_vk(struct demo *demo) {
 
     if (!surfaceExtFound) {
         ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_SURFACE_EXTENSION_NAME
-                 " extension.\n\n"
-                 "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                 "Please look at the Getting Started guide for additional information.\n",
+                 " instance extension.\n\n"
+                 "This indicates that no compatible Vulkan installable client driver (ICD) is present or that the system is not "
+                 "configured to present to the screen. \n",
                  "vkCreateInstance Failure");
     }
     if (!platformSurfaceExtFound) {
+        switch (demo->wsi_platform) {
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-        if (demo->wsi_platform == WSI_PLATFORM_WIN32) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_WIN32_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WSI_PLATFORM_WIN32):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_WIN32_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform win32 is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_METAL_EXT)
-        if (demo->wsi_platform == WSI_PLATFORM_METAL) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_EXT_METAL_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WSI_PLATFORM_METAL):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_EXT_METAL_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform metal is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_XCB_KHR)
-        if (demo->wsi_platform == WSI_PLATFORM_XCB) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_XCB_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WSI_PLATFORM_XCB):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_XCB_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform xcb is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-        if (demo->wsi_platform == WSI_PLATFORM_WAYLAND) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WSI_PLATFORM_WAYLAND):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform wayland is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_DISPLAY_KHR)
-        if (demo->wsi_platform == WSI_PLATFORM_DISPLAY) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_DISPLAY_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WSI_PLATFORM_DISPLAY):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_DISPLAY_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform display is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-        if (demo->wsi_platform == WSI_PLATFORM_ANDROID) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_ANDROID_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WSI_PLATFORM_ANDROID):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_ANDROID_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform android is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
-        if (demo->wsi_platform == WSI_PLATFORM_XLIB) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_XLIB_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WSI_PLATFORM_XLIB):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_XLIB_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform xlib is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
-        if (demo->wsi_platform == WSI_PLATFORM_DIRECTFB) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_EXT_DIRECTFB_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WSI_PLATFORM_DIRECTFB):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_EXT_DIRECTFB_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform directfb is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_SCREEN_QNX)
-        if (demo->wsi_platform == WSI_PLATFORM_WIN32) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_QNX_SCREEN_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WSI_PLATFORM_QNX):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_QNX_SCREEN_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform qnx is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
-        ERR_EXIT(
-            "vkEnumerateInstanceExtensionProperties failed to find any supported WSI surface extension.\n\n"
-            "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-            "Please look at the Getting Started guide for additional information.\n",
-            "vkCreateInstance Failure");
+            default:
+            case (WSI_PLATFORM_AUTO):
+                // Getting here indicates we are using the WSI extension that is default on this platform
+                ERR_EXIT(
+                    "vkEnumerateInstanceExtensionProperties failed to find any supported WSI surface instance extensions.\n\n"
+                    "This indicates that no compatible Vulkan installable client driver (ICD) is present or that the system is not "
+                    "configured to present to the screen. \n",
+                    "vkCreateInstance Failure");
+                break;
+        }
     }
 
     bool auto_wsi_platform = demo->wsi_platform == WSI_PLATFORM_AUTO;

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -1896,7 +1896,9 @@ void Demo::select_physical_device() {
             exit(1);
         }
 #else
-        printf("WSI selection was set to DISPLAY but vkcubepp was not compiled with support for the DISPLAY platform, exiting \n");
+        printf(
+            "WSI selection was set to DISPLAY but vkcubepp was not compiled with support for the DISPLAY platform, exiting "
+            "\n");
         fflush(stdout);
         exit(1);
 #endif
@@ -2975,7 +2977,8 @@ void Demo::resize() {
     // In order to properly resize the window, we must re-create the
     // swapchain
     //
-    // First, destroy the old swapchain and its associated resources, setting swapchain_ready to false to prevent draw from running
+    // First, destroy the old swapchain and its associated resources, setting swapchain_ready to false to prevent draw from
+    // running
     if (swapchain_ready) {
         swapchain_ready = false;
         auto result = device.waitIdle();

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -1712,102 +1712,96 @@ void Demo::init_vk() {
 
     if (!surfaceExtFound) {
         ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_SURFACE_EXTENSION_NAME
-                 " extension.\n\n"
-                 "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                 "Please look at the Getting Started guide for additional information.\n",
+                 " instance extension.\n\n"
+                 "This indicates that no compatible Vulkan installable client driver (ICD) is present or that the system is not "
+                 "configured to present to the screen. \n",
                  "vkCreateInstance Failure");
     }
 
     if (!platformSurfaceExtFound) {
+        switch (wsi_platform) {
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-        if (wsi_platform == WsiPlatform::win32) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_WIN32_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WsiPlatform::win32):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_WIN32_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform win32 is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_XCB_KHR)
-        if (wsi_platform == WsiPlatform::xcb) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_XCB_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WsiPlatform::xcb):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_XCB_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform xcb is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-        if (wsi_platform == WsiPlatform::wayland) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WsiPlatform::wayland):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform wayland is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
-        if (wsi_platform == WsiPlatform::xlib) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_XLIB_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WsiPlatform::xlib):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_XLIB_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform xlib is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
-        if (wsi_platform == WsiPlatform::directfb) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_EXT_DIRECTFB_SURFACE_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WsiPlatform::directfb):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_EXT_DIRECTFB_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform directfb is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_DISPLAY_KHR)
-        if (wsi_platform == WsiPlatform::display) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_DISPLAY_EXTENSION_NAME
-                     " extension.\n\n"
-                     "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-                     "Please look at the Getting Started guide for additional information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WsiPlatform::display):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_KHR_DISPLAY_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform display is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_METAL_EXT)
-        if (wsi_platform == WsiPlatform::metal) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_EXT_METAL_SURFACE_EXTENSION_NAME
-                     " extension.\n\nDo you have a compatible "
-                     "Vulkan installable client driver (ICD) installed?\nPlease "
-                     "look at the Getting Started guide for additional "
-                     "information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WsiPlatform::metal):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_EXT_METAL_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform metal is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_SCREEN_QNX)
-        if (wsi_platform == WsiPlatform::qnx) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_QNX_SCREEN_SURFACE_EXTENSION_NAME
-                     " extension.\n\nDo you have a compatible "
-                     "Vulkan installable client driver (ICD) installed?\nPlease "
-                     "look at the Getting Started guide for additional "
-                     "information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WsiPlatform::qnx):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_QNX_SCREEN_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform qnx is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
 #if defined(VK_USE_PLATFORM_FUCHSIA)
-        if (wsi_platform == WsiPlatform::fuchsia_display || wsi_platform == WsiPlatform::fuchsia_scenic) {
-            ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_FUCHSIA_IMAGEPIPE_SURFACE_EXTENSION_NAME
-                     " extension.\n\nDo you have a compatible "
-                     "Vulkan installable client driver (ICD) installed?\nPlease "
-                     "look at the Getting Started guide for additional "
-                     "information.\n",
-                     "vkCreateInstance Failure");
-        }
+            case (WsiPlatform::fuchsia_display):
+            case (WsiPlatform::fuchsia_scenic):
+                ERR_EXIT("vkEnumerateInstanceExtensionProperties failed to find the " VK_FUCHSIA_IMAGEPIPE_SURFACE_EXTENSION_NAME
+                         " instance extension.\n\n"
+                         "The selected WSI platform fuschia is not available, please choose a different WSI platform\n",
+                         "vkCreateInstance Failure");
+                break;
 #endif
-        ERR_EXIT(
-            "vkEnumerateInstanceExtensionProperties failed to find any supported WSI surface extension.\n\n"
-            "Do you have a compatible Vulkan installable client driver (ICD) installed?\n"
-            "Please look at the Getting Started guide for additional information.\n",
-            "vkCreateInstance Failure");
+            default:
+            case (WsiPlatform::auto_):
+                // Getting here indicates we are using the WSI extension that is default on this platform
+                ERR_EXIT(
+                    "vkEnumerateInstanceExtensionProperties failed to find any supported WSI surface instance extensions.\n\n"
+                    "This indicates that no compatible Vulkan installable client driver (ICD) is present or that the system is not "
+                    "configured to present to the screen. \n",
+                    "vkCreateInstance Failure");
+        }
     }
 
     bool auto_wsi_platform = wsi_platform == WsiPlatform::auto_;


### PR DESCRIPTION
Better indicates the error that triggered the message,
and what the user should do about it.

Also update the formatting of the cube source files to use clang-format-18 since they hadn't been updated in a while.