### PR TITLE
build: Update to header 1.4.321

### DIFF
--- a/icd/VkICD_mock_icd.json.in
+++ b/icd/VkICD_mock_icd.json.in
@@ -2,6 +2,6 @@
     "file_format_version": "1.0.1",
     "ICD": {
         "library_path": "@JSON_LIBRARY_PATH@",
-        "api_version": "1.4.320"
+        "api_version": "1.4.321"
     }
 }

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -7,7 +7,7 @@
             "sub_dir": "Vulkan-Headers",
             "build_dir": "Vulkan-Headers/build",
             "install_dir": "Vulkan-Headers/build/install",
-            "commit": "v1.4.320"
+            "commit": "v1.4.321"
         },
         {
             "name": "MoltenVK",
@@ -56,7 +56,7 @@
             "cmake_options": [
                 "-DLOADER_USE_UNSAFE_FILE_SEARCH=ON"
             ],
-            "commit": "v1.4.320",
+            "commit": "v1.4.321",
             "build_platforms": [
                 "windows",
                 "linux",


### PR DESCRIPTION
not sure if this was intentionally missed, bump the header to 1.4.321 (saw it when autobumping vulkan formulae on the homebrew side)

also, maybe cut a new release to bump tools to 1.4.321? Thanks!
