### PR TITLE
cube: Fix GOOGLE_display_timing desired-present-time calibration.

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -1143,7 +1143,7 @@ void DemoUpdateTargetIPD(struct demo *demo) {
         }
 
         if (calibrate_next) {
-            int64_t multiple = demo->next_present_id - past[count - 1].presentID;
+            int64_t multiple = demo->next_present_id - past[count - 1].presentID - 1;
             demo->prev_desired_present_time = (past[count - 1].actualPresentTime + (multiple * demo->target_IPD));
         }
         free(past);


### PR DESCRIPTION
as the name says, we're calculating what the previous present's desired time should have been, which will have IPD added for the next_present_id's presentation.  So for example, if we are processing the last presented frame's actualPresentTime, our multiple should be 0, not 1.

Now the demo properly locks to 60fps for a 1.0 IPD on my 60Hz display.