### PR TITLE
vulkaninfo: add missing <ctime> include

### DIFF
--- a/vulkaninfo/vulkaninfo.cpp
+++ b/vulkaninfo/vulkaninfo.cpp
@@ -28,6 +28,7 @@
  *
  */
 
+#include <ctime>
 #include <string>
 #ifdef _WIN32
 #include <crtdbg.h>


### PR DESCRIPTION
`vulkaninfo.cpp` uses `std::time` and `std::localtime`, but doesn't include `<ctime>` which causes a build failure with libc++ 23 since it's dropping a lot of transitive includes.

```
vulkaninfo/vulkaninfo.cpp:1122:9: error: no type named 'time_t' in namespace 'std'; did you mean simply 'time_t'?
 1122 |         std::time_t t = std::time(0);  // get time now
      |         ^~~~~~~~~~~
      |         time_t
/usr/include/bits/types/time_t.h:10:18: note: 'time_t' declared here
   10 | typedef __time_t time_t;
      |                  ^
vulkaninfo/vulkaninfo.cpp:1122:25: error: no member named 'time' in namespace 'std'; did you mean simply 'time'?
 1122 |         std::time_t t = std::time(0);  // get time now
      |                         ^~~~~~~~~
      |                         time
/usr/include/time.h:85:15: note: 'time' declared here
   85 | extern time_t time (time_t *__timer) __THROW;
      |               ^
vulkaninfo/vulkaninfo.cpp:1123:24: error: no member named 'localtime' in namespace 'std'; did you mean simply 'localtime'?
 1123 |         std::tm *now = std::localtime(&t);
      |                        ^~~~~~~~~~~~~~
      |                        localtime
/usr/include/time.h:145:19: note: 'localtime' declared here
  145 | extern struct tm *localtime (const time_t *__timer) __THROW;
      |   
```