### PR TITLE
vulkaninfo: Handle empty video profile name suffix nicer

### DIFF
--- a/scripts/vulkaninfo_generator.py
+++ b/scripts/vulkaninfo_generator.py
@@ -783,7 +783,8 @@ std::vector<std::unique_ptr<AppVideoProfile>> enumerate_supported_video_profiles
                     newProfiles = {}
                     for profileStructMemberValue, profileStructMemberName in profileStructMember.values.items():
                         for profileName, profile in profiles.items():
-                            newProfileName = f'{profileName} {profileStructMemberName}'
+                            # Only add video profile name suffix to the full descriptive name if not empty to avoid excess whitespace
+                            newProfileName = profileName if profileStructMemberName == '' else f'{profileName} {profileStructMemberName}'
                             newProfiles[newProfileName] = profile + [{
                                 "struct": profileStruct.struct,
                                 "member": profileStructMember.name,


### PR DESCRIPTION
In case the descriptive name corresponding to a `<videoprofilemember>` construct is empty, then avoid stacking space characters in the full descriptive name of the video profile.