### PR TITLE
cube: Fix crash with VK_GOOGLE_display_timing

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -1332,9 +1332,7 @@ static void demo_draw(struct demo *demo) {
             .pTimes = &ptime,
         };
 
-        if (demo->VK_GOOGLE_display_timing_enabled) {
-            present.pNext = &present_time;
-        }
+        present.pNext = &present_time;
     }
 
     err = vkQueuePresentKHR(demo->present_queue, &present);


### PR DESCRIPTION
We were referencing present_time and ptime past their lifetimes in the
block, resulting in corruption of the pNext chain.