### PR TITLE
vulkaninfo: Enable more instance extensions

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -662,6 +662,9 @@ struct AppInstance {
             if (strcmp(VK_EXT_DEBUG_REPORT_EXTENSION_NAME, ext.extensionName) == 0) {
                 inst_extensions.push_back(ext.extensionName);
             }
+            if (strcmp(VK_EXT_DEBUG_UTILS_EXTENSION_NAME, ext.extensionName) == 0) {
+                inst_extensions.push_back(ext.extensionName);
+            }
             if (strcmp(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, ext.extensionName) == 0) {
                 inst_extensions.push_back(ext.extensionName);
             }
@@ -669,6 +672,9 @@ struct AppInstance {
                 inst_extensions.push_back(ext.extensionName);
             }
             if (strcmp(VK_KHR_SURFACE_EXTENSION_NAME, ext.extensionName) == 0) {
+                inst_extensions.push_back(ext.extensionName);
+            }
+            if (strcmp(VK_KHR_SURFACE_MAINTENANCE_1_EXTENSION_NAME, ext.extensionName) == 0) {
                 inst_extensions.push_back(ext.extensionName);
             }
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
@@ -740,6 +746,9 @@ struct AppInstance {
             if (strcmp(VK_KHR_DISPLAY_EXTENSION_NAME, ext.extensionName) == 0) {
                 inst_extensions.push_back(ext.extensionName);
             }
+            if (strcmp(VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME, ext.extensionName) == 0) {
+                inst_extensions.push_back(ext.extensionName);
+            }
 #endif
             if (strcmp(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, ext.extensionName) == 0) {
                 inst_extensions.push_back(ext.extensionName);
@@ -754,6 +763,9 @@ struct AppInstance {
                 inst_extensions.push_back(ext.extensionName);
             }
             if (strcmp(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME, ext.extensionName) == 0) {
+                inst_extensions.push_back(ext.extensionName);
+            }
+            if (strcmp(VK_NV_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME, ext.extensionName) == 0) {
                 inst_extensions.push_back(ext.extensionName);
             }
         }


### PR DESCRIPTION
This is to allow drivers to advertise more device extensions that depend on them:
- VK_EXT_device_address_binding_report requires VK_EXT_debug_utils
- VK_KHR_swapchain_maintenance1 requires VK_KHR_swapchain+VK_KHR_surface_maintenance1
- VK_NV_acquire_winrt_display requires VK_EXT_direct_mode_display
- VK_NV_external_memory, VK_NV_external_memory_win32 and VK_NV_win32_keyed_mutex require VK_NV_external_memory_capabilities

I verified that this PR does not cause `VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-07776` or any other validation error as mentioned here: https://gitlab.khronos.org/vulkan/Vulkan-SDK-Packaging/-/issues/1299

Fixes #1237.