### PR TITLE
build: Remove pkg-config provided library names

### DIFF
--- a/cube/CMakeLists.txt
+++ b/cube/CMakeLists.txt
@@ -307,16 +307,6 @@ if (ANDROID)
     return()
 endif()
 
-if (XCB_LINK_LIBRARIES)
-    target_compile_definitions(vkcube PRIVATE "XCB_LIBRARY=\"${XCB_LINK_LIBRARIES}\"")
-endif()
-if (X11_LINK_LIBRARIES)
-    target_compile_definitions(vkcube PRIVATE "XLIB_LIBRARY=\"${X11_LINK_LIBRARIES}\"")
-endif()
-if (WAYLAND_CLIENT_LINK_LIBRARIES)
-    target_compile_definitions(vkcube PRIVATE "WAYLAND_LIBRARY=\"${WAYLAND_CLIENT_LINK_LIBRARIES}\"")
-endif()
-
 # ----------------------------------------------------------------------------
 # vkcubepp
 
@@ -359,16 +349,6 @@ endif()
 target_include_directories(vkcubepp PRIVATE .)
 target_compile_definitions(vkcubepp PRIVATE ${ENABLED_CUBE_PLATFORMS})
 target_link_libraries(vkcubepp ${CMAKE_DL_LIBS} Vulkan::Headers)
-
-if (XCB_LINK_LIBRARIES )
-    target_compile_definitions(vkcubepp PUBLIC "XCB_LIBRARY=\"${XCB_LINK_LIBRARIES}\"")
-endif()
-if (X11_LINK_LIBRARIES)
-    target_compile_definitions(vkcubepp PUBLIC "XLIB_LIBRARY=\"${X11_LINK_LIBRARIES}\"")
-endif()
-if (WAYLAND_CLIENT_LINK_LIBRARIES)
-    target_compile_definitions(vkcubepp PUBLIC "WAYLAND_LIBRARY=\"${WAYLAND_CLIENT_LINK_LIBRARIES}\"")
-endif()
 
 if(APPLE)
     install(

--- a/cube/wayland_loader.h
+++ b/cube/wayland_loader.h
@@ -80,9 +80,6 @@ static PFN_wl_display_disconnect cube_wl_display_disconnect = NULL;
 
 static inline void *initialize_wayland() {
     void *wayland_library = NULL;
-#if defined(WAYLAND_LIBRARY)
-    wayland_library = dlopen(WAYLAND_LIBRARY, RTLD_NOW | RTLD_LOCAL);
-#endif
     if (NULL == wayland_library) {
         wayland_library = dlopen("libwayland-client.so.0", RTLD_NOW | RTLD_LOCAL);
     }

--- a/cube/xcb_loader.h
+++ b/cube/xcb_loader.h
@@ -88,9 +88,6 @@ static PFN_xcb_screen_next cube_xcb_screen_next = NULL;
 
 void *initialize_xcb() {
     void *xcb_library = NULL;
-#if defined(XCB_LIBRARY)
-    xcb_library = dlopen(XCB_LIBRARY, RTLD_NOW | RTLD_LOCAL);
-#endif
     if (NULL == xcb_library) {
         xcb_library = dlopen("libxcb.so.1", RTLD_NOW | RTLD_LOCAL);
     }

--- a/cube/xlib_loader.h
+++ b/cube/xlib_loader.h
@@ -72,9 +72,6 @@ static PFN_XFlush cube_XFlush = NULL;
 
 void* initialize_xlib() {
     void* xlib_library = NULL;
-#if defined(XLIB_LIBRARY)
-    xlib_library = dlopen(XLIB_LIBRARY, RTLD_NOW | RTLD_LOCAL);
-#endif
     if (NULL == xlib_library) {
         xlib_library = dlopen("libX11.so.6", RTLD_NOW | RTLD_LOCAL);
     }


### PR DESCRIPTION
The library names of Xcb, Xlib, and Wayland do not need to be queried from pkg-config, instead they can be hardcoded to use the fallback names.

The intent of querying the library names was to prevent issues where the hardcoded name was not the platform-appropriate name. But because <library>_LINK_LIBRARIES can have more than one library name, the logic to assign <library>_LINK_LIBRARIES into a compile definition breaks horribly. While it is possible to handle this in CMake, the dlopen code would also have to handle it which is much more error prone.