### PR TITLE
cube: Link to CMAKE_DL_LIBS

### DIFF
--- a/cube/CMakeLists.txt
+++ b/cube/CMakeLists.txt
@@ -285,7 +285,7 @@ endif()
 
 target_compile_definitions(vkcube PRIVATE ${ENABLED_CUBE_PLATFORMS})
 target_include_directories(vkcube PRIVATE .)
-target_link_libraries(vkcube  Vulkan::Headers)
+target_link_libraries(vkcube ${CMAKE_DL_LIBS} Vulkan::Headers)
 
 if (ANDROID)
     install(TARGETS vkcube DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -358,7 +358,7 @@ endif()
 
 target_include_directories(vkcubepp PRIVATE .)
 target_compile_definitions(vkcubepp PRIVATE ${ENABLED_CUBE_PLATFORMS})
-target_link_libraries(vkcubepp Vulkan::Headers)
+target_link_libraries(vkcubepp ${CMAKE_DL_LIBS} Vulkan::Headers)
 
 if (XCB_LINK_LIBRARIES )
     target_compile_definitions(vkcubepp PUBLIC "XCB_LIBRARY=\"${XCB_LINK_LIBRARIES}\"")


### PR DESCRIPTION
Previously volk was doing this for cube, but with that removed vkcube/vkcubepp have to link it themselves.