### PR TITLE
vulkaninfo: Add a show-all option

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -1059,6 +1059,7 @@ const char *help_message_body =
     "                     interest. This number can be determined by running\n"
     "                     " APP_SHORT_NAME
     " without any options specified.\n"
+    "[--show-all]         Show everything (includes all the below options)\n"
     "[--show-tool-props]  Show the active VkPhysicalDeviceToolPropertiesEXT that " APP_SHORT_NAME
     " finds.\n"
     "[--show-formats]     Display the format properties of each physical device.\n"
@@ -1079,9 +1080,11 @@ void print_usage(const std::string &executable_name) {
     std::cout << "    " << executable_name << " -j | -j=<gpu-number> | --json | --json=<gpu-number>\n";
     std::cout << "    " << executable_name << " --text\n";
     std::cout << "    " << executable_name << " --html\n";
+    std::cout << "    " << executable_name << " --show-all\n";
     std::cout << "    " << executable_name << " --show-formats\n";
     std::cout << "    " << executable_name << " --show-tool-props\n";
     std::cout << "    " << executable_name << " --show-promoted-structs\n";
+    std::cout << "    " << executable_name << " --show-video-props\n";
     std::cout << "\n" << help_message_body << std::endl;
 }
 
@@ -1138,6 +1141,11 @@ util::vulkaninfo_optional<ParsedResults> parse_arguments(int argc, char **argv, 
             results.output_category = OutputCategory::html;
             results.print_to_file = true;
             results.default_filename = APP_SHORT_NAME ".html";
+        } else if (strcmp(argv[i], "--show-all") == 0) {
+            results.show_tool_props = true;
+            results.show_formats = true;
+            results.show_promoted_structs = true;
+            results.show_video_props = true;
         } else if (strcmp(argv[i], "--show-tool-props") == 0) {
             results.show_tool_props = true;
         } else if (strcmp(argv[i], "--show-formats") == 0) {

--- a/vulkaninfo/vulkaninfo.md
+++ b/vulkaninfo/vulkaninfo.md
@@ -56,8 +56,8 @@ USAGE:
     vulkaninfo -j | -j=<gpu-number> | --json | --json=<gpu-number>
     vulkaninfo --text
     vulkaninfo --html
+    vulkaninfo --show-all
     vulkaninfo --show-formats
-    vulkaninfo --show-tool-props
 
 OPTIONS:
 [-h, --help]        Print this help.
@@ -79,9 +79,18 @@ OPTIONS:
                     specifying the gpu-number associated with the gpu of
                     interest. This number can be determined by running
                     vulkaninfo without any options specified.
-[--show-tool-props] Show the active VkPhysicalDeviceToolPropertiesEXT that vulkaninfo finds.
+[--show-all]        Show everything (includes all the below options)
 [--show-formats]    Display the format properties of each physical device.
                     Note: This only affects text output.
+[--show-tool-props] Show the active VkPhysicalDeviceToolPropertiesEXT that vulkaninfo finds.
+[--show-promoted-structs]
+                    Include structs promoted to core in pNext Chains.
+[--show-video-props]
+                    Display the video profile info, video capabilities and
+                    video format properties of each video profile supported
+                    by each physical device.
+                    Note: This only affects text output which by default
+                    only contains the list of supported video profile names.
 ```
 
 ### Windows


### PR DESCRIPTION
I kinda want a "vulkaninfo" that I know just shows everything, seeing 4 `--show` options and ya, not going to pass them all

I still feel that `--show-all` should be the default, but regardless, here is a `--show-all` to turn on everything