### PR TITLE
cube: Recreate suboptimal swapchains

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -510,6 +510,7 @@ struct demo {
     SwapchainImageResources swapchain_resources[MAX_SWAPCHAIN_IMAGE_COUNT];
     VkPresentModeKHR presentMode;
     bool first_swapchain_frame;
+    bool swapchain_suboptimal;
 
     VkCommandPool cmd_pool;
     VkCommandPool present_cmd_pool;
@@ -1165,6 +1166,7 @@ static void demo_draw(struct demo *demo) {
     vkWaitForFences(demo->device, 1, &current_submission.fence, VK_TRUE, UINT64_MAX);
 
     uint32_t current_swapchain_image_index;
+    bool acquired_suboptimal_swapchain = false;
     do {
         // Get the index of the next available swapchain image:
         err = vkAcquireNextImageKHR(demo->device, demo->swapchain, UINT64_MAX, current_submission.image_acquired_semaphore,
@@ -1177,6 +1179,7 @@ static void demo_draw(struct demo *demo) {
         } else if (err == VK_SUBOPTIMAL_KHR) {
             // demo->swapchain is not as optimal as it could be, but the platform's
             // presentation engine will still present the image correctly.
+            acquired_suboptimal_swapchain = true;
             break;
         } else if (err == VK_ERROR_SURFACE_LOST_KHR) {
             vkDestroySurfaceKHR(demo->inst, demo->surface, NULL);
@@ -1345,13 +1348,11 @@ static void demo_draw(struct demo *demo) {
         // demo->swapchain is out of date (e.g. the window was resized) and
         // must be recreated:
         demo_resize(demo);
-    } else if (err == VK_SUBOPTIMAL_KHR) {
-        // SUBOPTIMAL could be due to a resize
-        VkSurfaceCapabilitiesKHR surfCapabilities;
-        err = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(demo->gpu, demo->surface, &surfCapabilities);
-        assert(!err);
-        if (surfCapabilities.currentExtent.width != (uint32_t)demo->width ||
-            surfCapabilities.currentExtent.height != (uint32_t)demo->height) {
+    } else if (err == VK_SUBOPTIMAL_KHR || (err == VK_SUCCESS && acquired_suboptimal_swapchain)) {
+        // Try once to adapt to changes such as new Wayland DMA-BUF feedback,
+        // but don't recreate every frame if the condition persists.
+        if (!demo->swapchain_suboptimal) {
+            demo->swapchain_suboptimal = true;
             demo_resize(demo);
         }
     } else if (err == VK_ERROR_SURFACE_LOST_KHR) {
@@ -1360,6 +1361,7 @@ static void demo_draw(struct demo *demo) {
         demo_resize(demo);
     } else {
         assert(!err);
+        demo->swapchain_suboptimal = false;
     }
 }
 

--- a/cube/cube.cpp
+++ b/cube/cube.cpp
@@ -506,6 +506,7 @@ struct Demo {
     std::vector<SwapchainImageResources> swapchain_resources;
     vk::PresentModeKHR presentMode = vk::PresentModeKHR::eFifo;
     bool first_swapchain_frame;
+    bool swapchain_suboptimal = false;
 
     vk::CommandPool cmd_pool;
     vk::CommandPool present_cmd_pool;
@@ -867,6 +868,7 @@ void Demo::draw() {
 
     vk::Result acquire_result;
     uint32_t current_swapchain_image_index = 0;
+    bool acquired_suboptimal_swapchain = false;
     do {
         acquire_result = device.acquireNextImageKHR(swapchain, UINT64_MAX, current_submission.image_acquired_semaphore, vk::Fence(),
                                                     &current_swapchain_image_index);
@@ -877,6 +879,7 @@ void Demo::draw() {
         } else if (acquire_result == vk::Result::eSuboptimalKHR) {
             // swapchain is not as optimal as it could be, but the platform's
             // presentation engine will still present the image correctly.
+            acquired_suboptimal_swapchain = true;
             break;
         } else if (acquire_result == vk::Result::eErrorSurfaceLostKHR) {
             inst.destroySurfaceKHR(surface);
@@ -951,12 +954,12 @@ void Demo::draw() {
         // swapchain is out of date (e.g. the window was resized) and
         // must be recreated:
         resize();
-    } else if (present_result == vk::Result::eSuboptimalKHR) {
-        // SUBOPTIMAL could be due to resize
-        vk::SurfaceCapabilitiesKHR surfCapabilities;
-        auto caps_result = gpu.getSurfaceCapabilitiesKHR(surface, &surfCapabilities);
-        VERIFY(caps_result == vk::Result::eSuccess);
-        if (surfCapabilities.currentExtent.width != width || surfCapabilities.currentExtent.height != height) {
+    } else if (present_result == vk::Result::eSuboptimalKHR ||
+               (present_result == vk::Result::eSuccess && acquired_suboptimal_swapchain)) {
+        // Try once to adapt to changes such as new Wayland DMA-BUF feedback,
+        // but don't recreate every frame if the condition persists.
+        if (!swapchain_suboptimal) {
+            swapchain_suboptimal = true;
             resize();
         }
     } else if (present_result == vk::Result::eErrorSurfaceLostKHR) {
@@ -965,6 +968,7 @@ void Demo::draw() {
         resize();
     } else {
         VERIFY(present_result == vk::Result::eSuccess);
+        swapchain_suboptimal = false;
     }
 }
 


### PR DESCRIPTION
A swapchain can become suboptimal without its extent changing. Wayland WSI uses this result when DMA-BUF feedback changes, for example when the compositor starts preferring scanout-capable buffers.

Remember a suboptimal acquire until its image has been presented, then try recreating the swapchain. If the replacement remains suboptimal, keep using it instead of recreating every frame. A clean frame re-arms the retry for later surface changes.

Tested on KWin. Before this change, vkcube could use direct scanout only after a resize forced swapchain recreation. With this change, it switches to scanout-capable buffers without requiring a resize.