### PR TITLE
cube: Rename window in macOS to not refer to moltenVK

### DIFF
--- a/cube/macOS/cube/Resources/Main.storyboard
+++ b/cube/macOS/cube/Resources/Main.storyboard
@@ -11,9 +11,9 @@
                 <application id="hnw-xV-0zn" sceneMemberID="viewController">
                     <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
                         <items>
-                            <menuItem title="MoltenVK Demo" id="1Xt-HY-uBw">
+                            <menuItem title="VkCube" id="1Xt-HY-uBw">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="MoltenVK Demo" systemMenu="apple" id="uQy-DD-JDr">
+                                <menu key="submenu" title="VkCube" systemMenu="apple" id="uQy-DD-JDr">
                                     <items>
                                         <menuItem title="About Demo" id="5kV-Vb-QxS">
                                             <modifierMask key="keyEquivalentModifierMask"/>
@@ -77,7 +77,7 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
                                     <items>
-                                        <menuItem title="MoltenVK Demo Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                        <menuItem title="VkCube Help" keyEquivalent="?" id="FKE-Sm-Kum">
                                             <connections>
                                                 <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
                                             </connections>
@@ -100,7 +100,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="MoltenVK Demo" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="VkCube" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <rect key="contentRect" x="1051" y="656" width="300" height="200"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>

--- a/cube/macOS/cubepp/Resources/Main.storyboard
+++ b/cube/macOS/cubepp/Resources/Main.storyboard
@@ -11,9 +11,9 @@
                 <application id="hnw-xV-0zn" sceneMemberID="viewController">
                     <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
                         <items>
-                            <menuItem title="MoltenVK Demo" id="1Xt-HY-uBw">
+                            <menuItem title="VkCubepp" id="1Xt-HY-uBw">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="MoltenVK Demo" systemMenu="apple" id="uQy-DD-JDr">
+                                <menu key="submenu" title="VkCubepp" systemMenu="apple" id="uQy-DD-JDr">
                                     <items>
                                         <menuItem title="About Demo" id="5kV-Vb-QxS">
                                             <modifierMask key="keyEquivalentModifierMask"/>
@@ -77,7 +77,7 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
                                     <items>
-                                        <menuItem title="MoltenVK Demo Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                        <menuItem title="VkCubepp Help" keyEquivalent="?" id="FKE-Sm-Kum">
                                             <connections>
                                                 <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
                                             </connections>
@@ -100,7 +100,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="MoltenVK Demo" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="VkCubepp" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <rect key="contentRect" x="1051" y="656" width="300" height="200"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>


### PR DESCRIPTION
Since KosmicKrisp is now released, the window title should not refer explicitly to MoltenVK.