### PR TITLE
build: Support compilation with MinGW

### DIFF
--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -498,7 +498,7 @@ class GoodRepo(object):
 
         # Use the CMake -A option to select the platform architecture
         # without needing a Visual Studio generator.
-        if platform.system() == 'Windows' and self._args.generator != "Ninja":
+        if platform.system() == 'Windows' and not self._args.generator in ["Ninja", "MinGW Makefiles"]:
             cmake_cmd.append('-A')
             if self._args.arch.lower() == '64' or self._args.arch == 'x64' or self._args.arch == 'win64':
                 cmake_cmd.append('x64')

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,11 @@ if (ANDROID)
     return()
 endif()
 
+# Testing isn't supported with mingw
+if (MINGW)
+    return()
+endif()
+
 find_package(VulkanLoader CONFIG)
 
 find_package(GTest REQUIRED CONFIG QUIET)


### PR DESCRIPTION
Allows this repository to be built using the MinGW compiler toolchain (aka GCC).

Required modifying update_deps.py to recognize "MinGW Makefiles" as a generator so that it wouldn't pass spurious compiler flags to CMake, and disabling tests if executing under CMake.