### PR TITLE
vulkaninfo: Fix running under RenderDoc

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -1814,6 +1814,9 @@ struct AppGpu {
 
         // Video //
         video_profiles = enumerate_supported_video_profiles(*this);
+
+        vkDestroyDevice(dev, nullptr);
+        dev = VK_NULL_HANDLE;
     }
     ~AppGpu() { vkDestroyDevice(dev, nullptr); }
 


### PR DESCRIPTION
RenderDoc allows only one simultaneously existing logical device, and vulkaninfo doesn't have a real need to keep them simultaneously alive.

Running vulkaninfo under RenderDoc is useful to get a Vulkan profile that will represent the RenderDoc capabilities on the current GPU, which can be useful to, e.g., make a gfxreconstruct trace that will be later capturable by RenderDoc.

With the change `ENABLE_VULKAN_RENDERDOC_CAPTURE=1 vulkaninfo` crashes with:

```
ERROR: [RDOC] Code 1 : RenderDoc does not support multiple simultaneous logical devices.
ERROR at /usr/src/debug/vulkan-tools/Vulkan-Tools/vulkaninfo/./vulkaninfo.h:1723:vkCreateDevice failed with ERROR_INITIALIZATION_FAILED
```