### PR TITLE
print vkGetPhysicalDeviceFragmentShadingRatesKHR and vkGetPhysicalDeviceMultisamplePropertiesEXT

### DIFF
--- a/scripts/generators/vulkaninfo_generator.py
+++ b/scripts/generators/vulkaninfo_generator.py
@@ -77,7 +77,7 @@ STRUCTURES_TO_GEN = ['VkExtent3D', 'VkExtent2D', 'VkPhysicalDeviceLimits', 'VkPh
                      'VkSurfaceCapabilitiesKHR', 'VkSurfaceFormatKHR', 'VkLayerProperties', 'VkPhysicalDeviceToolProperties', 'VkFormatProperties',
                      'VkSurfacePresentScalingCapabilitiesKHR', 'VkSurfacePresentModeCompatibilityKHR', 'VkPhysicalDeviceHostImageCopyProperties',
                      'VkVideoProfileInfoKHR', 'VkVideoCapabilitiesKHR', 'VkVideoFormatPropertiesKHR', 'VkCooperativeMatrixPropertiesKHR',
-                     'VkPhysicalDeviceFragmentShadingRateKHR']
+                     'VkPhysicalDeviceFragmentShadingRateKHR', 'VkMultisamplePropertiesEXT']
 ENUMS_TO_GEN = ['VkResult', 'VkFormat', 'VkPresentModeKHR',
                 'VkPhysicalDeviceType', 'VkImageTiling', 'VkTimeDomainKHR']
 FLAGS_TO_GEN = ['VkSurfaceTransformFlagsKHR', 'VkCompositeAlphaFlagsKHR', 'VkSurfaceCounterFlagsEXT', 'VkQueueFlags',

--- a/vulkaninfo/generated/vulkaninfo.hpp
+++ b/vulkaninfo/generated/vulkaninfo.hpp
@@ -4468,6 +4468,10 @@ void DumpVkLayerProperties(Printer &p, std::string name, const VkLayerProperties
     p.PrintKeyValue("implementationVersion", obj.implementationVersion);
     p.PrintKeyString("description", obj.description);
 }
+void DumpVkMultisamplePropertiesEXT(Printer &p, std::string name, const VkMultisamplePropertiesEXT &obj) {
+    ObjectWrapper object{p, name};
+    DumpVkExtent2D(p, "maxSampleLocationGridSize", obj.maxSampleLocationGridSize);
+}
 void DumpVkOffset2D(Printer &p, std::string name, const VkOffset2D &obj) {
     ObjectWrapper object{p, name};
     p.SetMinKeyWidth(1);

--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -28,6 +28,7 @@
  *
  */
 
+#include <string>
 #ifdef _WIN32
 #include <crtdbg.h>
 #endif
@@ -630,6 +631,21 @@ void GpuDumpFragmentShadingRate(Printer &p, AppGpu &gpu) {
     }
 }
 
+// VK_EXT_sample_locations ('Multisample Properties' is too ambiguous of a name)
+void GpuDumpSampleLocations(Printer &p, AppGpu &gpu) {
+    auto props = GetSampleLocationInfo(gpu);
+    if (props.size() > 0) {
+        p.SetSubHeader();
+        ObjectWrapper obj(p, "vkGetPhysicalDeviceMultisamplePropertiesEXT");
+        for (uint32_t i = 0; i < props.size(); i++) {
+            const VkSampleCountFlagBits sample_count = (VkSampleCountFlagBits)(1 << i);
+            DumpVkSampleCountFlagBits(p, "samples", sample_count);
+            DumpVkMultisamplePropertiesEXT(p, "VkMultisamplePropertiesEXT", props[i]);
+            p.AddNewline();
+        }
+    }
+}
+
 void GpuDevDump(Printer &p, AppGpu &gpu) {
     p.SetHeader();
     ObjectWrapper obj_format_props(p, "Format Properties");
@@ -778,6 +794,7 @@ void DumpGpu(Printer &p, AppGpu &gpu, const ShowSettings &show) {
         GpuDumpCooperativeMatrix(p, gpu);
         GpuDumpCalibrateableTimeDomain(p, gpu);
         GpuDumpFragmentShadingRate(p, gpu);
+        GpuDumpSampleLocations(p, gpu);
     }
 
     if (p.Type() != OutputType::text || show.formats) {

--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <exception>
 #include <iostream>
 #include <fstream>
@@ -1900,6 +1901,19 @@ std::vector<VkPhysicalDeviceFragmentShadingRateKHR> GetFragmentShadingRateInfo(A
     if (vkGetPhysicalDeviceFragmentShadingRatesKHR == nullptr) return {};
     return GetVector<VkPhysicalDeviceFragmentShadingRateKHR>("vkGetPhysicalDeviceFragmentShadingRatesKHR",
                                                              vkGetPhysicalDeviceFragmentShadingRatesKHR, gpu.phys_device);
+}
+// Returns vector where each index maps to VkSampleCountFlagBits
+std::vector<VkMultisamplePropertiesEXT> GetSampleLocationInfo(AppGpu &gpu) {
+    if (vkGetPhysicalDeviceMultisamplePropertiesEXT == nullptr) return {};
+    std::vector<VkMultisamplePropertiesEXT> result;
+    // 7 covers VK_SAMPLE_COUNT_1_BIT to 64_BIT
+    for (uint32_t i = 0; i < 7; i++) {
+        const VkSampleCountFlagBits sample_count = (VkSampleCountFlagBits)(1 << i);
+        VkMultisamplePropertiesEXT props = {VK_STRUCTURE_TYPE_MULTISAMPLE_PROPERTIES_EXT, nullptr};
+        vkGetPhysicalDeviceMultisamplePropertiesEXT(gpu.phys_device, sample_count, &props);
+        result.emplace_back(props);
+    }
+    return result;
 }
 
 // --------- Format Properties ----------//

--- a/vulkaninfo/vulkaninfo_functions.h
+++ b/vulkaninfo/vulkaninfo_functions.h
@@ -116,6 +116,7 @@ PFN_vkGetPhysicalDeviceFormatProperties2KHR vkGetPhysicalDeviceFormatProperties2
 PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR;
 PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsKHR vkGetPhysicalDeviceCalibrateableTimeDomainsKHR;
 PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR vkGetPhysicalDeviceFragmentShadingRatesKHR;
+PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT vkGetPhysicalDeviceMultisamplePropertiesEXT;
 
 // Device functions
 PFN_vkCreateImage vkCreateImage;
@@ -249,6 +250,7 @@ static void load_vulkan_instance_functions(VkInstance instance) {
     LOAD_INSTANCE_FUNCTION(instance, vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR);
     LOAD_INSTANCE_FUNCTION(instance, vkGetPhysicalDeviceCalibrateableTimeDomainsKHR);
     LOAD_INSTANCE_FUNCTION(instance, vkGetPhysicalDeviceFragmentShadingRatesKHR);
+    LOAD_INSTANCE_FUNCTION(instance, vkGetPhysicalDeviceMultisamplePropertiesEXT);
 
     // Load device functions using vkGetInstanceProcAddr, vulkaninfo doesn't care about the extra indirection it causes
     LOAD_INSTANCE_FUNCTION(instance, vkCreateImage);


### PR DESCRIPTION
From https://github.com/KhronosGroup/Vulkan-Tools/issues/1174

adds `vkGetPhysicalDeviceMultisamplePropertiesEXT` and `vkGetPhysicalDeviceFragmentShadingRatesKHR`