### PR TITLE
cube: Fix wayland resize broken when extent is 0xFFFFFFFF

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -1351,8 +1351,6 @@ static void demo_draw(struct demo *demo) {
         assert(!err);
         if (surfCapabilities.currentExtent.width != (uint32_t)demo->width ||
             surfCapabilities.currentExtent.height != (uint32_t)demo->height) {
-            demo->width = surfCapabilities.currentExtent.width;
-            demo->height = surfCapabilities.currentExtent.height;
             demo_resize(demo);
         }
     } else if (err == VK_ERROR_SURFACE_LOST_KHR) {

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -955,8 +955,6 @@ void Demo::draw() {
         auto caps_result = gpu.getSurfaceCapabilitiesKHR(surface, &surfCapabilities);
         VERIFY(caps_result == vk::Result::eSuccess);
         if (surfCapabilities.currentExtent.width != width || surfCapabilities.currentExtent.height != height) {
-            width = surfCapabilities.currentExtent.width;
-            height = surfCapabilities.currentExtent.height;
             resize();
         }
     } else if (present_result == vk::Result::eErrorSurfaceLostKHR) {


### PR DESCRIPTION
This is a 'magic value' that shouldn't be allowed to overwrite the current window width & height. There is code to handle the value, but not everywhere it can come from.