### PR TITLE
 Use the clock_gettime() function instead of the obsolescent gettimeofday for macOS and iOS

### DIFF
--- a/cube/gettime.h
+++ b/cube/gettime.h
@@ -26,13 +26,9 @@
 
 #include <windows.h>
 
-#elif defined(__unix__) || defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__ANDROID__) || defined(__EPOC32__) || defined(__QNX__)
+#elif defined(__unix__) || defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__ANDROID__) || defined(__EPOC32__) || defined(__QNX__) || defined(__APPLE__)
 
 #include <time.h>
-
-#elif defined(__APPLE__)
-
-#include <sys/time.h>
 
 #endif
 
@@ -55,7 +51,7 @@ uint64_t getTimeInNanoseconds(void) {
         return count.QuadPart / (freq.QuadPart / ns_in_s);
     }
 
-#elif defined(__unix__) || defined(__linux) || defined(__linux__) || defined(__ANDROID__) || defined(__QNX__)
+#elif defined(__unix__) || defined(__linux) || defined(__linux__) || defined(__ANDROID__) || defined(__QNX__) || defined(__APPLE__)
     struct timespec currTime;
     clock_gettime(CLOCK_MONOTONIC, &currTime);
     return (uint64_t)currTime.tv_sec * ns_in_s + (uint64_t)currTime.tv_nsec;
@@ -65,11 +61,6 @@ uint64_t getTimeInNanoseconds(void) {
     /* Symbian supports only realtime clock for clock_gettime. */
     clock_gettime(CLOCK_REALTIME, &currTime);
     return (uint64_t)currTime.tv_sec * ns_in_s + (uint64_t)currTime.tv_nsec;
-
-#elif defined(__APPLE__)
-    struct timeval currTime;
-    gettimeofday(&currTime, NULL);
-    return (uint64_t)currTime.tv_sec * ns_in_s + (uint64_t)currTime.tv_usec * ns_in_us;
 
 #else
 #error getTimeInNanoseconds Not implemented for target OS


### PR DESCRIPTION
Hi!
clock_gettime() can be used for macos since MacOS 10.12 Sierra and iOS 10 and never, instead of the obsolescent gettimeofday() function.

see POSIX documenation https://pubs.opengroup.org/onlinepubs/9699919799/functions/gettimeofday.html