### PR TITLE
cube: Rebuild swapchain only on a real size change

### DIFF
--- a/cube/cube.c
+++ b/cube/cube.c
@@ -3065,13 +3065,26 @@ static void handle_surface_configure(void *data, struct xdg_surface *xdg_surface
     struct demo *demo = (struct demo *)data;
     xdg_surface_ack_configure(xdg_surface, serial);
     demo->xdg_surface_has_been_configured = 1;
+    const uint32_t previous_width = demo->width;
+    const uint32_t previous_height = demo->height;
     if (demo->pending_width > 0) {
         demo->width = demo->pending_width;
     }
     if (demo->pending_height > 0) {
         demo->height = demo->pending_height;
     }
-    demo_resize(demo);
+    // Only rebuild the swapchain when the size actually changed. A compositor also sends
+    // xdg_surface.configure for state changes -- activation, maximization, tiling -- and those
+    // usually carry the size the surface already has, so rebuilding destroys and recreates every
+    // image, view, framebuffer and command buffer for nothing. Locally that is cheap enough to be
+    // invisible, but it is very visible when each Vulkan call is expensive.
+    //
+    // !swapchain_ready keeps the first configure creating the swapchain, and the
+    // VK_ERROR_OUT_OF_DATE_KHR / VK_SUBOPTIMAL_KHR paths in draw() remain the safety net for
+    // anything that invalidates the swapchain without changing the size.
+    if (demo->width != previous_width || demo->height != previous_height || !demo->swapchain_ready) {
+        demo_resize(demo);
+    }
 }
 
 static const struct xdg_surface_listener xdg_surface_listener = {handle_surface_configure};


### PR DESCRIPTION
On Wayland, `handle_surface_configure()` calls `demo_resize()` on every `xdg_surface.configure`. A compositor also sends `configure` for state changes — activation, maximization, tiling — and those usually carry the size the surface already has, so the swapchain and every image, view, framebuffer and command buffer are destroyed and recreated for nothing.

Locally a recreation costs about a millisecond and nobody notices. It becomes very visible wherever Vulkan calls are expensive. Under a compositor using focus-follows-mouse, moving the pointer across the window produces a `configure` per crossing, and each one froze the demo for roughly a second.

### Measured

60 s per run, pointer crossing only, same machine and compositor both times:

| | configures | swapchain rebuilds | visible stalls | worst stall |
|---|---:|---:|---:|---:|
| unpatched | 178 | 92 | 9 | 1117 ms |
| patched | 392 (391 same-size) | 1 | 0 | 104 ms |

The patched run also drew **4.3x as many frames** in the same wall clock. Behaviour was checked natively first, where the change makes no visible difference.

### Why this is safe

- `!demo->swapchain_ready` keeps the **first** configure creating the swapchain.
- The `VK_ERROR_OUT_OF_DATE_KHR` / `VK_SUBOPTIMAL_KHR` paths in `draw()` remain the safety net for anything that invalidates the swapchain without changing the size.
- This is how `vkgears` in mesa-demos has always handled it: record the size, compare, recreate only on a real difference.

Found while running `vkcube` over a remoting layer, where each Vulkan call is a network round trip and the cost of a needless rebuild is impossible to miss.

https://claude.ai/code/session_0153BQRRKAJcRSxUxRuEHQQs