### PR TITLE
vulkaninfo: Fix 32-bit image usage flags upper bound

### DIFF
--- a/vulkaninfo/vulkaninfo.h
+++ b/vulkaninfo/vulkaninfo.h
@@ -413,7 +413,7 @@ struct AppVideoProfile {
             VkPhysicalDeviceVideoFormatInfoKHR video_format_info = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_FORMAT_INFO_KHR,
                                                                     &profile_list};
 
-            if (create_format_properties_chain_info.image_usage_flags <= UINT32_MAX) {
+            if (create_format_properties_chain_info.image_usage_flags <= VK_IMAGE_USAGE_FLAG_BITS_MAX_ENUM) {
                 // Regular 32-bit VkImageUsageFlags is sufficient
                 video_format_info.imageUsage =
                     static_cast<VkImageUsageFlags>(create_format_properties_chain_info.image_usage_flags);


### PR DESCRIPTION
I apologize, my previous PR had a mistake related to the upper bounds of 32-bit flags, as bit 31 is never used in 32-bit flags.