### PR TITLE
Disable MacOS CI warnings as errors

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -157,7 +157,7 @@ jobs:
             - name: Add ccache to PATH
               run: echo "/usr/lib/ccache:/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
 
-            - run: cmake -S. -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -D UPDATE_DEPS=ON -D INSTALL_ICD=ON -D BUILD_TESTS=ON -D ENABLE_ADDRESS_SANITIZER=ON -D BUILD_WERROR=ON
+            - run: cmake -S. -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -D UPDATE_DEPS=ON -D INSTALL_ICD=ON -D BUILD_TESTS=ON -D ENABLE_ADDRESS_SANITIZER=ON -D BUILD_WERROR=OFF # Disable warnings as unavoidable deprecation notice causes CI to fail
 
             - run: cmake --build build
 


### PR DESCRIPTION
Stops a deprecation notice from failing CI jobs for the time being while an upgrade is written.